### PR TITLE
Fix GitHub Pages deployment with peaceiris v4

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,12 +38,6 @@ on:
 # Option B: Auto-deploy after merge (see auto-staging-deploy.yml)
 # Manual deployment workflow
 
-# Permissions for GitHub Pages deployment
-permissions:
-  contents: read
-  pages: write
-  id-token: write
-
 jobs:
   # Pre-deployment validation
   pre-deployment-tests:
@@ -127,9 +121,6 @@ jobs:
           echo "**Commit being deployed:** $(git rev-parse HEAD)" >> $GITHUB_STEP_SUMMARY
           echo "**Commit details:** $(git log --oneline -n 1)" >> $GITHUB_STEP_SUMMARY
 
-      - name: Setup Pages
-        uses: actions/configure-pages@v4
-
       - name: Setup Ruby for Jekyll
         uses: ruby/setup-ruby@v1
         with:
@@ -144,14 +135,16 @@ jobs:
           ls -la _site/ >> $GITHUB_STEP_SUMMARY
           echo "Sample of generated index.html:" >> $GITHUB_STEP_SUMMARY
           head -20 _site/index.html >> $GITHUB_STEP_SUMMARY
-
-      - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: ./_site
+          echo "Checking for Liquid syntax in generated files:" >> $GITHUB_STEP_SUMMARY
+          grep -n "{{" _site/index.html || echo "No unprocessed Liquid syntax found" >> $GITHUB_STEP_SUMMARY
 
       - name: Deploy to GitHub Pages (production)
-        uses: actions/deploy-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./_site
+          enable_jekyll: false
+          force_orphan: true
 
   # Staging deployment (disabled for now - focusing on production fix)
   deploy-staging:


### PR DESCRIPTION
- Reverted from actions/deploy-pages back to peaceiris/actions-gh-pages@v4
- Added force_orphan: true to resolve deployment issues
- Removed permissions that were causing conflicts
- Added debugging to check for unprocessed Liquid syntax in build
- This should work regardless of GitHub Pages configuration