### PR TITLE
Fix Jekyll/Ruby setup for Playwright tests in deploy and multi-enviro…

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -65,8 +65,18 @@ jobs:
           node-version: '22'
           cache: 'npm'
 
+      - name: Setup Ruby for Jekyll
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2'
+
       - name: Install dependencies
         run: npm ci
+
+      - name: Install Jekyll dependencies
+        run: |
+          bundle config set --local frozen false
+          bundle install
 
       - name: Install Playwright browsers
         run: npx playwright install --with-deps

--- a/.github/workflows/multi-environment-testing.yml
+++ b/.github/workflows/multi-environment-testing.yml
@@ -46,8 +46,18 @@ jobs:
           node-version: '22'
           cache: 'npm'
 
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2'
+
       - name: Install dependencies
         run: npm ci
+
+      - name: Install Jekyll dependencies
+        run: |
+          bundle config set --local frozen false
+          bundle install
 
       - name: Install Playwright browsers
         run: npx playwright install --with-deps
@@ -93,13 +103,14 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.2'
-          bundler-cache: true
 
       - name: Install dependencies
         run: npm ci
 
       - name: Install Jekyll dependencies
-        run: bundle install
+        run: |
+          bundle config set --local frozen false
+          bundle install
 
       - name: Install Playwright browsers
         run: npx playwright install --with-deps
@@ -122,8 +133,18 @@ jobs:
           node-version: '22'
           cache: 'npm'
 
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2'
+
       - name: Install dependencies
         run: npm ci
+
+      - name: Install Jekyll dependencies
+        run: |
+          bundle config set --local frozen false
+          bundle install
 
       - name: Install Playwright browsers
         run: npx playwright install --with-deps


### PR DESCRIPTION
…nment workflows

- deploy.yml: Add missing Ruby/Jekyll setup to pre-deployment-tests job
  * Fixes 'bundle: not found' error when running critical E2E tests
  * Added Ruby 3.2 setup and Jekyll dependencies installation

- multi-environment-testing.yml: Complete Jekyll/Ruby setup for all jobs
  * Added Ruby setup to multi-locale-testing job (was missing)
  * Added Ruby setup to macos-safari-testing job (was missing)
  * Fixed windows-testing job to use frozen mode disable

- Ensures all Playwright tests can start Jekyll server properly
- Resolves webServer startup failures in CI workflows