### PR TITLE
Fix staging 404: Correct Jekyll baseurl for staging deployments

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -182,7 +182,7 @@ jobs:
         run: |
           bundle config set --local frozen false
           bundle install
-          bundle exec jekyll build
+          bundle exec jekyll build --baseurl "/myFreecodecampLearning/staging"
           echo "Jekyll staging build completed. Contents of _site:" >> $GITHUB_STEP_SUMMARY
           ls -la _site/ >> $GITHUB_STEP_SUMMARY
 

--- a/.github/workflows/emergency-rollback.yml
+++ b/.github/workflows/emergency-rollback.yml
@@ -74,7 +74,12 @@ jobs:
 
       - name: Build Jekyll site (if Jekyll/tests enabled)
         if: env.ENABLE_JEKYLL_AND_TESTS == 'true'
-        run: bundle exec jekyll build
+        run: |
+          if [ "${{ github.event.inputs.environment }}" == "staging" ]; then
+            bundle exec jekyll build --baseurl "/myFreecodecampLearning/staging"
+          else
+            bundle exec jekyll build
+          fi
 
       - name: Run critical tests (if enabled and not skipped)
         if: env.ENABLE_JEKYLL_AND_TESTS == 'true' && github.event.inputs.skip_tests == 'false'


### PR DESCRIPTION
- deploy.yml: Add --baseurl '/myFreecodecampLearning/staging' for staging Jekyll builds
- emergency-rollback.yml: Add conditional baseurl override for staging environment

Problem: Staging deployments were 404ing because Jekyll was building with baseurl='/myFreecodecampLearning' but deploying to '/myFreecodecampLearning/staging' causing all internal links to point to wrong paths.

Solution: Override baseurl during Jekyll build for staging to match deployment path. This ensures all relative links work correctly in staging subdirectory.