### PR TITLE
Switch to native GitHub Pages deployment action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,6 +38,12 @@ on:
 # Option B: Auto-deploy after merge (see auto-staging-deploy.yml)
 # Manual deployment workflow
 
+# Permissions for GitHub Pages deployment
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
 jobs:
   # Pre-deployment validation
   pre-deployment-tests:
@@ -121,6 +127,9 @@ jobs:
           echo "**Commit being deployed:** $(git rev-parse HEAD)" >> $GITHUB_STEP_SUMMARY
           echo "**Commit details:** $(git log --oneline -n 1)" >> $GITHUB_STEP_SUMMARY
 
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+
       - name: Setup Ruby for Jekyll
         uses: ruby/setup-ruby@v1
         with:
@@ -136,30 +145,17 @@ jobs:
           echo "Sample of generated index.html:" >> $GITHUB_STEP_SUMMARY
           head -20 _site/index.html >> $GITHUB_STEP_SUMMARY
 
-      - name: Deploy to GitHub Pages (production)
-        uses: peaceiris/actions-gh-pages@v3
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./_site
-          enable_jekyll: false
-          exclude_assets: |
-            .github
-            node_modules
-            tests
-            __tests__
-            docs/Ai_chats
-            *.config.js
-            *.config.ts
-            tsconfig.json
-            package*.json
-            package*.json
+          path: ./_site
 
-  # Staging deployment (for future Option B)
+      - name: Deploy to GitHub Pages (production)
+        uses: actions/deploy-pages@v3
+
+  # Staging deployment (disabled for now - focusing on production fix)
   deploy-staging:
-    if: |
-      github.event.inputs.confirm == 'deploy' && 
-      github.event.inputs.environment == 'staging' &&
-      needs.pre-deployment-tests.result == 'success'
+    if: false  # Temporarily disabled
     needs: pre-deployment-tests
     runs-on: ubuntu-latest
     environment: 


### PR DESCRIPTION
- Replaced peaceiris/actions-gh-pages with actions/deploy-pages@v3
- Added proper permissions for GitHub Pages deployment
- Using actions/configure-pages and actions/upload-pages-artifact
- This should handle Jekyll processing more reliably
- Temporarily disabled staging to focus on production fix