### PR TITLE
Add staging deployment test workflow

### DIFF
--- a/.github/workflows/test-staging-deploy.yml
+++ b/.github/workflows/test-staging-deploy.yml
@@ -1,0 +1,35 @@
+name: Test Staging Deployment
+
+on:
+  workflow_dispatch:
+
+jobs:
+  test-staging:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Create simple test file
+        run: |
+          mkdir -p test-deploy
+          echo "<!DOCTYPE html>
+          <html>
+          <head><title>Staging Test</title></head>
+          <body>
+          <h1>Staging Test - $(date)</h1>
+          <p>If you see this, staging deployment is working!</p>
+          </body>
+          </html>" > test-deploy/index.html
+
+      - name: Deploy test to staging
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./test-deploy
+          destination_dir: staging-test
+          
+      - name: Deployment info
+        run: |
+          echo "## 🧪 Test Deployment Complete" >> $GITHUB_STEP_SUMMARY
+          echo "Test URL: https://t193r-w00d5.github.io/myFreecodecampLearning/staging-test" >> $GITHUB_STEP_SUMMARY

--- a/test-staging.html
+++ b/test-staging.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Staging Test</title>
+</head>
+<body>
+    <h1>Staging Deployment Test</h1>
+    <p>If you can see this, the staging deployment is working.</p>
+    <p>Current timestamp: 2025-12-06</p>
+</body>
+</html>


### PR DESCRIPTION
- Create simple test workflow to verify basic staging deployment functionality
- Test if peaceiris/actions-gh-pages can deploy to subdirectories
- Will help diagnose if the 404 issue is with Jekyll baseurl or GitHub Pages deployment

This isolates the staging deployment mechanism from Jekyll complexity.