### PR TITLE
Add debugging to Jekyll build process

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -133,6 +133,8 @@ jobs:
           bundle exec jekyll build
           echo "Jekyll build completed. Contents of _site:" >> $GITHUB_STEP_SUMMARY
           ls -la _site/ >> $GITHUB_STEP_SUMMARY
+          echo "Sample of generated index.html:" >> $GITHUB_STEP_SUMMARY
+          head -20 _site/index.html >> $GITHUB_STEP_SUMMARY
 
       - name: Deploy to GitHub Pages (production)
         uses: peaceiris/actions-gh-pages@v3
@@ -187,6 +189,8 @@ jobs:
           bundle exec jekyll build --baseurl "/myFreecodecampLearning/staging"
           echo "Jekyll staging build completed. Contents of _site:" >> $GITHUB_STEP_SUMMARY
           ls -la _site/ >> $GITHUB_STEP_SUMMARY
+          echo "Sample of generated staging index.html:" >> $GITHUB_STEP_SUMMARY
+          head -20 _site/index.html >> $GITHUB_STEP_SUMMARY
 
       - name: Deploy to GitHub Pages (staging)
         uses: peaceiris/actions-gh-pages@v3


### PR DESCRIPTION
- Added head -20 _site/index.html output to workflow summary
- This will help us see if Jekyll is actually processing Liquid templating
- Will show the first 20 lines of generated HTML in GitHub Actions logs