### PR TITLE
Revert production Jekyll baseurl override that broke templating

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -130,7 +130,7 @@ jobs:
         run: |
           bundle config set --local frozen false
           bundle install
-          bundle exec jekyll build --baseurl "/myFreecodecampLearning"
+          bundle exec jekyll build
           echo "Jekyll build completed. Contents of _site:" >> $GITHUB_STEP_SUMMARY
           ls -la _site/ >> $GITHUB_STEP_SUMMARY
 

--- a/.github/workflows/emergency-rollback.yml
+++ b/.github/workflows/emergency-rollback.yml
@@ -78,7 +78,7 @@ jobs:
           if [ "${{ github.event.inputs.environment }}" == "staging" ]; then
             bundle exec jekyll build --baseurl "/myFreecodecampLearning/staging"
           else
-            bundle exec jekyll build --baseurl "/myFreecodecampLearning"
+            bundle exec jekyll build
           fi
 
       - name: Run critical tests (if enabled and not skipped)


### PR DESCRIPTION
- Removed --baseurl from production Jekyll builds in deploy.yml and emergency-rollback.yml
- Production should use baseurl from _config.yml ('/myFreecodecampLearning')
- Only staging needs explicit --baseurl override for /staging path
- This should restore Jekyll Liquid templating processing for production