### PR TITLE
Fix GitHub Pages deployment with enable_jekyll: false

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -139,6 +139,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./_site
+          enable_jekyll: false
           exclude_assets: |
             .github
             node_modules
@@ -192,6 +193,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./_site
           destination_dir: staging
+          enable_jekyll: false
           exclude_assets: |
             .github
             node_modules

--- a/.github/workflows/emergency-rollback.yml
+++ b/.github/workflows/emergency-rollback.yml
@@ -96,6 +96,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./_site
           destination_dir: staging
+          enable_jekyll: false
 
       - name: Deploy rollback to staging (raw files)
         if: github.event.inputs.environment == 'staging' && env.ENABLE_JEKYLL_AND_TESTS == 'false'
@@ -124,6 +125,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./_site
+          enable_jekyll: false
 
       - name: Deploy rollback to production (raw files)
         if: github.event.inputs.environment == 'production' && env.ENABLE_JEKYLL_AND_TESTS == 'false'


### PR DESCRIPTION
- Added enable_jekyll: false to all Jekyll-built deployments
- This prevents GitHub Pages from re-processing our pre-built Jekyll files
- Should fix Liquid templating not being processed properly
- Jekyll builds locally, deploys static files to prevent double-processing