### PR TITLE
Restore manual Jekyll build with enable_jekyll: false

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -121,11 +121,25 @@ jobs:
           echo "**Commit being deployed:** $(git rev-parse HEAD)" >> $GITHUB_STEP_SUMMARY
           echo "**Commit details:** $(git log --oneline -n 1)" >> $GITHUB_STEP_SUMMARY
 
+      - name: Setup Ruby for Jekyll
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+
+      - name: Build Jekyll site
+        run: |
+          bundle config set --local frozen false
+          bundle install
+          bundle exec jekyll build
+          echo "Jekyll build completed. Contents of _site:" >> $GITHUB_STEP_SUMMARY
+          ls -la _site/ >> $GITHUB_STEP_SUMMARY
+
       - name: Deploy to GitHub Pages (production)
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./
+          publish_dir: ./_site
+          enable_jekyll: false
           exclude_assets: |
             .github
             node_modules
@@ -136,9 +150,6 @@ jobs:
             *.config.ts
             tsconfig.json
             package*.json
-            _site
-            .gitignore
-            README.md
             package*.json
 
   # Staging deployment (for future Option B)
@@ -164,20 +175,26 @@ jobs:
           echo "**Commit being deployed:** $(git rev-parse HEAD)" >> $GITHUB_STEP_SUMMARY
           echo "**Commit details:** $(git log --oneline -n 1)" >> $GITHUB_STEP_SUMMARY
 
-      - name: Configure Jekyll for staging
+      - name: Setup Ruby for Jekyll (staging)
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+
+      - name: Build Jekyll site (staging)
         run: |
-          # Create staging-specific _config.yml
-          cp _config.yml _config_staging.yml
-          sed -i 's|baseurl: "/myFreecodecampLearning"|baseurl: "/myFreecodecampLearning/staging"|' _config_staging.yml
-          mv _config_staging.yml _config.yml
-          echo "Staging configuration applied. baseurl set to /myFreecodecampLearning/staging"
+          bundle config set --local frozen false
+          bundle install
+          bundle exec jekyll build --baseurl "/myFreecodecampLearning/staging"
+          echo "Jekyll staging build completed. Contents of _site:" >> $GITHUB_STEP_SUMMARY
+          ls -la _site/ >> $GITHUB_STEP_SUMMARY
 
       - name: Deploy to GitHub Pages (staging)
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./
+          publish_dir: ./_site
           destination_dir: staging
+          enable_jekyll: false
           exclude_assets: |
             .github
             node_modules
@@ -188,9 +205,6 @@ jobs:
             *.config.ts
             tsconfig.json
             package*.json
-            _site
-            .gitignore
-            README.md
 
   # Deployment success notification
   deployment-success:


### PR DESCRIPTION
- Reverted to manual Jekyll builds (bundle exec jekyll build)
- Added enable_jekyll: false to prevent GitHub Pages from re-processing
- This should fix production CSS/templating issues
- Local Jekyll testing confirmed Liquid templating works correctly