### PR TITLE
Fix GitHub Pages double-processing issue

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -171,6 +171,7 @@ jobs:
           publish_dir: ./_site
           enable_jekyll: false
           force_orphan: true
+          disable_nojekyll: false  # Ensure .nojekyll file is created
 
   # Deployment success notification
   deployment-success:

--- a/docs/debug_dox/Deploy to Production 2 20251207_2052UTC.txt
+++ b/docs/debug_dox/Deploy to Production 2 20251207_2052UTC.txt
@@ -1,0 +1,2238 @@
+# job=pre-deployment-tests
+2025-12-07T20:52:37.9411474Z Current runner version: '2.329.0'
+2025-12-07T20:52:37.9447254Z ##[group]Runner Image Provisioner
+2025-12-07T20:52:37.9448866Z Hosted Compute Agent
+2025-12-07T20:52:37.9449802Z Version: 20251124.448
+2025-12-07T20:52:37.9450874Z Commit: fda5086b43ec66ade217e5fcd18146c879571177
+2025-12-07T20:52:37.9451989Z Build Date: 2025-11-24T21:16:26Z
+2025-12-07T20:52:37.9453112Z ##[endgroup]
+2025-12-07T20:52:37.9454050Z ##[group]Operating System
+2025-12-07T20:52:37.9455114Z Ubuntu
+2025-12-07T20:52:37.9456025Z 24.04.3
+2025-12-07T20:52:37.9456808Z LTS
+2025-12-07T20:52:37.9457894Z ##[endgroup]
+2025-12-07T20:52:37.9458770Z ##[group]Runner Image
+2025-12-07T20:52:37.9459790Z Image: ubuntu-24.04
+2025-12-07T20:52:37.9460601Z Version: 20251126.144.1
+2025-12-07T20:52:37.9462630Z Included Software: https://github.com/actions/runner-images/blob/ubuntu24/20251126.144/images/ubuntu/Ubuntu2404-Readme.md
+2025-12-07T20:52:37.9465460Z Image Release: https://github.com/actions/runner-images/releases/tag/ubuntu24%2F20251126.144
+2025-12-07T20:52:37.9467290Z ##[endgroup]
+2025-12-07T20:52:37.9472142Z ##[group]GITHUB_TOKEN Permissions
+2025-12-07T20:52:37.9475423Z Actions: write
+2025-12-07T20:52:37.9476304Z ArtifactMetadata: write
+2025-12-07T20:52:37.9477240Z Attestations: write
+2025-12-07T20:52:37.9478423Z Checks: write
+2025-12-07T20:52:37.9479324Z Contents: write
+2025-12-07T20:52:37.9480205Z Deployments: write
+2025-12-07T20:52:37.9481347Z Discussions: write
+2025-12-07T20:52:37.9482217Z Issues: write
+2025-12-07T20:52:37.9483011Z Metadata: read
+2025-12-07T20:52:37.9483962Z Models: read
+2025-12-07T20:52:37.9484764Z Packages: write
+2025-12-07T20:52:37.9485693Z Pages: write
+2025-12-07T20:52:37.9486697Z PullRequests: write
+2025-12-07T20:52:37.9488041Z RepositoryProjects: write
+2025-12-07T20:52:37.9489179Z SecurityEvents: write
+2025-12-07T20:52:37.9490183Z Statuses: write
+2025-12-07T20:52:37.9491124Z ##[endgroup]
+2025-12-07T20:52:37.9493974Z Secret source: Actions
+2025-12-07T20:52:37.9495516Z Prepare workflow directory
+2025-12-07T20:52:37.9831273Z Prepare all required actions
+2025-12-07T20:52:37.9871145Z Getting action download info
+2025-12-07T20:52:38.3887872Z Download action repository 'actions/checkout@v4' (SHA:34e114876b0b11c390a56381ad16ebd13914f8d5)
+2025-12-07T20:52:38.8474588Z Download action repository 'actions/setup-node@v4' (SHA:49933ea5288caeca8642d1e84afbd3f7d6820020)
+2025-12-07T20:52:38.9372035Z Download action repository 'ruby/setup-ruby@v1' (SHA:d697be2f83c6234b20877c3b5eac7a7f342f0d0c)
+2025-12-07T20:52:39.3641000Z Download action repository 'actions/upload-artifact@v4' (SHA:ea165f8d65b6e75b540449e92b4886f43607fa02)
+2025-12-07T20:52:39.5789156Z Complete job name: pre-deployment-tests
+2025-12-07T20:52:39.6629767Z ##[group]Run actions/checkout@v4
+2025-12-07T20:52:39.6631081Z with:
+2025-12-07T20:52:39.6631790Z   ref: main
+2025-12-07T20:52:39.6632670Z   repository: T193R-W00D5/myFreecodecampLearning
+2025-12-07T20:52:39.6634063Z   token: ***
+2025-12-07T20:52:39.6634836Z   ssh-strict: true
+2025-12-07T20:52:39.6635638Z   ssh-user: git
+2025-12-07T20:52:39.6636531Z   persist-credentials: true
+2025-12-07T20:52:39.6637444Z   clean: true
+2025-12-07T20:52:39.6638430Z   sparse-checkout-cone-mode: true
+2025-12-07T20:52:39.6639445Z   fetch-depth: 1
+2025-12-07T20:52:39.6640232Z   fetch-tags: false
+2025-12-07T20:52:39.6641034Z   show-progress: true
+2025-12-07T20:52:39.6641854Z   lfs: false
+2025-12-07T20:52:39.6642605Z   submodules: false
+2025-12-07T20:52:39.6643426Z   set-safe-directory: true
+2025-12-07T20:52:39.6644570Z ##[endgroup]
+2025-12-07T20:52:39.7761875Z Syncing repository: T193R-W00D5/myFreecodecampLearning
+2025-12-07T20:52:39.7765201Z ##[group]Getting Git version info
+2025-12-07T20:52:39.7767026Z Working directory is '/home/runner/work/myFreecodecampLearning/myFreecodecampLearning'
+2025-12-07T20:52:39.7769655Z [command]/usr/bin/git version
+2025-12-07T20:52:39.7833300Z git version 2.52.0
+2025-12-07T20:52:39.7861310Z ##[endgroup]
+2025-12-07T20:52:39.7878616Z Temporarily overriding HOME='/home/runner/work/_temp/dc5409a1-9ee4-41a1-8acf-f79ac236ce01' before making global git config changes
+2025-12-07T20:52:39.7883925Z Adding repository directory to the temporary git global config as a safe directory
+2025-12-07T20:52:39.7892928Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/myFreecodecampLearning/myFreecodecampLearning
+2025-12-07T20:52:39.7932792Z Deleting the contents of '/home/runner/work/myFreecodecampLearning/myFreecodecampLearning'
+2025-12-07T20:52:39.7937144Z ##[group]Initializing the repository
+2025-12-07T20:52:39.7941769Z [command]/usr/bin/git init /home/runner/work/myFreecodecampLearning/myFreecodecampLearning
+2025-12-07T20:52:39.8058476Z hint: Using 'master' as the name for the initial branch. This default branch name
+2025-12-07T20:52:39.8061016Z hint: will change to "main" in Git 3.0. To configure the initial branch name
+2025-12-07T20:52:39.8063718Z hint: to use in all of your new repositories, which will suppress this warning,
+2025-12-07T20:52:39.8066307Z hint: call:
+2025-12-07T20:52:39.8067875Z hint:
+2025-12-07T20:52:39.8069575Z hint: 	git config --global init.defaultBranch <name>
+2025-12-07T20:52:39.8071651Z hint:
+2025-12-07T20:52:39.8073673Z hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
+2025-12-07T20:52:39.8076955Z hint: 'development'. The just-created branch can be renamed via this command:
+2025-12-07T20:52:39.8079643Z hint:
+2025-12-07T20:52:39.8080940Z hint: 	git branch -m <name>
+2025-12-07T20:52:39.8081868Z hint:
+2025-12-07T20:52:39.8083051Z hint: Disable this message with "git config set advice.defaultBranchName false"
+2025-12-07T20:52:39.8085600Z Initialized empty Git repository in /home/runner/work/myFreecodecampLearning/myFreecodecampLearning/.git/
+2025-12-07T20:52:39.8091704Z [command]/usr/bin/git remote add origin https://github.com/T193R-W00D5/myFreecodecampLearning
+2025-12-07T20:52:39.8110639Z ##[endgroup]
+2025-12-07T20:52:39.8113239Z ##[group]Disabling automatic garbage collection
+2025-12-07T20:52:39.8115506Z [command]/usr/bin/git config --local gc.auto 0
+2025-12-07T20:52:39.8144417Z ##[endgroup]
+2025-12-07T20:52:39.8146756Z ##[group]Setting up auth
+2025-12-07T20:52:39.8151829Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+2025-12-07T20:52:39.8184226Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+2025-12-07T20:52:39.8535164Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+2025-12-07T20:52:39.8569605Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+2025-12-07T20:52:39.8785129Z [command]/usr/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+2025-12-07T20:52:39.8817585Z [command]/usr/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+2025-12-07T20:52:39.9046613Z [command]/usr/bin/git config --local http.https://github.com/.extraheader AUTHORIZATION: basic ***
+2025-12-07T20:52:39.9080735Z ##[endgroup]
+2025-12-07T20:52:39.9094146Z ##[group]Fetching the repository
+2025-12-07T20:52:39.9100070Z [command]/usr/bin/git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +refs/heads/main*:refs/remotes/origin/main* +refs/tags/main*:refs/tags/main*
+2025-12-07T20:52:40.4862806Z From https://github.com/T193R-W00D5/myFreecodecampLearning
+2025-12-07T20:52:40.4864348Z  * [new branch]      main       -> origin/main
+2025-12-07T20:52:40.4894420Z ##[endgroup]
+2025-12-07T20:52:40.4895733Z ##[group]Determining the checkout info
+2025-12-07T20:52:40.4900790Z [command]/usr/bin/git branch --list --remote origin/main
+2025-12-07T20:52:40.4924350Z   origin/main
+2025-12-07T20:52:40.4932245Z ##[endgroup]
+2025-12-07T20:52:40.4935442Z [command]/usr/bin/git sparse-checkout disable
+2025-12-07T20:52:40.4975597Z [command]/usr/bin/git config --local --unset-all extensions.worktreeConfig
+2025-12-07T20:52:40.5003631Z ##[group]Checking out the ref
+2025-12-07T20:52:40.5006478Z [command]/usr/bin/git checkout --progress --force -B main refs/remotes/origin/main
+2025-12-07T20:52:40.5336511Z Switched to a new branch 'main'
+2025-12-07T20:52:40.5338567Z branch 'main' set up to track 'origin/main'.
+2025-12-07T20:52:40.5348246Z ##[endgroup]
+2025-12-07T20:52:40.5384851Z [command]/usr/bin/git log -1 --format=%H
+2025-12-07T20:52:40.5405662Z 56eaffe66dbbb15d766743e78067cb82f61dfdc6
+2025-12-07T20:52:40.5612800Z ##[group]Run echo "🚀 PRODUCTION DEPLOYMENT INFORMATION" >> $GITHUB_STEP_SUMMARY
+2025-12-07T20:52:40.5614692Z [36;1mecho "🚀 PRODUCTION DEPLOYMENT INFORMATION" >> $GITHUB_STEP_SUMMARY[0m
+2025-12-07T20:52:40.5616325Z [36;1mecho "**Environment:** Production" >> $GITHUB_STEP_SUMMARY[0m
+2025-12-07T20:52:40.5617845Z [36;1mecho "**Branch:** main" >> $GITHUB_STEP_SUMMARY[0m
+2025-12-07T20:52:40.5619229Z [36;1mecho "**Commit:** $(git rev-parse HEAD)" >> $GITHUB_STEP_SUMMARY[0m
+2025-12-07T20:52:40.5620899Z [36;1mecho "**Commit Message:** $(git log --oneline -n 1)" >> $GITHUB_STEP_SUMMARY[0m
+2025-12-07T20:52:40.5622517Z [36;1mecho "**Triggered by:** T193R-W00D5" >> $GITHUB_STEP_SUMMARY[0m
+2025-12-07T20:52:40.5623931Z [36;1mecho "**Timestamp:** $(date)" >> $GITHUB_STEP_SUMMARY[0m
+2025-12-07T20:52:40.5662957Z shell: /usr/bin/bash -e {0}
+2025-12-07T20:52:40.5663856Z ##[endgroup]
+2025-12-07T20:52:40.5946682Z ##[group]Run actions/setup-node@v4
+2025-12-07T20:52:40.5947836Z with:
+2025-12-07T20:52:40.5948537Z   node-version: 22
+2025-12-07T20:52:40.5949262Z   cache: npm
+2025-12-07T20:52:40.5949969Z   always-auth: false
+2025-12-07T20:52:40.5950749Z   check-latest: false
+2025-12-07T20:52:40.5951735Z   token: ***
+2025-12-07T20:52:40.5952437Z ##[endgroup]
+2025-12-07T20:52:40.7713756Z Found in cache @ /opt/hostedtoolcache/node/22.21.1/x64
+2025-12-07T20:52:40.7719856Z ##[group]Environment details
+2025-12-07T20:52:42.9890489Z node: v22.21.1
+2025-12-07T20:52:42.9891012Z npm: 10.9.4
+2025-12-07T20:52:42.9891394Z yarn: 1.22.22
+2025-12-07T20:52:42.9892600Z ##[endgroup]
+2025-12-07T20:52:42.9922733Z [command]/opt/hostedtoolcache/node/22.21.1/x64/bin/npm config get cache
+2025-12-07T20:52:44.5854989Z /home/runner/.npm
+2025-12-07T20:52:44.8069660Z Cache hit for: node-cache-Linux-x64-npm-e3fade3f30968ac95fccac45edc85cd25eaa881f6a1cdb7268c834223e952c45
+2025-12-07T20:52:45.5384381Z Received 20062804 of 20062804 (100.0%), 32.9 MBs/sec
+2025-12-07T20:52:45.5385177Z Cache Size: ~19 MB (20062804 B)
+2025-12-07T20:52:45.5514641Z [command]/usr/bin/tar -xf /home/runner/work/_temp/62bfdef8-d9ed-4525-85ec-7ee30c0bad39/cache.tzst -P -C /home/runner/work/myFreecodecampLearning/myFreecodecampLearning --use-compress-program unzstd
+2025-12-07T20:52:45.6483113Z Cache restored successfully
+2025-12-07T20:52:45.6524928Z Cache restored from key: node-cache-Linux-x64-npm-e3fade3f30968ac95fccac45edc85cd25eaa881f6a1cdb7268c834223e952c45
+2025-12-07T20:52:45.6663796Z ##[group]Run ruby/setup-ruby@v1
+2025-12-07T20:52:45.6664094Z with:
+2025-12-07T20:52:45.6664292Z   ruby-version: 3.3
+2025-12-07T20:52:45.6664534Z   bundler-cache: false
+2025-12-07T20:52:45.6664765Z ##[endgroup]
+2025-12-07T20:52:45.8332704Z ##[group]Modifying PATH
+2025-12-07T20:52:45.8344095Z Entries added to PATH to use selected Ruby:
+2025-12-07T20:52:45.8344573Z   /opt/hostedtoolcache/Ruby/3.3.10/x64/bin
+2025-12-07T20:52:45.8349967Z ##[endgroup]
+2025-12-07T20:52:45.8350679Z ##[group]Print Ruby version
+2025-12-07T20:52:45.8453072Z [command]/opt/hostedtoolcache/Ruby/3.3.10/x64/bin/ruby --version
+2025-12-07T20:52:46.0268447Z ruby 3.3.10 (2025-10-23 revision 343ea05002) [x86_64-linux]
+2025-12-07T20:52:46.0303540Z Took   0.20 seconds
+2025-12-07T20:52:46.0305401Z ##[endgroup]
+2025-12-07T20:52:46.0306058Z ##[group]Installing Bundler
+2025-12-07T20:52:46.0312076Z Using Bundler 2.7.2 from Gemfile.lock BUNDLED WITH 2.7.2
+2025-12-07T20:52:46.0316697Z [command]/opt/hostedtoolcache/Ruby/3.3.10/x64/bin/gem install bundler -v 2.7.2
+2025-12-07T20:52:47.2344311Z Successfully installed bundler-2.7.2
+2025-12-07T20:52:47.2345010Z 1 gem installed
+2025-12-07T20:52:47.2396064Z Took   1.21 seconds
+2025-12-07T20:52:47.2396836Z ##[endgroup]
+2025-12-07T20:52:47.2470513Z ##[group]Run npm ci
+2025-12-07T20:52:47.2470762Z [36;1mnpm ci[0m
+2025-12-07T20:52:47.2510005Z shell: /usr/bin/bash -e {0}
+2025-12-07T20:52:47.2510253Z ##[endgroup]
+2025-12-07T20:52:48.6923527Z npm warn EBADENGINE Unsupported engine {
+2025-12-07T20:52:48.6924594Z npm warn EBADENGINE   package: 'freecodecamporg-website-copies@1.0.0',
+2025-12-07T20:52:48.6925632Z npm warn EBADENGINE   required: { node: '>=18 <=22.21.0' },
+2025-12-07T20:52:48.6926704Z npm warn EBADENGINE   current: { node: 'v22.21.1', npm: '10.9.4' }
+2025-12-07T20:52:48.6927503Z npm warn EBADENGINE }
+2025-12-07T20:52:49.8413215Z npm warn deprecated inflight@1.0.6: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
+2025-12-07T20:52:50.0465971Z npm warn deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported
+2025-12-07T20:52:50.9956383Z 
+2025-12-07T20:52:50.9957232Z added 557 packages, and audited 558 packages in 4s
+2025-12-07T20:52:50.9957943Z 
+2025-12-07T20:52:50.9958368Z 68 packages are looking for funding
+2025-12-07T20:52:50.9959581Z   run `npm fund` for details
+2025-12-07T20:52:50.9979321Z 
+2025-12-07T20:52:50.9979846Z 1 moderate severity vulnerability
+2025-12-07T20:52:50.9980168Z 
+2025-12-07T20:52:50.9980373Z To address all issues, run:
+2025-12-07T20:52:50.9980770Z   npm audit fix
+2025-12-07T20:52:50.9980981Z 
+2025-12-07T20:52:50.9981166Z Run `npm audit` for details.
+2025-12-07T20:52:51.0601907Z ##[group]Run bundle config set --local frozen false
+2025-12-07T20:52:51.0602319Z [36;1mbundle config set --local frozen false[0m
+2025-12-07T20:52:51.0602596Z [36;1mbundle install[0m
+2025-12-07T20:52:51.0639651Z shell: /usr/bin/bash -e {0}
+2025-12-07T20:52:51.0639915Z ##[endgroup]
+2025-12-07T20:52:53.7425318Z Fetching gem metadata from https://rubygems.org/..........
+2025-12-07T20:52:53.7474182Z Fetching rake 13.3.1
+2025-12-07T20:52:53.8424819Z Installing rake 13.3.1
+2025-12-07T20:52:53.8572819Z Fetching public_suffix 7.0.0
+2025-12-07T20:52:53.8575505Z Fetching base64 0.3.0
+2025-12-07T20:52:53.8575808Z Fetching bigdecimal 3.3.1
+2025-12-07T20:52:53.8576062Z Fetching colorator 1.1.0
+2025-12-07T20:52:53.8753109Z Installing public_suffix 7.0.0
+2025-12-07T20:52:53.8813868Z Fetching concurrent-ruby 1.3.5
+2025-12-07T20:52:53.8836936Z Installing base64 0.3.0
+2025-12-07T20:52:53.8864740Z Fetching csv 3.3.5
+2025-12-07T20:52:53.9028421Z Installing bigdecimal 3.3.1 with native extensions
+2025-12-07T20:52:53.9118542Z Installing colorator 1.1.0
+2025-12-07T20:52:53.9185780Z Fetching eventmachine 1.2.7
+2025-12-07T20:52:53.9474344Z Installing concurrent-ruby 1.3.5
+2025-12-07T20:52:53.9515746Z Installing csv 3.3.5
+2025-12-07T20:52:54.0087496Z Installing eventmachine 1.2.7 with native extensions
+2025-12-07T20:52:54.0193705Z Fetching http_parser.rb 0.8.0
+2025-12-07T20:52:54.0566598Z Installing http_parser.rb 0.8.0 with native extensions
+2025-12-07T20:52:54.1144099Z Fetching ffi 1.17.2 (x86_64-linux-gnu)
+2025-12-07T20:52:54.1702215Z Installing ffi 1.17.2 (x86_64-linux-gnu)
+2025-12-07T20:52:54.2396547Z Fetching forwardable-extended 2.6.0
+2025-12-07T20:52:54.2564140Z Installing forwardable-extended 2.6.0
+2025-12-07T20:52:54.2596811Z Fetching rb-fsevent 0.11.2
+2025-12-07T20:52:54.2758467Z Installing rb-fsevent 0.11.2
+2025-12-07T20:52:54.2887345Z Fetching json 2.17.1
+2025-12-07T20:52:54.3075529Z Installing json 2.17.1 with native extensions
+2025-12-07T20:52:55.8625709Z Fetching liquid 4.0.4
+2025-12-07T20:52:55.8859248Z Installing liquid 4.0.4
+2025-12-07T20:52:55.9367587Z Fetching mercenary 0.4.0
+2025-12-07T20:52:55.9604718Z Installing mercenary 0.4.0
+2025-12-07T20:52:55.9985892Z Fetching rouge 4.6.1
+2025-12-07T20:52:56.0709354Z Installing rouge 4.6.1
+2025-12-07T20:52:56.2171852Z Fetching safe_yaml 1.0.5
+2025-12-07T20:52:56.2335121Z Installing safe_yaml 1.0.5
+2025-12-07T20:52:56.2531097Z Fetching unicode-display_width 2.6.0
+2025-12-07T20:52:56.2679600Z Installing unicode-display_width 2.6.0
+2025-12-07T20:52:56.2736553Z Fetching webrick 1.9.2
+2025-12-07T20:52:56.3101185Z Installing webrick 1.9.2
+2025-12-07T20:52:56.3300489Z Fetching addressable 2.8.8
+2025-12-07T20:52:56.3484742Z Installing addressable 2.8.8
+2025-12-07T20:52:56.3628987Z Fetching i18n 1.14.7
+2025-12-07T20:52:56.3788718Z Installing i18n 1.14.7
+2025-12-07T20:52:56.3949617Z Fetching rb-inotify 0.11.1
+2025-12-07T20:52:56.4096675Z Installing rb-inotify 0.11.1
+2025-12-07T20:52:56.4176184Z Fetching pathutil 0.16.2
+2025-12-07T20:52:56.4338765Z Installing pathutil 0.16.2
+2025-12-07T20:52:56.4362361Z Fetching kramdown 2.5.1
+2025-12-07T20:52:56.4631535Z Installing kramdown 2.5.1
+2025-12-07T20:52:56.5991623Z Fetching terminal-table 3.0.2
+2025-12-07T20:52:56.6208968Z Installing terminal-table 3.0.2
+2025-12-07T20:52:56.6310554Z Fetching listen 3.9.0
+2025-12-07T20:52:56.6510575Z Installing listen 3.9.0
+2025-12-07T20:52:56.6618132Z Fetching kramdown-parser-gfm 1.1.0
+2025-12-07T20:52:56.6779659Z Installing kramdown-parser-gfm 1.1.0
+2025-12-07T20:52:56.6908104Z Fetching jekyll-watch 2.2.1
+2025-12-07T20:52:56.7089580Z Installing jekyll-watch 2.2.1
+2025-12-07T20:53:04.2883597Z Fetching google-protobuf 4.33.1 (x86_64-linux-gnu)
+2025-12-07T20:53:04.4339079Z Installing google-protobuf 4.33.1 (x86_64-linux-gnu)
+2025-12-07T20:53:04.4895777Z Fetching sass-embedded 1.94.2 (x86_64-linux-gnu)
+2025-12-07T20:53:04.6242341Z Installing sass-embedded 1.94.2 (x86_64-linux-gnu)
+2025-12-07T20:53:04.7241778Z Fetching jekyll-sass-converter 3.1.0
+2025-12-07T20:53:04.7412122Z Installing jekyll-sass-converter 3.1.0
+2025-12-07T20:53:08.6701307Z Fetching em-websocket 0.5.3
+2025-12-07T20:53:08.7281828Z Installing em-websocket 0.5.3
+2025-12-07T20:53:08.7383377Z Fetching jekyll 4.4.1
+2025-12-07T20:53:08.7799285Z Installing jekyll 4.4.1
+2025-12-07T20:53:08.8055792Z Fetching jekyll-feed 0.17.0
+2025-12-07T20:53:08.8059129Z Fetching jekyll-seo-tag 2.8.0
+2025-12-07T20:53:08.8059561Z Fetching jekyll-sitemap 1.4.0
+2025-12-07T20:53:08.8256461Z Installing jekyll-feed 0.17.0
+2025-12-07T20:53:08.8483456Z Installing jekyll-seo-tag 2.8.0
+2025-12-07T20:53:08.8684836Z Installing jekyll-sitemap 1.4.0
+2025-12-07T20:53:08.8929142Z Bundle complete! 9 Gemfile dependencies, 38 gems now installed.
+2025-12-07T20:53:08.8929823Z Use `bundle info [gemname]` to see where a bundled gem is installed.
+2025-12-07T20:53:08.9434809Z ##[group]Run npx playwright install --with-deps
+2025-12-07T20:53:08.9435460Z [36;1mnpx playwright install --with-deps[0m
+2025-12-07T20:53:08.9483127Z shell: /usr/bin/bash -e {0}
+2025-12-07T20:53:08.9483544Z ##[endgroup]
+2025-12-07T20:53:09.7848404Z Installing dependencies...
+2025-12-07T20:53:09.7944124Z Switching to root user to install dependencies...
+2025-12-07T20:53:09.8740775Z Get:1 file:/etc/apt/apt-mirrors.txt Mirrorlist [144 B]
+2025-12-07T20:53:09.9073215Z Get:6 https://packages.microsoft.com/repos/azure-cli noble InRelease [3564 B]
+2025-12-07T20:53:09.9178416Z Get:7 https://packages.microsoft.com/ubuntu/24.04/prod noble InRelease [3600 B]
+2025-12-07T20:53:09.9308106Z Hit:2 http://azure.archive.ubuntu.com/ubuntu noble InRelease
+2025-12-07T20:53:09.9328137Z Get:3 http://azure.archive.ubuntu.com/ubuntu noble-updates InRelease [126 kB]
+2025-12-07T20:53:09.9392337Z Get:4 http://azure.archive.ubuntu.com/ubuntu noble-backports InRelease [126 kB]
+2025-12-07T20:53:09.9400569Z Get:5 http://azure.archive.ubuntu.com/ubuntu noble-security InRelease [126 kB]
+2025-12-07T20:53:09.9900182Z Get:8 https://packages.microsoft.com/repos/azure-cli noble/main amd64 Packages [1822 B]
+2025-12-07T20:53:10.0371921Z Get:9 https://packages.microsoft.com/ubuntu/24.04/prod noble/main arm64 Packages [55.6 kB]
+2025-12-07T20:53:10.0418874Z Get:10 https://packages.microsoft.com/ubuntu/24.04/prod noble/main amd64 Packages [73.9 kB]
+2025-12-07T20:53:10.0460319Z Get:11 https://packages.microsoft.com/ubuntu/24.04/prod noble/main armhf Packages [11.2 kB]
+2025-12-07T20:53:10.1413156Z Get:12 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 Packages [1627 kB]
+2025-12-07T20:53:10.1508956Z Get:13 http://azure.archive.ubuntu.com/ubuntu noble-updates/main Translation-en [305 kB]
+2025-12-07T20:53:10.1534724Z Get:14 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 Components [175 kB]
+2025-12-07T20:53:10.1554889Z Get:15 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 c-n-f Metadata [15.7 kB]
+2025-12-07T20:53:10.1581031Z Get:16 http://azure.archive.ubuntu.com/ubuntu noble-updates/universe amd64 Packages [1501 kB]
+2025-12-07T20:53:10.1662483Z Get:17 http://azure.archive.ubuntu.com/ubuntu noble-updates/universe Translation-en [304 kB]
+2025-12-07T20:53:10.1693953Z Get:18 http://azure.archive.ubuntu.com/ubuntu noble-updates/universe amd64 Components [377 kB]
+2025-12-07T20:53:10.1730399Z Get:19 http://azure.archive.ubuntu.com/ubuntu noble-updates/universe amd64 c-n-f Metadata [31.4 kB]
+2025-12-07T20:53:10.1736640Z Get:20 http://azure.archive.ubuntu.com/ubuntu noble-updates/restricted amd64 Packages [2309 kB]
+2025-12-07T20:53:10.1857085Z Get:21 http://azure.archive.ubuntu.com/ubuntu noble-updates/restricted Translation-en [526 kB]
+2025-12-07T20:53:10.2318239Z Get:22 http://azure.archive.ubuntu.com/ubuntu noble-updates/restricted amd64 Components [212 B]
+2025-12-07T20:53:10.2338074Z Get:23 http://azure.archive.ubuntu.com/ubuntu noble-updates/multiverse amd64 Components [940 B]
+2025-12-07T20:53:10.2351959Z Get:24 http://azure.archive.ubuntu.com/ubuntu noble-backports/main amd64 Components [7136 B]
+2025-12-07T20:53:10.2359097Z Get:25 http://azure.archive.ubuntu.com/ubuntu noble-backports/universe amd64 Packages [29.2 kB]
+2025-12-07T20:53:10.2372072Z Get:26 http://azure.archive.ubuntu.com/ubuntu noble-backports/universe Translation-en [17.6 kB]
+2025-12-07T20:53:10.2384460Z Get:27 http://azure.archive.ubuntu.com/ubuntu noble-backports/universe amd64 Components [11.0 kB]
+2025-12-07T20:53:10.2396904Z Get:28 http://azure.archive.ubuntu.com/ubuntu noble-backports/restricted amd64 Components [212 B]
+2025-12-07T20:53:10.2410792Z Get:29 http://azure.archive.ubuntu.com/ubuntu noble-backports/multiverse amd64 Components [212 B]
+2025-12-07T20:53:10.2498204Z Get:30 http://azure.archive.ubuntu.com/ubuntu noble-security/main amd64 Packages [1349 kB]
+2025-12-07T20:53:10.2587346Z Get:31 http://azure.archive.ubuntu.com/ubuntu noble-security/main Translation-en [221 kB]
+2025-12-07T20:53:10.2610449Z Get:32 http://azure.archive.ubuntu.com/ubuntu noble-security/main amd64 Components [21.6 kB]
+2025-12-07T20:53:10.2620442Z Get:33 http://azure.archive.ubuntu.com/ubuntu noble-security/main amd64 c-n-f Metadata [9448 B]
+2025-12-07T20:53:10.2630984Z Get:34 http://azure.archive.ubuntu.com/ubuntu noble-security/universe amd64 Packages [915 kB]
+2025-12-07T20:53:10.2685983Z Get:35 http://azure.archive.ubuntu.com/ubuntu noble-security/universe Translation-en [206 kB]
+2025-12-07T20:53:10.3192446Z Get:36 http://azure.archive.ubuntu.com/ubuntu noble-security/universe amd64 Components [71.5 kB]
+2025-12-07T20:53:10.3207012Z Get:37 http://azure.archive.ubuntu.com/ubuntu noble-security/universe amd64 c-n-f Metadata [19.4 kB]
+2025-12-07T20:53:10.3228352Z Get:38 http://azure.archive.ubuntu.com/ubuntu noble-security/restricted amd64 Packages [2205 kB]
+2025-12-07T20:53:10.3343756Z Get:39 http://azure.archive.ubuntu.com/ubuntu noble-security/restricted Translation-en [503 kB]
+2025-12-07T20:53:10.3376689Z Get:40 http://azure.archive.ubuntu.com/ubuntu noble-security/restricted amd64 Components [208 B]
+2025-12-07T20:53:10.3385110Z Get:41 http://azure.archive.ubuntu.com/ubuntu noble-security/multiverse amd64 Components [208 B]
+2025-12-07T20:53:19.3078416Z Fetched 13.3 MB in 2s (8312 kB/s)
+2025-12-07T20:53:20.1164334Z Reading package lists...
+2025-12-07T20:53:20.1425169Z Reading package lists...
+2025-12-07T20:53:20.3820167Z Building dependency tree...
+2025-12-07T20:53:20.3828239Z Reading state information...
+2025-12-07T20:53:20.4041769Z libasound2t64 is already the newest version (1.2.11-1ubuntu0.1).
+2025-12-07T20:53:20.4043043Z libasound2t64 set to manually installed.
+2025-12-07T20:53:20.4043746Z libatk-bridge2.0-0t64 is already the newest version (2.52.0-1build1).
+2025-12-07T20:53:20.4044428Z libatk-bridge2.0-0t64 set to manually installed.
+2025-12-07T20:53:20.4045090Z libatk1.0-0t64 is already the newest version (2.52.0-1build1).
+2025-12-07T20:53:20.4045679Z libatk1.0-0t64 set to manually installed.
+2025-12-07T20:53:20.4046331Z libatspi2.0-0t64 is already the newest version (2.52.0-1build1).
+2025-12-07T20:53:20.4046944Z libatspi2.0-0t64 set to manually installed.
+2025-12-07T20:53:20.4047551Z libcairo2 is already the newest version (1.18.0-3build1).
+2025-12-07T20:53:20.4048458Z libcairo2 set to manually installed.
+2025-12-07T20:53:20.4049072Z libdbus-1-3 is already the newest version (1.14.10-4ubuntu4.1).
+2025-12-07T20:53:20.4049654Z libdbus-1-3 set to manually installed.
+2025-12-07T20:53:20.4050287Z libdrm2 is already the newest version (2.4.122-1~ubuntu0.24.04.2).
+2025-12-07T20:53:20.4050884Z libdrm2 set to manually installed.
+2025-12-07T20:53:20.4051512Z libgbm1 is already the newest version (25.0.7-0ubuntu0.24.04.2).
+2025-12-07T20:53:20.4052109Z libgbm1 set to manually installed.
+2025-12-07T20:53:20.4052702Z libnspr4 is already the newest version (2:4.35-1.1build1).
+2025-12-07T20:53:20.4053275Z libnspr4 set to manually installed.
+2025-12-07T20:53:20.4053844Z libnss3 is already the newest version (2:3.98-1build1).
+2025-12-07T20:53:20.4054393Z libnss3 set to manually installed.
+2025-12-07T20:53:20.4055009Z libpango-1.0-0 is already the newest version (1.52.1+ds-1build1).
+2025-12-07T20:53:20.4055661Z libpango-1.0-0 set to manually installed.
+2025-12-07T20:53:20.4056263Z libx11-6 is already the newest version (2:1.8.7-1build1).
+2025-12-07T20:53:20.4056812Z libx11-6 set to manually installed.
+2025-12-07T20:53:20.4057361Z libxcb1 is already the newest version (1.15-1ubuntu2).
+2025-12-07T20:53:20.4058062Z libxcb1 set to manually installed.
+2025-12-07T20:53:20.4058683Z libxcomposite1 is already the newest version (1:0.4.5-1build3).
+2025-12-07T20:53:20.4059314Z libxcomposite1 set to manually installed.
+2025-12-07T20:53:20.4059939Z libxdamage1 is already the newest version (1:1.1.6-1build1).
+2025-12-07T20:53:20.4060525Z libxdamage1 set to manually installed.
+2025-12-07T20:53:20.4061121Z libxext6 is already the newest version (2:1.3.4-1build2).
+2025-12-07T20:53:20.4061672Z libxext6 set to manually installed.
+2025-12-07T20:53:20.4062605Z libxfixes3 is already the newest version (1:6.0.0-2build1).
+2025-12-07T20:53:20.4063197Z libxfixes3 set to manually installed.
+2025-12-07T20:53:20.4063807Z libxkbcommon0 is already the newest version (1.6.0-1build1).
+2025-12-07T20:53:20.4064405Z libxkbcommon0 set to manually installed.
+2025-12-07T20:53:20.4065022Z libxrandr2 is already the newest version (2:1.5.2-2build1).
+2025-12-07T20:53:20.4065593Z libxrandr2 set to manually installed.
+2025-12-07T20:53:20.4066240Z libcairo-gobject2 is already the newest version (1.18.0-3build1).
+2025-12-07T20:53:20.4066892Z libcairo-gobject2 set to manually installed.
+2025-12-07T20:53:20.4067578Z libfontconfig1 is already the newest version (2.15.0-1.1ubuntu2).
+2025-12-07T20:53:20.4068353Z libfontconfig1 set to manually installed.
+2025-12-07T20:53:20.4069012Z libfreetype6 is already the newest version (2.13.2+dfsg-1build3).
+2025-12-07T20:53:20.4069625Z libfreetype6 set to manually installed.
+2025-12-07T20:53:20.4070346Z libgdk-pixbuf-2.0-0 is already the newest version (2.42.10+dfsg-3ubuntu3.2).
+2025-12-07T20:53:20.4071065Z libgdk-pixbuf-2.0-0 set to manually installed.
+2025-12-07T20:53:20.4071731Z libgtk-3-0t64 is already the newest version (3.24.41-4ubuntu1.3).
+2025-12-07T20:53:20.4072342Z libgtk-3-0t64 set to manually installed.
+2025-12-07T20:53:20.4073022Z libpangocairo-1.0-0 is already the newest version (1.52.1+ds-1build1).
+2025-12-07T20:53:20.4073719Z libpangocairo-1.0-0 set to manually installed.
+2025-12-07T20:53:20.4074367Z libx11-xcb1 is already the newest version (2:1.8.7-1build1).
+2025-12-07T20:53:20.4074950Z libx11-xcb1 set to manually installed.
+2025-12-07T20:53:20.4075720Z libxcb-shm0 is already the newest version (1.15-1ubuntu2).
+2025-12-07T20:53:20.4076295Z libxcb-shm0 set to manually installed.
+2025-12-07T20:53:20.4076908Z libxcursor1 is already the newest version (1:1.2.1-1build1).
+2025-12-07T20:53:20.4077550Z libxcursor1 set to manually installed.
+2025-12-07T20:53:20.4078431Z libxi6 is already the newest version (2:1.8.1-1build1).
+2025-12-07T20:53:20.4078976Z libxi6 set to manually installed.
+2025-12-07T20:53:20.4079591Z libxrender1 is already the newest version (1:0.9.10-1.1build1).
+2025-12-07T20:53:20.4080190Z libxrender1 set to manually installed.
+2025-12-07T20:53:20.4080786Z libicu74 is already the newest version (74.2-1ubuntu3.1).
+2025-12-07T20:53:20.4081505Z libatomic1 is already the newest version (14.2.0-4ubuntu2~24.04).
+2025-12-07T20:53:20.4082112Z libatomic1 set to manually installed.
+2025-12-07T20:53:20.4082818Z libenchant-2-2 is already the newest version (2.3.3-2build2).
+2025-12-07T20:53:20.4083447Z libenchant-2-2 set to manually installed.
+2025-12-07T20:53:20.4084066Z libepoxy0 is already the newest version (1.5.10-1build1).
+2025-12-07T20:53:20.4084632Z libepoxy0 set to manually installed.
+2025-12-07T20:53:20.4085292Z libgstreamer1.0-0 is already the newest version (1.24.2-1ubuntu0.1).
+2025-12-07T20:53:20.4085950Z libgstreamer1.0-0 set to manually installed.
+2025-12-07T20:53:20.4086595Z libharfbuzz0b is already the newest version (8.3.0-2build2).
+2025-12-07T20:53:20.4087205Z libharfbuzz0b set to manually installed.
+2025-12-07T20:53:20.4088056Z libjpeg-turbo8 is already the newest version (2.1.5-2ubuntu2).
+2025-12-07T20:53:20.4088680Z libjpeg-turbo8 set to manually installed.
+2025-12-07T20:53:20.4089284Z liblcms2-2 is already the newest version (2.14-2build1).
+2025-12-07T20:53:20.4089845Z liblcms2-2 set to manually installed.
+2025-12-07T20:53:20.4090474Z libpng16-16t64 is already the newest version (1.6.43-5build1).
+2025-12-07T20:53:20.4091090Z libpng16-16t64 set to manually installed.
+2025-12-07T20:53:20.4091780Z libwayland-client0 is already the newest version (1.22.0-2.1build1).
+2025-12-07T20:53:20.4092570Z libwayland-client0 set to manually installed.
+2025-12-07T20:53:20.5816102Z libwayland-egl1 is already the newest version (1.22.0-2.1build1).
+2025-12-07T20:53:20.5816895Z libwayland-egl1 set to manually installed.
+2025-12-07T20:53:20.5817840Z libwayland-server0 is already the newest version (1.22.0-2.1build1).
+2025-12-07T20:53:20.5819086Z libwayland-server0 set to manually installed.
+2025-12-07T20:53:20.5819875Z libwebp7 is already the newest version (1.3.2-0.4build3).
+2025-12-07T20:53:20.5820519Z libwebp7 set to manually installed.
+2025-12-07T20:53:20.5821195Z libwebpdemux2 is already the newest version (1.3.2-0.4build3).
+2025-12-07T20:53:20.5821865Z libwebpdemux2 set to manually installed.
+2025-12-07T20:53:20.5822621Z libxml2 is already the newest version (2.9.14+dfsg-1.3ubuntu3.6).
+2025-12-07T20:53:20.5823258Z libxml2 set to manually installed.
+2025-12-07T20:53:20.5823959Z libxslt1.1 is already the newest version (1.1.39-0exp1ubuntu0.24.04.2).
+2025-12-07T20:53:20.5824654Z libxslt1.1 set to manually installed.
+2025-12-07T20:53:20.5825292Z xvfb is already the newest version (2:21.1.12-1ubuntu1.5).
+2025-12-07T20:53:20.5826126Z fonts-noto-color-emoji is already the newest version (2.047-0ubuntu0.24.04.1).
+2025-12-07T20:53:20.5826963Z fonts-liberation is already the newest version (1:2.1.5-3).
+2025-12-07T20:53:20.5827802Z fonts-liberation set to manually installed.
+2025-12-07T20:53:20.5828426Z The following additional packages will be installed:
+2025-12-07T20:53:20.5829080Z   gir1.2-glib-2.0 glib-networking glib-networking-common
+2025-12-07T20:53:20.5829866Z   glib-networking-services gsettings-desktop-schemas libaa1 libabsl20220623t64
+2025-12-07T20:53:20.5830807Z   libass9 libasyncns0 libavc1394-0 libavcodec60 libavfilter9 libavformat60
+2025-12-07T20:53:20.5831740Z   libavtp0 libavutil58 libblas3 libbluray2 libbs2b0 libcaca0
+2025-12-07T20:53:20.5832570Z   libcairo-script-interpreter2 libcdparanoia0 libchromaprint1 libcjson1
+2025-12-07T20:53:20.5833665Z   libcodec2-1.2 libdav1d7 libdc1394-25 libdca0 libdecor-0-0
+2025-12-07T20:53:20.5834486Z   libdirectfb-1.7-7t64 libdv4t64 libdvdnav4 libdvdread8t64 libegl-mesa0
+2025-12-07T20:53:20.5835301Z   libegl1 libfaad2 libflac12t64 libfluidsynth3 libfreeaptx0 libgav1-1
+2025-12-07T20:53:20.5836067Z   libglib2.0-bin libglib2.0-data libgme0 libgraphene-1.0-0 libgsm1
+2025-12-07T20:53:20.5836899Z   libgssdp-1.6-0 libgstreamer-plugins-good1.0-0 libgtk-4-common libgupnp-1.6-0
+2025-12-07T20:53:20.5837894Z   libgupnp-igd-1.6-0 libhwy1t64 libiec61883-0 libimath-3-1-29t64
+2025-12-07T20:53:20.5838404Z   libinstpatch-1.0-2 libjack-jackd2-0 libjxl0.7 liblapack3 liblc3-1
+2025-12-07T20:53:20.5838897Z   libldacbt-enc2 liblilv-0-0 liblrdf0 libltc11 libmbedcrypto7t64 libmfx1
+2025-12-07T20:53:20.5839347Z   libmjpegutils-2.1-0t64 libmodplug1 libmp3lame0 libmpcdec6
+2025-12-07T20:53:20.5839782Z   libmpeg2encpp-2.1-0t64 libmpg123-0t64 libmplex2-2.1-0t64 libmysofa1
+2025-12-07T20:53:20.5840250Z   libneon27t64 libnice10 libopenal-data libopenal1 libopenexr-3-1-30
+2025-12-07T20:53:20.5840886Z   libopenh264-7 libopenmpt0t64 libopenni2-0 liborc-0.4-0t64
+2025-12-07T20:53:20.5841329Z   libpipewire-0.3-0t64 libplacebo338 libpocketsphinx3 libpostproc57
+2025-12-07T20:53:20.5841829Z   libproxy1v5 libpulse0 libqrencode4 libraptor2-0 librav1e0 libraw1394-11
+2025-12-07T20:53:20.5842347Z   librist4 librsvg2-2 librubberband2 libsamplerate0 libsbc1 libsdl2-2.0-0
+2025-12-07T20:53:20.5842970Z   libsecret-common libserd-0-0 libshine3 libshout3 libsndfile1 libsndio7.0
+2025-12-07T20:53:20.5843534Z   libsord-0-0 libsoundtouch1 libsoup-3.0-0 libsoup-3.0-common libsoxr0
+2025-12-07T20:53:20.5844071Z   libspa-0.2-modules libspandsp2t64 libspeex1 libsphinxbase3t64 libsratom-0-0
+2025-12-07T20:53:20.5844581Z   libsrt1.5-gnutls libsrtp2-1 libssh-4 libssh-gcrypt-4 libsvtav1enc1d1
+2025-12-07T20:53:20.5845173Z   libswresample4 libswscale7 libtag1v5 libtag1v5-vanilla libtheora0
+2025-12-07T20:53:20.5845973Z   libtwolame0 libudfread0 libunibreak5 libv4l-0t64 libv4lconvert0t64
+2025-12-07T20:53:20.5846850Z   libva-drm2 libva-x11-2 libva2 libvdpau1 libvidstab1.1 libvisual-0.4-0
+2025-12-07T20:53:20.5847906Z   libvo-aacenc0 libvo-amrwbenc0 libvorbisenc2 libvpl2 libwavpack1
+2025-12-07T20:53:20.5848485Z   libwebrtc-audio-processing1 libwildmidi2 libx265-199 libxcb-xkb1
+2025-12-07T20:53:20.5848978Z   libxkbcommon-x11-0 libxvidcore4 libyuv0 libzbar0t64 libzimg2 libzix-0-0
+2025-12-07T20:53:20.5849699Z   libzvbi-common libzvbi0t64 libzxing3 ocl-icd-libopencl1 session-migration
+2025-12-07T20:53:20.5850224Z   timgm6mb-soundfont xfonts-encodings xfonts-utils
+2025-12-07T20:53:20.5850548Z Suggested packages:
+2025-12-07T20:53:20.5850910Z   frei0r-plugins gvfs libcuda1 libnvcuvid1 libnvidia-encode1 libbluray-bdj
+2025-12-07T20:53:20.5851388Z   cups-common libdirectfb-extra libdv-bin oss-compat libdvdcss2
+2025-12-07T20:53:20.5851966Z   low-memory-monitor libvisual-0.4-plugins jackd2 liblrdf0-dev libportaudio2
+2025-12-07T20:53:20.5852963Z   opus-tools pipewire pulseaudio raptor2-utils libraw1394-doc librsvg2-bin
+2025-12-07T20:53:20.5853887Z   serdi sndiod sordi speex libwildmidi-config opencl-icd fluid-soundfont-gm
+2025-12-07T20:53:20.5854296Z Recommended packages:
+2025-12-07T20:53:20.5854624Z   fonts-ipafont-mincho fonts-tlwg-loma gstreamer1.0-x libaacs0
+2025-12-07T20:53:20.5855099Z   default-libdecor-0-plugin-1 | libdecor-0-plugin-1 gstreamer1.0-gl
+2025-12-07T20:53:20.5855625Z   libgtk-4-bin librsvg2-common libgtk-4-media-gstreamer libpipewire-0.3-common
+2025-12-07T20:53:20.5856166Z   pocketsphinx-en-us va-driver-all | va-driver vdpau-driver-all | vdpau-driver
+2025-12-07T20:53:20.5856548Z   libmagickcore-6.q16-7-extra
+2025-12-07T20:53:20.6628938Z The following NEW packages will be installed:
+2025-12-07T20:53:20.6629862Z   fonts-freefont-ttf fonts-ipafont-gothic fonts-tlwg-loma-otf fonts-unifont
+2025-12-07T20:53:20.6630758Z   fonts-wqy-zenhei glib-networking glib-networking-common
+2025-12-07T20:53:20.6631635Z   glib-networking-services gsettings-desktop-schemas gstreamer1.0-libav
+2025-12-07T20:53:20.6633091Z   gstreamer1.0-plugins-bad gstreamer1.0-plugins-base gstreamer1.0-plugins-good
+2025-12-07T20:53:20.6634113Z   libaa1 libabsl20220623t64 libass9 libasyncns0 libavc1394-0 libavcodec60
+2025-12-07T20:53:20.6635044Z   libavfilter9 libavformat60 libavif16 libavtp0 libavutil58 libblas3
+2025-12-07T20:53:20.6635998Z   libbluray2 libbs2b0 libcaca0 libcairo-script-interpreter2 libcdparanoia0
+2025-12-07T20:53:20.6636969Z   libchromaprint1 libcjson1 libcodec2-1.2 libdav1d7 libdc1394-25 libdca0
+2025-12-07T20:53:20.6638202Z   libdecor-0-0 libdirectfb-1.7-7t64 libdv4t64 libdvdnav4 libdvdread8t64
+2025-12-07T20:53:20.6639132Z   libegl-mesa0 libegl1 libevent-2.1-7t64 libfaad2 libflac12t64 libflite1
+2025-12-07T20:53:20.6667109Z   libfluidsynth3 libfreeaptx0 libgav1-1 libgles2 libgme0 libgraphene-1.0-0
+2025-12-07T20:53:20.6668307Z   libgsm1 libgssdp-1.6-0 libgstreamer-gl1.0-0 libgstreamer-plugins-bad1.0-0
+2025-12-07T20:53:20.6669294Z   libgstreamer-plugins-base1.0-0 libgstreamer-plugins-good1.0-0 libgtk-4-1
+2025-12-07T20:53:20.6670205Z   libgtk-4-common libgupnp-1.6-0 libgupnp-igd-1.6-0 libharfbuzz-icu0
+2025-12-07T20:53:20.6671042Z   libhwy1t64 libhyphen0 libiec61883-0 libimath-3-1-29t64 libinstpatch-1.0-2
+2025-12-07T20:53:20.6671893Z   libjack-jackd2-0 libjxl0.7 liblapack3 liblc3-1 libldacbt-enc2 liblilv-0-0
+2025-12-07T20:53:20.6672673Z   liblrdf0 libltc11 libmanette-0.2-0 libmbedcrypto7t64 libmfx1
+2025-12-07T20:53:20.6673418Z   libmjpegutils-2.1-0t64 libmodplug1 libmp3lame0 libmpcdec6
+2025-12-07T20:53:20.6674163Z   libmpeg2encpp-2.1-0t64 libmpg123-0t64 libmplex2-2.1-0t64 libmysofa1
+2025-12-07T20:53:20.6674965Z   libneon27t64 libnice10 libopenal-data libopenal1 libopenexr-3-1-30
+2025-12-07T20:53:20.6675746Z   libopenh264-7 libopenmpt0t64 libopenni2-0 libopus0 liborc-0.4-0t64
+2025-12-07T20:53:20.6676524Z   libpipewire-0.3-0t64 libplacebo338 libpocketsphinx3 libpostproc57
+2025-12-07T20:53:20.6677331Z   libproxy1v5 libpulse0 libqrencode4 libraptor2-0 librav1e0 libraw1394-11
+2025-12-07T20:53:20.6678350Z   librist4 librsvg2-2 librubberband2 libsamplerate0 libsbc1 libsdl2-2.0-0
+2025-12-07T20:53:20.6679202Z   libsecret-1-0 libsecret-common libserd-0-0 libshine3 libshout3 libsndfile1
+2025-12-07T20:53:20.6680039Z   libsndio7.0 libsord-0-0 libsoundtouch1 libsoup-3.0-0 libsoup-3.0-common
+2025-12-07T20:53:20.6680858Z   libsoxr0 libspa-0.2-modules libspandsp2t64 libspeex1 libsphinxbase3t64
+2025-12-07T20:53:20.6681977Z   libsratom-0-0 libsrt1.5-gnutls libsrtp2-1 libssh-gcrypt-4 libsvtav1enc1d1
+2025-12-07T20:53:20.6682796Z   libswresample4 libswscale7 libtag1v5 libtag1v5-vanilla libtheora0
+2025-12-07T20:53:20.6683571Z   libtwolame0 libudfread0 libunibreak5 libv4l-0t64 libv4lconvert0t64
+2025-12-07T20:53:20.6684340Z   libva-drm2 libva-x11-2 libva2 libvdpau1 libvidstab1.1 libvisual-0.4-0
+2025-12-07T20:53:20.6685132Z   libvo-aacenc0 libvo-amrwbenc0 libvorbisenc2 libvpl2 libvpx9 libwavpack1
+2025-12-07T20:53:20.6685982Z   libwebrtc-audio-processing1 libwildmidi2 libwoff1 libx264-164 libx265-199
+2025-12-07T20:53:20.6686844Z   libxcb-xkb1 libxkbcommon-x11-0 libxvidcore4 libyuv0 libzbar0t64 libzimg2
+2025-12-07T20:53:20.6687810Z   libzix-0-0 libzvbi-common libzvbi0t64 libzxing3 ocl-icd-libopencl1
+2025-12-07T20:53:20.6688595Z   session-migration timgm6mb-soundfont xfonts-cyrillic xfonts-encodings
+2025-12-07T20:53:20.6689265Z   xfonts-scalable xfonts-utils
+2025-12-07T20:53:20.6689747Z The following packages will be upgraded:
+2025-12-07T20:53:20.6690412Z   gir1.2-glib-2.0 libcups2t64 libglib2.0-0t64 libglib2.0-bin libglib2.0-data
+2025-12-07T20:53:20.6690961Z   libssh-4
+2025-12-07T20:53:20.6900654Z 6 upgraded, 179 newly installed, 0 to remove and 47 not upgraded.
+2025-12-07T20:53:20.6901381Z Need to get 116 MB of archives.
+2025-12-07T20:53:20.6902083Z After this operation, 363 MB of additional disk space will be used.
+2025-12-07T20:53:20.6902831Z Get:1 file:/etc/apt/apt-mirrors.txt Mirrorlist [144 B]
+2025-12-07T20:53:20.7714740Z Get:2 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 fonts-ipafont-gothic all 00303-21ubuntu1 [3513 kB]
+2025-12-07T20:53:20.8422258Z Get:3 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libglib2.0-data all 2.80.0-6ubuntu3.5 [48.8 kB]
+2025-12-07T20:53:20.8752065Z Get:4 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libglib2.0-bin amd64 2.80.0-6ubuntu3.5 [97.9 kB]
+2025-12-07T20:53:20.9092374Z Get:5 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 gir1.2-glib-2.0 amd64 2.80.0-6ubuntu3.5 [183 kB]
+2025-12-07T20:53:20.9459540Z Get:6 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libglib2.0-0t64 amd64 2.80.0-6ubuntu3.5 [1544 kB]
+2025-12-07T20:53:20.9965388Z Get:7 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 fonts-freefont-ttf all 20211204+svn4273-2 [5641 kB]
+2025-12-07T20:53:21.1457219Z Get:8 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 fonts-tlwg-loma-otf all 1:0.7.3-1 [107 kB]
+2025-12-07T20:53:21.1785519Z Get:9 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 fonts-unifont all 1:15.1.01-1build1 [2993 kB]
+2025-12-07T20:53:21.2453550Z Get:10 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 fonts-wqy-zenhei all 0.9.45-8 [7472 kB]
+2025-12-07T20:53:21.3739359Z Get:11 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libproxy1v5 amd64 0.5.4-4build1 [26.5 kB]
+2025-12-07T20:53:21.4064606Z Get:12 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 glib-networking-common all 2.80.0-1build1 [6702 B]
+2025-12-07T20:53:21.4386434Z Get:13 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 glib-networking-services amd64 2.80.0-1build1 [12.8 kB]
+2025-12-07T20:53:21.4708224Z Get:14 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 session-migration amd64 0.3.9build1 [9034 B]
+2025-12-07T20:53:21.5035815Z Get:15 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 gsettings-desktop-schemas all 46.1-0ubuntu1 [35.6 kB]
+2025-12-07T20:53:21.5366916Z Get:16 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 glib-networking amd64 2.80.0-1build1 [64.1 kB]
+2025-12-07T20:53:21.5698598Z Get:17 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libva2 amd64 2.20.0-2build1 [66.2 kB]
+2025-12-07T20:53:21.6036810Z Get:18 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libva-drm2 amd64 2.20.0-2build1 [7124 B]
+2025-12-07T20:53:21.6362474Z Get:19 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libva-x11-2 amd64 2.20.0-2build1 [12.0 kB]
+2025-12-07T20:53:21.7084364Z Get:20 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libvdpau1 amd64 1.5-2build1 [27.8 kB]
+2025-12-07T20:53:21.7382223Z Get:21 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libvpl2 amd64 2023.3.0-1build1 [99.8 kB]
+2025-12-07T20:53:21.7691177Z Get:22 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 ocl-icd-libopencl1 amd64 2.3.2-1build1 [38.5 kB]
+2025-12-07T20:53:21.7992282Z Get:23 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libavutil58 amd64 7:6.1.1-3ubuntu5 [401 kB]
+2025-12-07T20:53:21.8326699Z Get:24 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libcodec2-1.2 amd64 1.2.0-2build1 [8998 kB]
+2025-12-07T20:53:21.9584742Z Get:25 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libdav1d7 amd64 1.4.1-1build1 [604 kB]
+2025-12-07T20:53:21.9982423Z Get:26 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libgsm1 amd64 1.0.22-1build1 [27.8 kB]
+2025-12-07T20:53:22.0286546Z Get:27 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libhwy1t64 amd64 1.0.7-8.1build1 [584 kB]
+2025-12-07T20:53:22.0660429Z Get:28 http://azure.archive.ubuntu.com/ubuntu noble-updates/universe amd64 libjxl0.7 amd64 0.7.0-10.2ubuntu6.1 [1001 kB]
+2025-12-07T20:53:22.1205164Z Get:29 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libmp3lame0 amd64 3.100-6build1 [142 kB]
+2025-12-07T20:53:22.1509175Z Get:30 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libopus0 amd64 1.4-1build1 [208 kB]
+2025-12-07T20:53:22.1827214Z Get:31 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 librav1e0 amd64 0.7.1-2 [1022 kB]
+2025-12-07T20:53:22.2239386Z Get:32 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 librsvg2-2 amd64 2.58.0+dfsg-1build1 [2135 kB]
+2025-12-07T20:53:22.2774978Z Get:33 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libshine3 amd64 3.1.1-2build1 [23.2 kB]
+2025-12-07T20:53:22.3071429Z Get:34 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libspeex1 amd64 1.2.1-2ubuntu2.24.04.1 [59.6 kB]
+2025-12-07T20:53:22.3370325Z Get:35 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libsvtav1enc1d1 amd64 1.7.0+dfsg-2build1 [2425 kB]
+2025-12-07T20:53:22.3932814Z Get:36 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libsoxr0 amd64 0.1.3-4build3 [80.0 kB]
+2025-12-07T20:53:22.4229504Z Get:37 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libswresample4 amd64 7:6.1.1-3ubuntu5 [63.8 kB]
+2025-12-07T20:53:22.4529183Z Get:38 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libtheora0 amd64 1.1.1+dfsg.1-16.1build3 [211 kB]
+2025-12-07T20:53:22.5281811Z Get:39 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libtwolame0 amd64 0.4.0-2build3 [52.3 kB]
+2025-12-07T20:53:22.5582527Z Get:40 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libvorbisenc2 amd64 1.3.7-1build3 [80.8 kB]
+2025-12-07T20:53:22.5886230Z Get:41 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libvpx9 amd64 1.14.0-1ubuntu2.2 [1143 kB]
+2025-12-07T20:53:22.6270577Z Get:42 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libx264-164 amd64 2:0.164.3108+git31e19f9-1 [604 kB]
+2025-12-07T20:53:22.6631713Z Get:43 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libx265-199 amd64 3.5-2build1 [1226 kB]
+2025-12-07T20:53:22.7022903Z Get:44 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libxvidcore4 amd64 2:1.3.7-1build1 [219 kB]
+2025-12-07T20:53:22.7339509Z Get:45 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libzvbi-common all 0.2.42-2 [42.4 kB]
+2025-12-07T20:53:22.7639776Z Get:46 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libzvbi0t64 amd64 0.2.42-2 [261 kB]
+2025-12-07T20:53:22.7956556Z Get:47 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libavcodec60 amd64 7:6.1.1-3ubuntu5 [5851 kB]
+2025-12-07T20:53:22.8853871Z Get:48 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libunibreak5 amd64 5.1-2build1 [25.0 kB]
+2025-12-07T20:53:22.9152218Z Get:49 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libass9 amd64 1:0.17.1-2build1 [104 kB]
+2025-12-07T20:53:22.9455286Z Get:50 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libudfread0 amd64 1.1.2-1build1 [19.0 kB]
+2025-12-07T20:53:22.9754631Z Get:51 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libbluray2 amd64 1:1.3.4-1build1 [159 kB]
+2025-12-07T20:53:23.0065174Z Get:52 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libchromaprint1 amd64 1.5.1-5 [30.5 kB]
+2025-12-07T20:53:23.0363499Z Get:53 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libgme0 amd64 0.6.3-7build1 [134 kB]
+2025-12-07T20:53:23.0675558Z Get:54 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libmpg123-0t64 amd64 1.32.5-1ubuntu1.1 [169 kB]
+2025-12-07T20:53:23.0980668Z Get:55 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libopenmpt0t64 amd64 0.7.3-1.1build3 [647 kB]
+2025-12-07T20:53:23.1350510Z Get:56 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libcjson1 amd64 1.7.17-1 [24.8 kB]
+2025-12-07T20:53:23.1652052Z Get:57 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libmbedcrypto7t64 amd64 2.28.8-1 [209 kB]
+2025-12-07T20:53:23.2406411Z Get:58 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 librist4 amd64 0.2.10+dfsg-2 [74.9 kB]
+2025-12-07T20:53:23.2706368Z Get:59 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libsrt1.5-gnutls amd64 1.5.3-1build2 [316 kB]
+2025-12-07T20:53:23.3042544Z Get:60 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libssh-gcrypt-4 amd64 0.10.6-2ubuntu0.2 [224 kB]
+2025-12-07T20:53:23.3352974Z Get:61 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libavformat60 amd64 7:6.1.1-3ubuntu5 [1153 kB]
+2025-12-07T20:53:23.3746028Z Get:62 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libbs2b0 amd64 3.1.0+dfsg-7build1 [10.6 kB]
+2025-12-07T20:53:23.4043579Z Get:63 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libflite1 amd64 2.2-6build3 [13.6 MB]
+2025-12-07T20:53:23.5699953Z Get:64 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libserd-0-0 amd64 0.32.2-1 [43.6 kB]
+2025-12-07T20:53:23.5994676Z Get:65 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libzix-0-0 amd64 0.4.2-2build1 [23.6 kB]
+2025-12-07T20:53:23.6292409Z Get:66 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libsord-0-0 amd64 0.16.16-2build1 [15.8 kB]
+2025-12-07T20:53:23.6596622Z Get:67 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libsratom-0-0 amd64 0.6.16-1build1 [17.3 kB]
+2025-12-07T20:53:23.6894206Z Get:68 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 liblilv-0-0 amd64 0.24.22-1build1 [41.0 kB]
+2025-12-07T20:53:23.7189319Z Get:69 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libmysofa1 amd64 1.3.2+dfsg-2ubuntu2 [1158 kB]
+2025-12-07T20:53:23.7606301Z Get:70 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libplacebo338 amd64 6.338.2-2build1 [2654 kB]
+2025-12-07T20:53:23.8188406Z Get:71 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libblas3 amd64 3.12.0-3build1.1 [238 kB]
+2025-12-07T20:53:23.8516276Z Get:72 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 liblapack3 amd64 3.12.0-3build1.1 [2646 kB]
+2025-12-07T20:53:23.9084485Z Get:73 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libasyncns0 amd64 0.8-6build4 [11.3 kB]
+2025-12-07T20:53:23.9380585Z Get:74 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libflac12t64 amd64 1.4.3+ds-2.1ubuntu2 [197 kB]
+2025-12-07T20:53:23.9696700Z Get:75 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libsndfile1 amd64 1.2.2-1ubuntu5.24.04.1 [209 kB]
+2025-12-07T20:53:24.0443076Z Get:76 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libpulse0 amd64 1:16.1+dfsg1-2ubuntu10.1 [292 kB]
+2025-12-07T20:53:24.0765289Z Get:77 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libsphinxbase3t64 amd64 0.8+5prealpha+1-17build2 [126 kB]
+2025-12-07T20:53:24.1071707Z Get:78 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libpocketsphinx3 amd64 0.8.0+real5prealpha+1-15ubuntu5 [133 kB]
+2025-12-07T20:53:24.1383714Z Get:79 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libpostproc57 amd64 7:6.1.1-3ubuntu5 [49.9 kB]
+2025-12-07T20:53:24.1682957Z Get:80 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libsamplerate0 amd64 0.2.2-4build1 [1344 kB]
+2025-12-07T20:53:24.2119184Z Get:81 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 librubberband2 amd64 3.3.0+dfsg-2build1 [130 kB]
+2025-12-07T20:53:24.2444676Z Get:82 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libswscale7 amd64 7:6.1.1-3ubuntu5 [193 kB]
+2025-12-07T20:53:24.2786322Z Get:83 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libvidstab1.1 amd64 1.1.0-2build1 [38.5 kB]
+2025-12-07T20:53:24.3095883Z Get:84 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libzimg2 amd64 3.0.5+ds1-1build1 [254 kB]
+2025-12-07T20:53:24.3449197Z Get:85 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libavfilter9 amd64 7:6.1.1-3ubuntu5 [4235 kB]
+2025-12-07T20:53:24.4505826Z Get:86 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 liborc-0.4-0t64 amd64 1:0.4.38-1ubuntu0.1 [207 kB]
+2025-12-07T20:53:24.4906662Z Get:87 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libgstreamer-plugins-base1.0-0 amd64 1.24.2-1ubuntu0.3 [862 kB]
+2025-12-07T20:53:24.5334418Z Get:88 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 gstreamer1.0-libav amd64 1.24.1-1build1 [103 kB]
+2025-12-07T20:53:24.5645548Z Get:89 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libcdparanoia0 amd64 3.10.2+debian-14build3 [48.5 kB]
+2025-12-07T20:53:24.5952224Z Get:90 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libvisual-0.4-0 amd64 0.4.2-2build1 [115 kB]
+2025-12-07T20:53:24.6281035Z Get:91 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 gstreamer1.0-plugins-base amd64 1.24.2-1ubuntu0.3 [721 kB]
+2025-12-07T20:53:24.6734990Z Get:92 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libaa1 amd64 1.4p5-51.1 [49.9 kB]
+2025-12-07T20:53:24.7048121Z Get:93 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libraw1394-11 amd64 2.1.2-2build3 [26.2 kB]
+2025-12-07T20:53:24.7368921Z Get:94 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libavc1394-0 amd64 0.5.4-5build3 [15.4 kB]
+2025-12-07T20:53:24.8125817Z Get:95 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libcaca0 amd64 0.99.beta20-4build2 [208 kB]
+2025-12-07T20:53:24.8470436Z Get:96 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libdv4t64 amd64 1.0.0-17.1build1 [63.2 kB]
+2025-12-07T20:53:24.8772926Z Get:97 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libgstreamer-plugins-good1.0-0 amd64 1.24.2-1ubuntu1.2 [33.0 kB]
+2025-12-07T20:53:24.9088675Z Get:98 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libiec61883-0 amd64 1.2.0-6build1 [24.5 kB]
+2025-12-07T20:53:24.9398189Z Get:99 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libshout3 amd64 2.4.6-1build2 [50.3 kB]
+2025-12-07T20:53:24.9700238Z Get:100 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libtag1v5-vanilla amd64 1.13.1-1build1 [326 kB]
+2025-12-07T20:53:25.0104415Z Get:101 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libtag1v5 amd64 1.13.1-1build1 [11.7 kB]
+2025-12-07T20:53:25.0401846Z Get:102 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libv4lconvert0t64 amd64 1.26.1-4build3 [87.6 kB]
+2025-12-07T20:53:25.0723568Z Get:103 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libv4l-0t64 amd64 1.26.1-4build3 [46.9 kB]
+2025-12-07T20:53:25.1026905Z Get:104 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libwavpack1 amd64 5.6.0-1build1 [84.6 kB]
+2025-12-07T20:53:25.1324357Z Get:105 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libsoup-3.0-common all 3.4.4-5ubuntu0.5 [11.3 kB]
+2025-12-07T20:53:25.1626691Z Get:106 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libsoup-3.0-0 amd64 3.4.4-5ubuntu0.5 [291 kB]
+2025-12-07T20:53:25.1940228Z Get:107 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 gstreamer1.0-plugins-good amd64 1.24.2-1ubuntu1.2 [2238 kB]
+2025-12-07T20:53:25.2426253Z Get:108 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libabsl20220623t64 amd64 20220623.1-3.1ubuntu3.2 [423 kB]
+2025-12-07T20:53:25.2752605Z Get:109 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libgav1-1 amd64 0.18.0-1build3 [357 kB]
+2025-12-07T20:53:25.3078517Z Get:110 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libyuv0 amd64 0.0~git202401110.af6ac82-1 [178 kB]
+2025-12-07T20:53:25.3383585Z Get:111 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libavif16 amd64 1.0.4-1ubuntu3 [91.2 kB]
+2025-12-07T20:53:25.3678154Z Get:112 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libavtp0 amd64 0.2.0-1build1 [6414 B]
+2025-12-07T20:53:25.3965723Z Get:113 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libcairo-script-interpreter2 amd64 1.18.0-3build1 [60.3 kB]
+2025-12-07T20:53:25.4268023Z Get:114 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libcups2t64 amd64 2.4.7-1.2ubuntu7.9 [273 kB]
+2025-12-07T20:53:25.4586855Z Get:115 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libdc1394-25 amd64 2.2.6-4build1 [90.1 kB]
+2025-12-07T20:53:25.4882222Z Get:116 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libdecor-0-0 amd64 0.2.2-1build2 [16.5 kB]
+2025-12-07T20:53:25.5177820Z Get:117 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libgles2 amd64 1.7.0-1build1 [17.1 kB]
+2025-12-07T20:53:25.5483127Z Get:118 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libdirectfb-1.7-7t64 amd64 1.7.7-11.1ubuntu2 [1035 kB]
+2025-12-07T20:53:25.5872090Z Get:119 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libdvdread8t64 amd64 6.1.3-1.1build1 [54.7 kB]
+2025-12-07T20:53:25.6166500Z Get:120 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libdvdnav4 amd64 6.1.1-3build1 [39.5 kB]
+2025-12-07T20:53:25.6900415Z Get:121 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libegl-mesa0 amd64 25.0.7-0ubuntu0.24.04.2 [124 kB]
+2025-12-07T20:53:25.7204199Z Get:122 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libevent-2.1-7t64 amd64 2.1.12-stable-9ubuntu2 [145 kB]
+2025-12-07T20:53:25.7506267Z Get:123 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libfaad2 amd64 2.11.1-1build1 [207 kB]
+2025-12-07T20:53:25.7821240Z Get:124 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libinstpatch-1.0-2 amd64 1.1.6-1build2 [251 kB]
+2025-12-07T20:53:25.8139945Z Get:125 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libjack-jackd2-0 amd64 1.9.21~dfsg-3ubuntu3 [289 kB]
+2025-12-07T20:53:25.8463167Z Get:126 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libwebrtc-audio-processing1 amd64 0.3.1-0ubuntu6 [290 kB]
+2025-12-07T20:53:25.8789219Z Get:127 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libspa-0.2-modules amd64 1.0.5-1ubuntu3.1 [626 kB]
+2025-12-07T20:53:25.9128680Z Get:128 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libpipewire-0.3-0t64 amd64 1.0.5-1ubuntu3.1 [252 kB]
+2025-12-07T20:53:25.9440137Z Get:129 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libsdl2-2.0-0 amd64 2.30.0+dfsg-1ubuntu3.1 [686 kB]
+2025-12-07T20:53:25.9799472Z Get:130 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 timgm6mb-soundfont all 1.3-5 [5427 kB]
+2025-12-07T20:53:26.0648439Z Get:131 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libfluidsynth3 amd64 2.3.4-1build3 [249 kB]
+2025-12-07T20:53:26.0962574Z Get:132 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libfreeaptx0 amd64 0.1.1-2build1 [13.5 kB]
+2025-12-07T20:53:26.1259336Z Get:133 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libgraphene-1.0-0 amd64 1.10.8-3build2 [46.2 kB]
+2025-12-07T20:53:26.1558711Z Get:134 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libgssdp-1.6-0 amd64 1.6.3-1build3 [40.4 kB]
+2025-12-07T20:53:26.1852568Z Get:135 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libegl1 amd64 1.7.0-1build1 [28.7 kB]
+2025-12-07T20:53:26.2151203Z Get:136 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libgstreamer-gl1.0-0 amd64 1.24.2-1ubuntu0.3 [214 kB]
+2025-12-07T20:53:26.2467086Z Get:137 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libgtk-4-common all 4.14.5+ds-0ubuntu0.7 [1496 kB]
+2025-12-07T20:53:26.2881629Z Get:138 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libgtk-4-1 amd64 4.14.5+ds-0ubuntu0.7 [3294 kB]
+2025-12-07T20:53:26.3944609Z Get:139 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libgupnp-1.6-0 amd64 1.6.6-1build3 [92.7 kB]
+2025-12-07T20:53:26.4253371Z Get:140 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libgupnp-igd-1.6-0 amd64 1.6.0-3build3 [16.5 kB]
+2025-12-07T20:53:26.4548432Z Get:141 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libharfbuzz-icu0 amd64 8.3.0-2build2 [13.3 kB]
+2025-12-07T20:53:26.4845885Z Get:142 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libhyphen0 amd64 2.8.8-7build3 [26.5 kB]
+2025-12-07T20:53:26.5143586Z Get:143 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libimath-3-1-29t64 amd64 3.1.9-3.1ubuntu2 [72.2 kB]
+2025-12-07T20:53:26.5441378Z Get:144 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 liblc3-1 amd64 1.0.4-3build1 [69.7 kB]
+2025-12-07T20:53:26.5749351Z Get:145 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libldacbt-enc2 amd64 2.0.2.3+git20200429+ed310a0-4ubuntu2 [27.1 kB]
+2025-12-07T20:53:26.6049375Z Get:146 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libraptor2-0 amd64 2.0.16-3ubuntu0.1 [165 kB]
+2025-12-07T20:53:26.6355813Z Get:147 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 liblrdf0 amd64 0.6.1-4build1 [18.5 kB]
+2025-12-07T20:53:26.6651263Z Get:148 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libltc11 amd64 1.3.2-1build1 [13.0 kB]
+2025-12-07T20:53:26.6943805Z Get:149 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libmanette-0.2-0 amd64 0.2.7-1build2 [30.6 kB]
+2025-12-07T20:53:26.7243087Z Get:150 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libmfx1 amd64 22.5.4-1 [3124 kB]
+2025-12-07T20:53:26.7789101Z Get:151 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libmjpegutils-2.1-0t64 amd64 1:2.1.0+debian-8.1build1 [25.5 kB]
+2025-12-07T20:53:26.8085570Z Get:152 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libmodplug1 amd64 1:0.8.9.0-3build1 [166 kB]
+2025-12-07T20:53:26.8393384Z Get:153 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libmpcdec6 amd64 2:0.1~r495-2build1 [32.7 kB]
+2025-12-07T20:53:26.8691364Z Get:154 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libmpeg2encpp-2.1-0t64 amd64 1:2.1.0+debian-8.1build1 [75.6 kB]
+2025-12-07T20:53:26.9014553Z Get:155 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libmplex2-2.1-0t64 amd64 1:2.1.0+debian-8.1build1 [46.1 kB]
+2025-12-07T20:53:26.9314461Z Get:156 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libneon27t64 amd64 0.33.0-1.1build3 [102 kB]
+2025-12-07T20:53:26.9621278Z Get:157 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libnice10 amd64 0.1.21-2build3 [157 kB]
+2025-12-07T20:53:27.0359283Z Get:158 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libopenal-data all 1:1.23.1-4build1 [161 kB]
+2025-12-07T20:53:27.0664975Z Get:159 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libopenexr-3-1-30 amd64 3.1.5-5.1build3 [1004 kB]
+2025-12-07T20:53:27.1052865Z Get:160 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libopenh264-7 amd64 2.4.1+dfsg-1 [409 kB]
+2025-12-07T20:53:27.1385913Z Get:161 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libopenni2-0 amd64 2.2.0.33+dfsg-18 [370 kB]
+2025-12-07T20:53:27.1715246Z Get:162 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libqrencode4 amd64 4.1.1-1build2 [25.0 kB]
+2025-12-07T20:53:27.2015734Z Get:163 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libsecret-common all 0.21.4-1build3 [4962 B]
+2025-12-07T20:53:27.2309338Z Get:164 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libsecret-1-0 amd64 0.21.4-1build3 [116 kB]
+2025-12-07T20:53:27.2615536Z Get:165 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libsndio7.0 amd64 1.9.0-0.3build3 [29.6 kB]
+2025-12-07T20:53:27.2917921Z Get:166 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libsoundtouch1 amd64 2.3.2+ds1-1build1 [60.5 kB]
+2025-12-07T20:53:27.3491117Z Get:167 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libspandsp2t64 amd64 0.0.6+dfsg-2.1build1 [311 kB]
+2025-12-07T20:53:27.5052942Z Get:168 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libsrtp2-1 amd64 2.5.0-3build1 [41.9 kB]
+2025-12-07T20:53:27.5350991Z Get:169 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libssh-4 amd64 0.10.6-2ubuntu0.2 [188 kB]
+2025-12-07T20:53:27.5744840Z Get:170 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libwildmidi2 amd64 0.4.3-1build3 [68.5 kB]
+2025-12-07T20:53:27.6061833Z Get:171 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libwoff1 amd64 1.0.2-2build1 [45.3 kB]
+2025-12-07T20:53:27.6362036Z Get:172 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libxcb-xkb1 amd64 1.15-1ubuntu2 [32.3 kB]
+2025-12-07T20:53:27.6660136Z Get:173 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libxkbcommon-x11-0 amd64 1.6.0-1build1 [14.5 kB]
+2025-12-07T20:53:27.6958047Z Get:174 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libzbar0t64 amd64 0.23.93-4build3 [123 kB]
+2025-12-07T20:53:27.7306146Z Get:175 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libzxing3 amd64 2.2.1-3 [583 kB]
+2025-12-07T20:53:27.8388724Z Get:176 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 xfonts-encodings all 1:1.0.5-0ubuntu2 [578 kB]
+2025-12-07T20:53:27.8811330Z Get:177 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 xfonts-utils amd64 1:7.7+6build3 [94.4 kB]
+2025-12-07T20:53:27.9109316Z Get:178 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 xfonts-cyrillic all 1:1.0.5+nmu1 [384 kB]
+2025-12-07T20:53:27.9469047Z Get:179 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 xfonts-scalable all 1:1.0.3-1.3 [304 kB]
+2025-12-07T20:53:27.9814304Z Get:180 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libgstreamer-plugins-bad1.0-0 amd64 1.24.2-1ubuntu4 [797 kB]
+2025-12-07T20:53:28.0263339Z Get:181 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libdca0 amd64 0.0.7-2build1 [93.8 kB]
+2025-12-07T20:53:28.0562469Z Get:182 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libopenal1 amd64 1:1.23.1-4build1 [540 kB]
+2025-12-07T20:53:28.0938313Z Get:183 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libsbc1 amd64 2.0-1build1 [33.9 kB]
+2025-12-07T20:53:28.1231174Z Get:184 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libvo-aacenc0 amd64 0.1.3-2build1 [67.8 kB]
+2025-12-07T20:53:28.1525171Z Get:185 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libvo-amrwbenc0 amd64 0.1.3-2build1 [76.7 kB]
+2025-12-07T20:53:28.1816094Z Get:186 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 gstreamer1.0-plugins-bad amd64 1.24.2-1ubuntu4 [3081 kB]
+2025-12-07T20:53:28.6946866Z Fetched 116 MB in 8s (15.4 MB/s)
+2025-12-07T20:53:28.7233564Z Selecting previously unselected package fonts-ipafont-gothic.
+2025-12-07T20:53:28.7509977Z (Reading database ... 
+2025-12-07T20:53:28.7510539Z (Reading database ... 5%
+2025-12-07T20:53:28.7511051Z (Reading database ... 10%
+2025-12-07T20:53:28.7511379Z (Reading database ... 15%
+2025-12-07T20:53:28.7511664Z (Reading database ... 20%
+2025-12-07T20:53:28.7511953Z (Reading database ... 25%
+2025-12-07T20:53:28.7512230Z (Reading database ... 30%
+2025-12-07T20:53:28.7512531Z (Reading database ... 35%
+2025-12-07T20:53:28.7512822Z (Reading database ... 40%
+2025-12-07T20:53:28.7513115Z (Reading database ... 45%
+2025-12-07T20:53:28.7513400Z (Reading database ... 50%
+2025-12-07T20:53:28.7602549Z (Reading database ... 55%
+2025-12-07T20:53:28.9364562Z (Reading database ... 60%
+2025-12-07T20:53:29.0158473Z (Reading database ... 65%
+2025-12-07T20:53:29.0868991Z (Reading database ... 70%
+2025-12-07T20:53:29.1489190Z (Reading database ... 75%
+2025-12-07T20:53:29.3821764Z (Reading database ... 80%
+2025-12-07T20:53:29.5352144Z (Reading database ... 85%
+2025-12-07T20:53:29.7676916Z (Reading database ... 90%
+2025-12-07T20:53:29.9423408Z (Reading database ... 95%
+2025-12-07T20:53:29.9423991Z (Reading database ... 100%
+2025-12-07T20:53:29.9424848Z (Reading database ... 217049 files and directories currently installed.)
+2025-12-07T20:53:29.9468016Z Preparing to unpack .../000-fonts-ipafont-gothic_00303-21ubuntu1_all.deb ...
+2025-12-07T20:53:29.9563583Z Unpacking fonts-ipafont-gothic (00303-21ubuntu1) ...
+2025-12-07T20:53:30.2055878Z Preparing to unpack .../001-libglib2.0-data_2.80.0-6ubuntu3.5_all.deb ...
+2025-12-07T20:53:30.2089474Z Unpacking libglib2.0-data (2.80.0-6ubuntu3.5) over (2.80.0-6ubuntu3.4) ...
+2025-12-07T20:53:30.2481749Z Preparing to unpack .../002-libglib2.0-bin_2.80.0-6ubuntu3.5_amd64.deb ...
+2025-12-07T20:53:30.2520710Z Unpacking libglib2.0-bin (2.80.0-6ubuntu3.5) over (2.80.0-6ubuntu3.4) ...
+2025-12-07T20:53:30.3429316Z Preparing to unpack .../003-gir1.2-glib-2.0_2.80.0-6ubuntu3.5_amd64.deb ...
+2025-12-07T20:53:30.3456992Z Unpacking gir1.2-glib-2.0:amd64 (2.80.0-6ubuntu3.5) over (2.80.0-6ubuntu3.4) ...
+2025-12-07T20:53:30.3896807Z Preparing to unpack .../004-libglib2.0-0t64_2.80.0-6ubuntu3.5_amd64.deb ...
+2025-12-07T20:53:30.3980279Z Unpacking libglib2.0-0t64:amd64 (2.80.0-6ubuntu3.5) over (2.80.0-6ubuntu3.4) ...
+2025-12-07T20:53:30.4454749Z Selecting previously unselected package fonts-freefont-ttf.
+2025-12-07T20:53:30.4591670Z Preparing to unpack .../005-fonts-freefont-ttf_20211204+svn4273-2_all.deb ...
+2025-12-07T20:53:30.4602799Z Unpacking fonts-freefont-ttf (20211204+svn4273-2) ...
+2025-12-07T20:53:30.5468582Z Selecting previously unselected package fonts-tlwg-loma-otf.
+2025-12-07T20:53:30.5603614Z Preparing to unpack .../006-fonts-tlwg-loma-otf_1%3a0.7.3-1_all.deb ...
+2025-12-07T20:53:30.5612724Z Unpacking fonts-tlwg-loma-otf (1:0.7.3-1) ...
+2025-12-07T20:53:30.5843842Z Selecting previously unselected package fonts-unifont.
+2025-12-07T20:53:30.5978805Z Preparing to unpack .../007-fonts-unifont_1%3a15.1.01-1build1_all.deb ...
+2025-12-07T20:53:30.5988195Z Unpacking fonts-unifont (1:15.1.01-1build1) ...
+2025-12-07T20:53:30.7164431Z Selecting previously unselected package fonts-wqy-zenhei.
+2025-12-07T20:53:30.7298057Z Preparing to unpack .../008-fonts-wqy-zenhei_0.9.45-8_all.deb ...
+2025-12-07T20:53:30.7439379Z Unpacking fonts-wqy-zenhei (0.9.45-8) ...
+2025-12-07T20:53:31.2093305Z Selecting previously unselected package libproxy1v5:amd64.
+2025-12-07T20:53:31.2225994Z Preparing to unpack .../009-libproxy1v5_0.5.4-4build1_amd64.deb ...
+2025-12-07T20:53:31.2239083Z Unpacking libproxy1v5:amd64 (0.5.4-4build1) ...
+2025-12-07T20:53:31.2468833Z Selecting previously unselected package glib-networking-common.
+2025-12-07T20:53:31.2603618Z Preparing to unpack .../010-glib-networking-common_2.80.0-1build1_all.deb ...
+2025-12-07T20:53:31.2620354Z Unpacking glib-networking-common (2.80.0-1build1) ...
+2025-12-07T20:53:31.2836587Z Selecting previously unselected package glib-networking-services.
+2025-12-07T20:53:31.2971207Z Preparing to unpack .../011-glib-networking-services_2.80.0-1build1_amd64.deb ...
+2025-12-07T20:53:31.2987350Z Unpacking glib-networking-services (2.80.0-1build1) ...
+2025-12-07T20:53:31.3231845Z Selecting previously unselected package session-migration.
+2025-12-07T20:53:31.3365882Z Preparing to unpack .../012-session-migration_0.3.9build1_amd64.deb ...
+2025-12-07T20:53:31.3377090Z Unpacking session-migration (0.3.9build1) ...
+2025-12-07T20:53:31.3626346Z Selecting previously unselected package gsettings-desktop-schemas.
+2025-12-07T20:53:31.3760447Z Preparing to unpack .../013-gsettings-desktop-schemas_46.1-0ubuntu1_all.deb ...
+2025-12-07T20:53:31.3771003Z Unpacking gsettings-desktop-schemas (46.1-0ubuntu1) ...
+2025-12-07T20:53:31.4063025Z Selecting previously unselected package glib-networking:amd64.
+2025-12-07T20:53:31.4196740Z Preparing to unpack .../014-glib-networking_2.80.0-1build1_amd64.deb ...
+2025-12-07T20:53:31.4206587Z Unpacking glib-networking:amd64 (2.80.0-1build1) ...
+2025-12-07T20:53:31.4442302Z Selecting previously unselected package libva2:amd64.
+2025-12-07T20:53:31.4577195Z Preparing to unpack .../015-libva2_2.20.0-2build1_amd64.deb ...
+2025-12-07T20:53:31.4587870Z Unpacking libva2:amd64 (2.20.0-2build1) ...
+2025-12-07T20:53:31.4826058Z Selecting previously unselected package libva-drm2:amd64.
+2025-12-07T20:53:31.4961625Z Preparing to unpack .../016-libva-drm2_2.20.0-2build1_amd64.deb ...
+2025-12-07T20:53:31.4976007Z Unpacking libva-drm2:amd64 (2.20.0-2build1) ...
+2025-12-07T20:53:31.5224619Z Selecting previously unselected package libva-x11-2:amd64.
+2025-12-07T20:53:31.5358837Z Preparing to unpack .../017-libva-x11-2_2.20.0-2build1_amd64.deb ...
+2025-12-07T20:53:31.5370897Z Unpacking libva-x11-2:amd64 (2.20.0-2build1) ...
+2025-12-07T20:53:31.5616696Z Selecting previously unselected package libvdpau1:amd64.
+2025-12-07T20:53:31.5750146Z Preparing to unpack .../018-libvdpau1_1.5-2build1_amd64.deb ...
+2025-12-07T20:53:31.5761537Z Unpacking libvdpau1:amd64 (1.5-2build1) ...
+2025-12-07T20:53:31.5998235Z Selecting previously unselected package libvpl2.
+2025-12-07T20:53:31.6131944Z Preparing to unpack .../019-libvpl2_2023.3.0-1build1_amd64.deb ...
+2025-12-07T20:53:31.6146752Z Unpacking libvpl2 (2023.3.0-1build1) ...
+2025-12-07T20:53:31.6408216Z Selecting previously unselected package ocl-icd-libopencl1:amd64.
+2025-12-07T20:53:31.6541859Z Preparing to unpack .../020-ocl-icd-libopencl1_2.3.2-1build1_amd64.deb ...
+2025-12-07T20:53:31.6556445Z Unpacking ocl-icd-libopencl1:amd64 (2.3.2-1build1) ...
+2025-12-07T20:53:31.6810419Z Selecting previously unselected package libavutil58:amd64.
+2025-12-07T20:53:31.6943420Z Preparing to unpack .../021-libavutil58_7%3a6.1.1-3ubuntu5_amd64.deb ...
+2025-12-07T20:53:31.6956233Z Unpacking libavutil58:amd64 (7:6.1.1-3ubuntu5) ...
+2025-12-07T20:53:31.7259120Z Selecting previously unselected package libcodec2-1.2:amd64.
+2025-12-07T20:53:31.7392031Z Preparing to unpack .../022-libcodec2-1.2_1.2.0-2build1_amd64.deb ...
+2025-12-07T20:53:31.7405449Z Unpacking libcodec2-1.2:amd64 (1.2.0-2build1) ...
+2025-12-07T20:53:31.8199152Z Selecting previously unselected package libdav1d7:amd64.
+2025-12-07T20:53:31.8335645Z Preparing to unpack .../023-libdav1d7_1.4.1-1build1_amd64.deb ...
+2025-12-07T20:53:31.8344548Z Unpacking libdav1d7:amd64 (1.4.1-1build1) ...
+2025-12-07T20:53:31.8648404Z Selecting previously unselected package libgsm1:amd64.
+2025-12-07T20:53:31.8783832Z Preparing to unpack .../024-libgsm1_1.0.22-1build1_amd64.deb ...
+2025-12-07T20:53:31.8799358Z Unpacking libgsm1:amd64 (1.0.22-1build1) ...
+2025-12-07T20:53:31.9038439Z Selecting previously unselected package libhwy1t64:amd64.
+2025-12-07T20:53:31.9172481Z Preparing to unpack .../025-libhwy1t64_1.0.7-8.1build1_amd64.deb ...
+2025-12-07T20:53:31.9183261Z Unpacking libhwy1t64:amd64 (1.0.7-8.1build1) ...
+2025-12-07T20:53:31.9542533Z Selecting previously unselected package libjxl0.7:amd64.
+2025-12-07T20:53:31.9676913Z Preparing to unpack .../026-libjxl0.7_0.7.0-10.2ubuntu6.1_amd64.deb ...
+2025-12-07T20:53:31.9688262Z Unpacking libjxl0.7:amd64 (0.7.0-10.2ubuntu6.1) ...
+2025-12-07T20:53:32.0073768Z Selecting previously unselected package libmp3lame0:amd64.
+2025-12-07T20:53:32.0211221Z Preparing to unpack .../027-libmp3lame0_3.100-6build1_amd64.deb ...
+2025-12-07T20:53:32.0225913Z Unpacking libmp3lame0:amd64 (3.100-6build1) ...
+2025-12-07T20:53:32.0495304Z Selecting previously unselected package libopus0:amd64.
+2025-12-07T20:53:32.0631659Z Preparing to unpack .../028-libopus0_1.4-1build1_amd64.deb ...
+2025-12-07T20:53:32.0644011Z Unpacking libopus0:amd64 (1.4-1build1) ...
+2025-12-07T20:53:32.0906814Z Selecting previously unselected package librav1e0:amd64.
+2025-12-07T20:53:32.1041074Z Preparing to unpack .../029-librav1e0_0.7.1-2_amd64.deb ...
+2025-12-07T20:53:32.1055742Z Unpacking librav1e0:amd64 (0.7.1-2) ...
+2025-12-07T20:53:32.1426992Z Selecting previously unselected package librsvg2-2:amd64.
+2025-12-07T20:53:32.1562871Z Preparing to unpack .../030-librsvg2-2_2.58.0+dfsg-1build1_amd64.deb ...
+2025-12-07T20:53:32.1574511Z Unpacking librsvg2-2:amd64 (2.58.0+dfsg-1build1) ...
+2025-12-07T20:53:32.2090912Z Selecting previously unselected package libshine3:amd64.
+2025-12-07T20:53:32.2223351Z Preparing to unpack .../031-libshine3_3.1.1-2build1_amd64.deb ...
+2025-12-07T20:53:32.2237457Z Unpacking libshine3:amd64 (3.1.1-2build1) ...
+2025-12-07T20:53:32.2470820Z Selecting previously unselected package libspeex1:amd64.
+2025-12-07T20:53:32.2605034Z Preparing to unpack .../032-libspeex1_1.2.1-2ubuntu2.24.04.1_amd64.deb ...
+2025-12-07T20:53:32.2616087Z Unpacking libspeex1:amd64 (1.2.1-2ubuntu2.24.04.1) ...
+2025-12-07T20:53:32.2847260Z Selecting previously unselected package libsvtav1enc1d1:amd64.
+2025-12-07T20:53:32.2981394Z Preparing to unpack .../033-libsvtav1enc1d1_1.7.0+dfsg-2build1_amd64.deb ...
+2025-12-07T20:53:32.2991711Z Unpacking libsvtav1enc1d1:amd64 (1.7.0+dfsg-2build1) ...
+2025-12-07T20:53:32.3542193Z Selecting previously unselected package libsoxr0:amd64.
+2025-12-07T20:53:32.3677016Z Preparing to unpack .../034-libsoxr0_0.1.3-4build3_amd64.deb ...
+2025-12-07T20:53:32.3690302Z Unpacking libsoxr0:amd64 (0.1.3-4build3) ...
+2025-12-07T20:53:32.3942104Z Selecting previously unselected package libswresample4:amd64.
+2025-12-07T20:53:32.4075571Z Preparing to unpack .../035-libswresample4_7%3a6.1.1-3ubuntu5_amd64.deb ...
+2025-12-07T20:53:32.4088082Z Unpacking libswresample4:amd64 (7:6.1.1-3ubuntu5) ...
+2025-12-07T20:53:32.4331105Z Selecting previously unselected package libtheora0:amd64.
+2025-12-07T20:53:32.4465510Z Preparing to unpack .../036-libtheora0_1.1.1+dfsg.1-16.1build3_amd64.deb ...
+2025-12-07T20:53:32.4478705Z Unpacking libtheora0:amd64 (1.1.1+dfsg.1-16.1build3) ...
+2025-12-07T20:53:32.4746585Z Selecting previously unselected package libtwolame0:amd64.
+2025-12-07T20:53:32.4879583Z Preparing to unpack .../037-libtwolame0_0.4.0-2build3_amd64.deb ...
+2025-12-07T20:53:32.4946197Z Unpacking libtwolame0:amd64 (0.4.0-2build3) ...
+2025-12-07T20:53:32.5198944Z Selecting previously unselected package libvorbisenc2:amd64.
+2025-12-07T20:53:32.5333918Z Preparing to unpack .../038-libvorbisenc2_1.3.7-1build3_amd64.deb ...
+2025-12-07T20:53:32.5345771Z Unpacking libvorbisenc2:amd64 (1.3.7-1build3) ...
+2025-12-07T20:53:32.5603598Z Selecting previously unselected package libvpx9:amd64.
+2025-12-07T20:53:32.5740555Z Preparing to unpack .../039-libvpx9_1.14.0-1ubuntu2.2_amd64.deb ...
+2025-12-07T20:53:32.5751397Z Unpacking libvpx9:amd64 (1.14.0-1ubuntu2.2) ...
+2025-12-07T20:53:32.6132389Z Selecting previously unselected package libx264-164:amd64.
+2025-12-07T20:53:32.6265356Z Preparing to unpack .../040-libx264-164_2%3a0.164.3108+git31e19f9-1_amd64.deb ...
+2025-12-07T20:53:32.6274591Z Unpacking libx264-164:amd64 (2:0.164.3108+git31e19f9-1) ...
+2025-12-07T20:53:32.6595411Z Selecting previously unselected package libx265-199:amd64.
+2025-12-07T20:53:32.6729835Z Preparing to unpack .../041-libx265-199_3.5-2build1_amd64.deb ...
+2025-12-07T20:53:32.6738370Z Unpacking libx265-199:amd64 (3.5-2build1) ...
+2025-12-07T20:53:32.7477513Z Selecting previously unselected package libxvidcore4:amd64.
+2025-12-07T20:53:32.7611621Z Preparing to unpack .../042-libxvidcore4_2%3a1.3.7-1build1_amd64.deb ...
+2025-12-07T20:53:32.7621714Z Unpacking libxvidcore4:amd64 (2:1.3.7-1build1) ...
+2025-12-07T20:53:32.7861681Z Selecting previously unselected package libzvbi-common.
+2025-12-07T20:53:32.7994731Z Preparing to unpack .../043-libzvbi-common_0.2.42-2_all.deb ...
+2025-12-07T20:53:32.8008931Z Unpacking libzvbi-common (0.2.42-2) ...
+2025-12-07T20:53:32.8462828Z Selecting previously unselected package libzvbi0t64:amd64.
+2025-12-07T20:53:32.8596082Z Preparing to unpack .../044-libzvbi0t64_0.2.42-2_amd64.deb ...
+2025-12-07T20:53:32.8608269Z Unpacking libzvbi0t64:amd64 (0.2.42-2) ...
+2025-12-07T20:53:32.8870252Z Selecting previously unselected package libavcodec60:amd64.
+2025-12-07T20:53:32.9003630Z Preparing to unpack .../045-libavcodec60_7%3a6.1.1-3ubuntu5_amd64.deb ...
+2025-12-07T20:53:32.9016531Z Unpacking libavcodec60:amd64 (7:6.1.1-3ubuntu5) ...
+2025-12-07T20:53:32.9926698Z Selecting previously unselected package libunibreak5:amd64.
+2025-12-07T20:53:33.0059907Z Preparing to unpack .../046-libunibreak5_5.1-2build1_amd64.deb ...
+2025-12-07T20:53:33.0072292Z Unpacking libunibreak5:amd64 (5.1-2build1) ...
+2025-12-07T20:53:33.0363825Z Selecting previously unselected package libass9:amd64.
+2025-12-07T20:53:33.0498540Z Preparing to unpack .../047-libass9_1%3a0.17.1-2build1_amd64.deb ...
+2025-12-07T20:53:33.0511537Z Unpacking libass9:amd64 (1:0.17.1-2build1) ...
+2025-12-07T20:53:33.0752157Z Selecting previously unselected package libudfread0:amd64.
+2025-12-07T20:53:33.0885796Z Preparing to unpack .../048-libudfread0_1.1.2-1build1_amd64.deb ...
+2025-12-07T20:53:33.0896178Z Unpacking libudfread0:amd64 (1.1.2-1build1) ...
+2025-12-07T20:53:33.1123143Z Selecting previously unselected package libbluray2:amd64.
+2025-12-07T20:53:33.1256906Z Preparing to unpack .../049-libbluray2_1%3a1.3.4-1build1_amd64.deb ...
+2025-12-07T20:53:33.1270113Z Unpacking libbluray2:amd64 (1:1.3.4-1build1) ...
+2025-12-07T20:53:33.1535287Z Selecting previously unselected package libchromaprint1:amd64.
+2025-12-07T20:53:33.1673569Z Preparing to unpack .../050-libchromaprint1_1.5.1-5_amd64.deb ...
+2025-12-07T20:53:33.1685310Z Unpacking libchromaprint1:amd64 (1.5.1-5) ...
+2025-12-07T20:53:33.1929394Z Selecting previously unselected package libgme0:amd64.
+2025-12-07T20:53:33.2062580Z Preparing to unpack .../051-libgme0_0.6.3-7build1_amd64.deb ...
+2025-12-07T20:53:33.2073666Z Unpacking libgme0:amd64 (0.6.3-7build1) ...
+2025-12-07T20:53:33.2335031Z Selecting previously unselected package libmpg123-0t64:amd64.
+2025-12-07T20:53:33.2468452Z Preparing to unpack .../052-libmpg123-0t64_1.32.5-1ubuntu1.1_amd64.deb ...
+2025-12-07T20:53:33.2488833Z Unpacking libmpg123-0t64:amd64 (1.32.5-1ubuntu1.1) ...
+2025-12-07T20:53:33.2767019Z Selecting previously unselected package libopenmpt0t64:amd64.
+2025-12-07T20:53:33.2898827Z Preparing to unpack .../053-libopenmpt0t64_0.7.3-1.1build3_amd64.deb ...
+2025-12-07T20:53:33.2910910Z Unpacking libopenmpt0t64:amd64 (0.7.3-1.1build3) ...
+2025-12-07T20:53:33.3226070Z Selecting previously unselected package libcjson1:amd64.
+2025-12-07T20:53:33.3361210Z Preparing to unpack .../054-libcjson1_1.7.17-1_amd64.deb ...
+2025-12-07T20:53:33.3374473Z Unpacking libcjson1:amd64 (1.7.17-1) ...
+2025-12-07T20:53:33.3605247Z Selecting previously unselected package libmbedcrypto7t64:amd64.
+2025-12-07T20:53:33.3739438Z Preparing to unpack .../055-libmbedcrypto7t64_2.28.8-1_amd64.deb ...
+2025-12-07T20:53:33.3754916Z Unpacking libmbedcrypto7t64:amd64 (2.28.8-1) ...
+2025-12-07T20:53:33.4015278Z Selecting previously unselected package librist4:amd64.
+2025-12-07T20:53:33.4147450Z Preparing to unpack .../056-librist4_0.2.10+dfsg-2_amd64.deb ...
+2025-12-07T20:53:33.4162334Z Unpacking librist4:amd64 (0.2.10+dfsg-2) ...
+2025-12-07T20:53:33.4410504Z Selecting previously unselected package libsrt1.5-gnutls:amd64.
+2025-12-07T20:53:33.4543264Z Preparing to unpack .../057-libsrt1.5-gnutls_1.5.3-1build2_amd64.deb ...
+2025-12-07T20:53:33.4568127Z Unpacking libsrt1.5-gnutls:amd64 (1.5.3-1build2) ...
+2025-12-07T20:53:33.4851095Z Selecting previously unselected package libssh-gcrypt-4:amd64.
+2025-12-07T20:53:33.4983879Z Preparing to unpack .../058-libssh-gcrypt-4_0.10.6-2ubuntu0.2_amd64.deb ...
+2025-12-07T20:53:33.4999728Z Unpacking libssh-gcrypt-4:amd64 (0.10.6-2ubuntu0.2) ...
+2025-12-07T20:53:33.5294919Z Selecting previously unselected package libavformat60:amd64.
+2025-12-07T20:53:33.5429466Z Preparing to unpack .../059-libavformat60_7%3a6.1.1-3ubuntu5_amd64.deb ...
+2025-12-07T20:53:33.5477194Z Unpacking libavformat60:amd64 (7:6.1.1-3ubuntu5) ...
+2025-12-07T20:53:33.5867281Z Selecting previously unselected package libbs2b0:amd64.
+2025-12-07T20:53:33.6001529Z Preparing to unpack .../060-libbs2b0_3.1.0+dfsg-7build1_amd64.deb ...
+2025-12-07T20:53:33.6018797Z Unpacking libbs2b0:amd64 (3.1.0+dfsg-7build1) ...
+2025-12-07T20:53:33.6469689Z Selecting previously unselected package libflite1:amd64.
+2025-12-07T20:53:33.6604333Z Preparing to unpack .../061-libflite1_2.2-6build3_amd64.deb ...
+2025-12-07T20:53:33.6623167Z Unpacking libflite1:amd64 (2.2-6build3) ...
+2025-12-07T20:53:33.7915058Z Selecting previously unselected package libserd-0-0:amd64.
+2025-12-07T20:53:33.8074324Z Preparing to unpack .../062-libserd-0-0_0.32.2-1_amd64.deb ...
+2025-12-07T20:53:33.8082999Z Unpacking libserd-0-0:amd64 (0.32.2-1) ...
+2025-12-07T20:53:33.8377090Z Selecting previously unselected package libzix-0-0:amd64.
+2025-12-07T20:53:33.8513295Z Preparing to unpack .../063-libzix-0-0_0.4.2-2build1_amd64.deb ...
+2025-12-07T20:53:33.8533555Z Unpacking libzix-0-0:amd64 (0.4.2-2build1) ...
+2025-12-07T20:53:33.8776969Z Selecting previously unselected package libsord-0-0:amd64.
+2025-12-07T20:53:33.8912402Z Preparing to unpack .../064-libsord-0-0_0.16.16-2build1_amd64.deb ...
+2025-12-07T20:53:33.8923709Z Unpacking libsord-0-0:amd64 (0.16.16-2build1) ...
+2025-12-07T20:53:33.9156665Z Selecting previously unselected package libsratom-0-0:amd64.
+2025-12-07T20:53:33.9291693Z Preparing to unpack .../065-libsratom-0-0_0.6.16-1build1_amd64.deb ...
+2025-12-07T20:53:33.9304745Z Unpacking libsratom-0-0:amd64 (0.6.16-1build1) ...
+2025-12-07T20:53:33.9541177Z Selecting previously unselected package liblilv-0-0:amd64.
+2025-12-07T20:53:33.9675647Z Preparing to unpack .../066-liblilv-0-0_0.24.22-1build1_amd64.deb ...
+2025-12-07T20:53:33.9690173Z Unpacking liblilv-0-0:amd64 (0.24.22-1build1) ...
+2025-12-07T20:53:33.9991256Z Selecting previously unselected package libmysofa1:amd64.
+2025-12-07T20:53:34.0124843Z Preparing to unpack .../067-libmysofa1_1.3.2+dfsg-2ubuntu2_amd64.deb ...
+2025-12-07T20:53:34.0134920Z Unpacking libmysofa1:amd64 (1.3.2+dfsg-2ubuntu2) ...
+2025-12-07T20:53:34.0414707Z Selecting previously unselected package libplacebo338:amd64.
+2025-12-07T20:53:34.0552402Z Preparing to unpack .../068-libplacebo338_6.338.2-2build1_amd64.deb ...
+2025-12-07T20:53:34.0580294Z Unpacking libplacebo338:amd64 (6.338.2-2build1) ...
+2025-12-07T20:53:34.1294784Z Selecting previously unselected package libblas3:amd64.
+2025-12-07T20:53:34.1428060Z Preparing to unpack .../069-libblas3_3.12.0-3build1.1_amd64.deb ...
+2025-12-07T20:53:34.1471571Z Unpacking libblas3:amd64 (3.12.0-3build1.1) ...
+2025-12-07T20:53:34.1763311Z Selecting previously unselected package liblapack3:amd64.
+2025-12-07T20:53:34.1896673Z Preparing to unpack .../070-liblapack3_3.12.0-3build1.1_amd64.deb ...
+2025-12-07T20:53:34.1935184Z Unpacking liblapack3:amd64 (3.12.0-3build1.1) ...
+2025-12-07T20:53:34.2443631Z Selecting previously unselected package libasyncns0:amd64.
+2025-12-07T20:53:34.2576540Z Preparing to unpack .../071-libasyncns0_0.8-6build4_amd64.deb ...
+2025-12-07T20:53:34.2586952Z Unpacking libasyncns0:amd64 (0.8-6build4) ...
+2025-12-07T20:53:34.2834286Z Selecting previously unselected package libflac12t64:amd64.
+2025-12-07T20:53:34.2968887Z Preparing to unpack .../072-libflac12t64_1.4.3+ds-2.1ubuntu2_amd64.deb ...
+2025-12-07T20:53:34.2988235Z Unpacking libflac12t64:amd64 (1.4.3+ds-2.1ubuntu2) ...
+2025-12-07T20:53:34.3252947Z Selecting previously unselected package libsndfile1:amd64.
+2025-12-07T20:53:34.3386677Z Preparing to unpack .../073-libsndfile1_1.2.2-1ubuntu5.24.04.1_amd64.deb ...
+2025-12-07T20:53:34.3395841Z Unpacking libsndfile1:amd64 (1.2.2-1ubuntu5.24.04.1) ...
+2025-12-07T20:53:34.3669234Z Selecting previously unselected package libpulse0:amd64.
+2025-12-07T20:53:34.3804792Z Preparing to unpack .../074-libpulse0_1%3a16.1+dfsg1-2ubuntu10.1_amd64.deb ...
+2025-12-07T20:53:34.3875870Z Unpacking libpulse0:amd64 (1:16.1+dfsg1-2ubuntu10.1) ...
+2025-12-07T20:53:34.4260505Z Selecting previously unselected package libsphinxbase3t64:amd64.
+2025-12-07T20:53:34.4394220Z Preparing to unpack .../075-libsphinxbase3t64_0.8+5prealpha+1-17build2_amd64.deb ...
+2025-12-07T20:53:34.4405253Z Unpacking libsphinxbase3t64:amd64 (0.8+5prealpha+1-17build2) ...
+2025-12-07T20:53:34.4653665Z Selecting previously unselected package libpocketsphinx3:amd64.
+2025-12-07T20:53:34.4787305Z Preparing to unpack .../076-libpocketsphinx3_0.8.0+real5prealpha+1-15ubuntu5_amd64.deb ...
+2025-12-07T20:53:34.4800012Z Unpacking libpocketsphinx3:amd64 (0.8.0+real5prealpha+1-15ubuntu5) ...
+2025-12-07T20:53:34.5060386Z Selecting previously unselected package libpostproc57:amd64.
+2025-12-07T20:53:34.5193900Z Preparing to unpack .../077-libpostproc57_7%3a6.1.1-3ubuntu5_amd64.deb ...
+2025-12-07T20:53:34.5208674Z Unpacking libpostproc57:amd64 (7:6.1.1-3ubuntu5) ...
+2025-12-07T20:53:34.5452830Z Selecting previously unselected package libsamplerate0:amd64.
+2025-12-07T20:53:34.5588596Z Preparing to unpack .../078-libsamplerate0_0.2.2-4build1_amd64.deb ...
+2025-12-07T20:53:34.5598028Z Unpacking libsamplerate0:amd64 (0.2.2-4build1) ...
+2025-12-07T20:53:34.6034762Z Selecting previously unselected package librubberband2:amd64.
+2025-12-07T20:53:34.6171150Z Preparing to unpack .../079-librubberband2_3.3.0+dfsg-2build1_amd64.deb ...
+2025-12-07T20:53:34.6181814Z Unpacking librubberband2:amd64 (3.3.0+dfsg-2build1) ...
+2025-12-07T20:53:34.6426509Z Selecting previously unselected package libswscale7:amd64.
+2025-12-07T20:53:34.6560303Z Preparing to unpack .../080-libswscale7_7%3a6.1.1-3ubuntu5_amd64.deb ...
+2025-12-07T20:53:34.6571378Z Unpacking libswscale7:amd64 (7:6.1.1-3ubuntu5) ...
+2025-12-07T20:53:34.6824928Z Selecting previously unselected package libvidstab1.1:amd64.
+2025-12-07T20:53:34.6959182Z Preparing to unpack .../081-libvidstab1.1_1.1.0-2build1_amd64.deb ...
+2025-12-07T20:53:34.6972891Z Unpacking libvidstab1.1:amd64 (1.1.0-2build1) ...
+2025-12-07T20:53:34.7215279Z Selecting previously unselected package libzimg2:amd64.
+2025-12-07T20:53:34.7348999Z Preparing to unpack .../082-libzimg2_3.0.5+ds1-1build1_amd64.deb ...
+2025-12-07T20:53:34.7360441Z Unpacking libzimg2:amd64 (3.0.5+ds1-1build1) ...
+2025-12-07T20:53:34.7628223Z Selecting previously unselected package libavfilter9:amd64.
+2025-12-07T20:53:34.7763008Z Preparing to unpack .../083-libavfilter9_7%3a6.1.1-3ubuntu5_amd64.deb ...
+2025-12-07T20:53:34.7771709Z Unpacking libavfilter9:amd64 (7:6.1.1-3ubuntu5) ...
+2025-12-07T20:53:34.8550100Z Selecting previously unselected package liborc-0.4-0t64:amd64.
+2025-12-07T20:53:34.8684519Z Preparing to unpack .../084-liborc-0.4-0t64_1%3a0.4.38-1ubuntu0.1_amd64.deb ...
+2025-12-07T20:53:34.8698551Z Unpacking liborc-0.4-0t64:amd64 (1:0.4.38-1ubuntu0.1) ...
+2025-12-07T20:53:34.8991536Z Selecting previously unselected package libgstreamer-plugins-base1.0-0:amd64.
+2025-12-07T20:53:34.9128270Z Preparing to unpack .../085-libgstreamer-plugins-base1.0-0_1.24.2-1ubuntu0.3_amd64.deb ...
+2025-12-07T20:53:34.9137420Z Unpacking libgstreamer-plugins-base1.0-0:amd64 (1.24.2-1ubuntu0.3) ...
+2025-12-07T20:53:34.9500808Z Selecting previously unselected package gstreamer1.0-libav:amd64.
+2025-12-07T20:53:34.9633868Z Preparing to unpack .../086-gstreamer1.0-libav_1.24.1-1build1_amd64.deb ...
+2025-12-07T20:53:34.9642589Z Unpacking gstreamer1.0-libav:amd64 (1.24.1-1build1) ...
+2025-12-07T20:53:34.9878591Z Selecting previously unselected package libcdparanoia0:amd64.
+2025-12-07T20:53:35.0011510Z Preparing to unpack .../087-libcdparanoia0_3.10.2+debian-14build3_amd64.deb ...
+2025-12-07T20:53:35.0021625Z Unpacking libcdparanoia0:amd64 (3.10.2+debian-14build3) ...
+2025-12-07T20:53:35.0285233Z Selecting previously unselected package libvisual-0.4-0:amd64.
+2025-12-07T20:53:35.0420450Z Preparing to unpack .../088-libvisual-0.4-0_0.4.2-2build1_amd64.deb ...
+2025-12-07T20:53:35.0433219Z Unpacking libvisual-0.4-0:amd64 (0.4.2-2build1) ...
+2025-12-07T20:53:35.0677357Z Selecting previously unselected package gstreamer1.0-plugins-base:amd64.
+2025-12-07T20:53:35.0812103Z Preparing to unpack .../089-gstreamer1.0-plugins-base_1.24.2-1ubuntu0.3_amd64.deb ...
+2025-12-07T20:53:35.0824388Z Unpacking gstreamer1.0-plugins-base:amd64 (1.24.2-1ubuntu0.3) ...
+2025-12-07T20:53:35.1183698Z Selecting previously unselected package libaa1:amd64.
+2025-12-07T20:53:35.1317453Z Preparing to unpack .../090-libaa1_1.4p5-51.1_amd64.deb ...
+2025-12-07T20:53:35.1327986Z Unpacking libaa1:amd64 (1.4p5-51.1) ...
+2025-12-07T20:53:35.1575043Z Selecting previously unselected package libraw1394-11:amd64.
+2025-12-07T20:53:35.1708273Z Preparing to unpack .../091-libraw1394-11_2.1.2-2build3_amd64.deb ...
+2025-12-07T20:53:35.1723117Z Unpacking libraw1394-11:amd64 (2.1.2-2build3) ...
+2025-12-07T20:53:35.2005260Z Selecting previously unselected package libavc1394-0:amd64.
+2025-12-07T20:53:35.2138655Z Preparing to unpack .../092-libavc1394-0_0.5.4-5build3_amd64.deb ...
+2025-12-07T20:53:35.2148885Z Unpacking libavc1394-0:amd64 (0.5.4-5build3) ...
+2025-12-07T20:53:35.2379450Z Selecting previously unselected package libcaca0:amd64.
+2025-12-07T20:53:35.2512562Z Preparing to unpack .../093-libcaca0_0.99.beta20-4build2_amd64.deb ...
+2025-12-07T20:53:35.2521486Z Unpacking libcaca0:amd64 (0.99.beta20-4build2) ...
+2025-12-07T20:53:35.2808487Z Selecting previously unselected package libdv4t64:amd64.
+2025-12-07T20:53:35.2943887Z Preparing to unpack .../094-libdv4t64_1.0.0-17.1build1_amd64.deb ...
+2025-12-07T20:53:35.2953849Z Unpacking libdv4t64:amd64 (1.0.0-17.1build1) ...
+2025-12-07T20:53:35.3210272Z Selecting previously unselected package libgstreamer-plugins-good1.0-0:amd64.
+2025-12-07T20:53:35.3344487Z Preparing to unpack .../095-libgstreamer-plugins-good1.0-0_1.24.2-1ubuntu1.2_amd64.deb ...
+2025-12-07T20:53:35.3354873Z Unpacking libgstreamer-plugins-good1.0-0:amd64 (1.24.2-1ubuntu1.2) ...
+2025-12-07T20:53:35.3593279Z Selecting previously unselected package libiec61883-0:amd64.
+2025-12-07T20:53:35.3727928Z Preparing to unpack .../096-libiec61883-0_1.2.0-6build1_amd64.deb ...
+2025-12-07T20:53:35.3740897Z Unpacking libiec61883-0:amd64 (1.2.0-6build1) ...
+2025-12-07T20:53:35.3998573Z Selecting previously unselected package libshout3:amd64.
+2025-12-07T20:53:35.4134314Z Preparing to unpack .../097-libshout3_2.4.6-1build2_amd64.deb ...
+2025-12-07T20:53:35.4147944Z Unpacking libshout3:amd64 (2.4.6-1build2) ...
+2025-12-07T20:53:35.4402959Z Selecting previously unselected package libtag1v5-vanilla:amd64.
+2025-12-07T20:53:35.4535336Z Preparing to unpack .../098-libtag1v5-vanilla_1.13.1-1build1_amd64.deb ...
+2025-12-07T20:53:35.4546461Z Unpacking libtag1v5-vanilla:amd64 (1.13.1-1build1) ...
+2025-12-07T20:53:35.4806713Z Selecting previously unselected package libtag1v5:amd64.
+2025-12-07T20:53:35.4941134Z Preparing to unpack .../099-libtag1v5_1.13.1-1build1_amd64.deb ...
+2025-12-07T20:53:35.4977045Z Unpacking libtag1v5:amd64 (1.13.1-1build1) ...
+2025-12-07T20:53:35.5216339Z Selecting previously unselected package libv4lconvert0t64:amd64.
+2025-12-07T20:53:35.5351070Z Preparing to unpack .../100-libv4lconvert0t64_1.26.1-4build3_amd64.deb ...
+2025-12-07T20:53:35.5364327Z Unpacking libv4lconvert0t64:amd64 (1.26.1-4build3) ...
+2025-12-07T20:53:35.5634539Z Selecting previously unselected package libv4l-0t64:amd64.
+2025-12-07T20:53:35.5769953Z Preparing to unpack .../101-libv4l-0t64_1.26.1-4build3_amd64.deb ...
+2025-12-07T20:53:35.5782328Z Unpacking libv4l-0t64:amd64 (1.26.1-4build3) ...
+2025-12-07T20:53:35.6060558Z Selecting previously unselected package libwavpack1:amd64.
+2025-12-07T20:53:35.6194978Z Preparing to unpack .../102-libwavpack1_5.6.0-1build1_amd64.deb ...
+2025-12-07T20:53:35.6209207Z Unpacking libwavpack1:amd64 (5.6.0-1build1) ...
+2025-12-07T20:53:35.6435413Z Selecting previously unselected package libsoup-3.0-common.
+2025-12-07T20:53:35.6569661Z Preparing to unpack .../103-libsoup-3.0-common_3.4.4-5ubuntu0.5_all.deb ...
+2025-12-07T20:53:35.6580078Z Unpacking libsoup-3.0-common (3.4.4-5ubuntu0.5) ...
+2025-12-07T20:53:35.6809586Z Selecting previously unselected package libsoup-3.0-0:amd64.
+2025-12-07T20:53:35.6943154Z Preparing to unpack .../104-libsoup-3.0-0_3.4.4-5ubuntu0.5_amd64.deb ...
+2025-12-07T20:53:35.6955816Z Unpacking libsoup-3.0-0:amd64 (3.4.4-5ubuntu0.5) ...
+2025-12-07T20:53:35.7214625Z Selecting previously unselected package gstreamer1.0-plugins-good:amd64.
+2025-12-07T20:53:35.7349517Z Preparing to unpack .../105-gstreamer1.0-plugins-good_1.24.2-1ubuntu1.2_amd64.deb ...
+2025-12-07T20:53:35.7367441Z Unpacking gstreamer1.0-plugins-good:amd64 (1.24.2-1ubuntu1.2) ...
+2025-12-07T20:53:35.7959852Z Selecting previously unselected package libabsl20220623t64:amd64.
+2025-12-07T20:53:35.8094518Z Preparing to unpack .../106-libabsl20220623t64_20220623.1-3.1ubuntu3.2_amd64.deb ...
+2025-12-07T20:53:35.8106733Z Unpacking libabsl20220623t64:amd64 (20220623.1-3.1ubuntu3.2) ...
+2025-12-07T20:53:35.8557035Z Selecting previously unselected package libgav1-1:amd64.
+2025-12-07T20:53:35.8691172Z Preparing to unpack .../107-libgav1-1_0.18.0-1build3_amd64.deb ...
+2025-12-07T20:53:35.8704236Z Unpacking libgav1-1:amd64 (0.18.0-1build3) ...
+2025-12-07T20:53:35.8979279Z Selecting previously unselected package libyuv0:amd64.
+2025-12-07T20:53:35.9114223Z Preparing to unpack .../108-libyuv0_0.0~git202401110.af6ac82-1_amd64.deb ...
+2025-12-07T20:53:35.9126070Z Unpacking libyuv0:amd64 (0.0~git202401110.af6ac82-1) ...
+2025-12-07T20:53:35.9380675Z Selecting previously unselected package libavif16:amd64.
+2025-12-07T20:53:35.9515573Z Preparing to unpack .../109-libavif16_1.0.4-1ubuntu3_amd64.deb ...
+2025-12-07T20:53:35.9526869Z Unpacking libavif16:amd64 (1.0.4-1ubuntu3) ...
+2025-12-07T20:53:35.9786252Z Selecting previously unselected package libavtp0:amd64.
+2025-12-07T20:53:35.9920256Z Preparing to unpack .../110-libavtp0_0.2.0-1build1_amd64.deb ...
+2025-12-07T20:53:35.9930215Z Unpacking libavtp0:amd64 (0.2.0-1build1) ...
+2025-12-07T20:53:36.0190511Z Selecting previously unselected package libcairo-script-interpreter2:amd64.
+2025-12-07T20:53:36.0327322Z Preparing to unpack .../111-libcairo-script-interpreter2_1.18.0-3build1_amd64.deb ...
+2025-12-07T20:53:36.0339346Z Unpacking libcairo-script-interpreter2:amd64 (1.18.0-3build1) ...
+2025-12-07T20:53:36.0747106Z Preparing to unpack .../112-libcups2t64_2.4.7-1.2ubuntu7.9_amd64.deb ...
+2025-12-07T20:53:36.0789621Z Unpacking libcups2t64:amd64 (2.4.7-1.2ubuntu7.9) over (2.4.7-1.2ubuntu7.4) ...
+2025-12-07T20:53:36.1213474Z Selecting previously unselected package libdc1394-25:amd64.
+2025-12-07T20:53:36.1351251Z Preparing to unpack .../113-libdc1394-25_2.2.6-4build1_amd64.deb ...
+2025-12-07T20:53:36.1359433Z Unpacking libdc1394-25:amd64 (2.2.6-4build1) ...
+2025-12-07T20:53:36.1624032Z Selecting previously unselected package libdecor-0-0:amd64.
+2025-12-07T20:53:36.1760262Z Preparing to unpack .../114-libdecor-0-0_0.2.2-1build2_amd64.deb ...
+2025-12-07T20:53:36.1776841Z Unpacking libdecor-0-0:amd64 (0.2.2-1build2) ...
+2025-12-07T20:53:36.2030819Z Selecting previously unselected package libgles2:amd64.
+2025-12-07T20:53:36.2166928Z Preparing to unpack .../115-libgles2_1.7.0-1build1_amd64.deb ...
+2025-12-07T20:53:36.2177517Z Unpacking libgles2:amd64 (1.7.0-1build1) ...
+2025-12-07T20:53:36.2423969Z Selecting previously unselected package libdirectfb-1.7-7t64:amd64.
+2025-12-07T20:53:36.2559236Z Preparing to unpack .../116-libdirectfb-1.7-7t64_1.7.7-11.1ubuntu2_amd64.deb ...
+2025-12-07T20:53:36.2569838Z Unpacking libdirectfb-1.7-7t64:amd64 (1.7.7-11.1ubuntu2) ...
+2025-12-07T20:53:36.3023068Z Selecting previously unselected package libdvdread8t64:amd64.
+2025-12-07T20:53:36.3157426Z Preparing to unpack .../117-libdvdread8t64_6.1.3-1.1build1_amd64.deb ...
+2025-12-07T20:53:36.3170473Z Unpacking libdvdread8t64:amd64 (6.1.3-1.1build1) ...
+2025-12-07T20:53:36.3428860Z Selecting previously unselected package libdvdnav4:amd64.
+2025-12-07T20:53:36.3561316Z Preparing to unpack .../118-libdvdnav4_6.1.1-3build1_amd64.deb ...
+2025-12-07T20:53:36.3574272Z Unpacking libdvdnav4:amd64 (6.1.1-3build1) ...
+2025-12-07T20:53:36.3866673Z Selecting previously unselected package libegl-mesa0:amd64.
+2025-12-07T20:53:36.4002704Z Preparing to unpack .../119-libegl-mesa0_25.0.7-0ubuntu0.24.04.2_amd64.deb ...
+2025-12-07T20:53:36.4013785Z Unpacking libegl-mesa0:amd64 (25.0.7-0ubuntu0.24.04.2) ...
+2025-12-07T20:53:36.4308398Z Selecting previously unselected package libevent-2.1-7t64:amd64.
+2025-12-07T20:53:36.4441262Z Preparing to unpack .../120-libevent-2.1-7t64_2.1.12-stable-9ubuntu2_amd64.deb ...
+2025-12-07T20:53:36.4452345Z Unpacking libevent-2.1-7t64:amd64 (2.1.12-stable-9ubuntu2) ...
+2025-12-07T20:53:36.4721396Z Selecting previously unselected package libfaad2:amd64.
+2025-12-07T20:53:36.4854552Z Preparing to unpack .../121-libfaad2_2.11.1-1build1_amd64.deb ...
+2025-12-07T20:53:36.4866232Z Unpacking libfaad2:amd64 (2.11.1-1build1) ...
+2025-12-07T20:53:36.5177092Z Selecting previously unselected package libinstpatch-1.0-2:amd64.
+2025-12-07T20:53:36.5312995Z Preparing to unpack .../122-libinstpatch-1.0-2_1.1.6-1build2_amd64.deb ...
+2025-12-07T20:53:36.5325977Z Unpacking libinstpatch-1.0-2:amd64 (1.1.6-1build2) ...
+2025-12-07T20:53:36.5602158Z Selecting previously unselected package libjack-jackd2-0:amd64.
+2025-12-07T20:53:36.5736681Z Preparing to unpack .../123-libjack-jackd2-0_1.9.21~dfsg-3ubuntu3_amd64.deb ...
+2025-12-07T20:53:36.5746489Z Unpacking libjack-jackd2-0:amd64 (1.9.21~dfsg-3ubuntu3) ...
+2025-12-07T20:53:36.6024965Z Selecting previously unselected package libwebrtc-audio-processing1:amd64.
+2025-12-07T20:53:36.6158743Z Preparing to unpack .../124-libwebrtc-audio-processing1_0.3.1-0ubuntu6_amd64.deb ...
+2025-12-07T20:53:36.6171467Z Unpacking libwebrtc-audio-processing1:amd64 (0.3.1-0ubuntu6) ...
+2025-12-07T20:53:36.6455495Z Selecting previously unselected package libspa-0.2-modules:amd64.
+2025-12-07T20:53:36.6588624Z Preparing to unpack .../125-libspa-0.2-modules_1.0.5-1ubuntu3.1_amd64.deb ...
+2025-12-07T20:53:36.6609966Z Unpacking libspa-0.2-modules:amd64 (1.0.5-1ubuntu3.1) ...
+2025-12-07T20:53:36.6962952Z Selecting previously unselected package libpipewire-0.3-0t64:amd64.
+2025-12-07T20:53:36.7096453Z Preparing to unpack .../126-libpipewire-0.3-0t64_1.0.5-1ubuntu3.1_amd64.deb ...
+2025-12-07T20:53:36.7108256Z Unpacking libpipewire-0.3-0t64:amd64 (1.0.5-1ubuntu3.1) ...
+2025-12-07T20:53:36.7437868Z Selecting previously unselected package libsdl2-2.0-0:amd64.
+2025-12-07T20:53:36.7571217Z Preparing to unpack .../127-libsdl2-2.0-0_2.30.0+dfsg-1ubuntu3.1_amd64.deb ...
+2025-12-07T20:53:36.7588459Z Unpacking libsdl2-2.0-0:amd64 (2.30.0+dfsg-1ubuntu3.1) ...
+2025-12-07T20:53:36.7922134Z Selecting previously unselected package timgm6mb-soundfont.
+2025-12-07T20:53:36.8057000Z Preparing to unpack .../128-timgm6mb-soundfont_1.3-5_all.deb ...
+2025-12-07T20:53:36.8070748Z Unpacking timgm6mb-soundfont (1.3-5) ...
+2025-12-07T20:53:37.1482859Z Selecting previously unselected package libfluidsynth3:amd64.
+2025-12-07T20:53:37.1620056Z Preparing to unpack .../129-libfluidsynth3_2.3.4-1build3_amd64.deb ...
+2025-12-07T20:53:37.1632010Z Unpacking libfluidsynth3:amd64 (2.3.4-1build3) ...
+2025-12-07T20:53:37.1940955Z Selecting previously unselected package libfreeaptx0:amd64.
+2025-12-07T20:53:37.2077387Z Preparing to unpack .../130-libfreeaptx0_0.1.1-2build1_amd64.deb ...
+2025-12-07T20:53:37.2088289Z Unpacking libfreeaptx0:amd64 (0.1.1-2build1) ...
+2025-12-07T20:53:37.2336384Z Selecting previously unselected package libgraphene-1.0-0:amd64.
+2025-12-07T20:53:37.2474860Z Preparing to unpack .../131-libgraphene-1.0-0_1.10.8-3build2_amd64.deb ...
+2025-12-07T20:53:37.2488824Z Unpacking libgraphene-1.0-0:amd64 (1.10.8-3build2) ...
+2025-12-07T20:53:37.2736267Z Selecting previously unselected package libgssdp-1.6-0:amd64.
+2025-12-07T20:53:37.2873765Z Preparing to unpack .../132-libgssdp-1.6-0_1.6.3-1build3_amd64.deb ...
+2025-12-07T20:53:37.2884598Z Unpacking libgssdp-1.6-0:amd64 (1.6.3-1build3) ...
+2025-12-07T20:53:37.3129164Z Selecting previously unselected package libegl1:amd64.
+2025-12-07T20:53:37.3264999Z Preparing to unpack .../133-libegl1_1.7.0-1build1_amd64.deb ...
+2025-12-07T20:53:37.3275061Z Unpacking libegl1:amd64 (1.7.0-1build1) ...
+2025-12-07T20:53:37.3525729Z Selecting previously unselected package libgstreamer-gl1.0-0:amd64.
+2025-12-07T20:53:37.3662526Z Preparing to unpack .../134-libgstreamer-gl1.0-0_1.24.2-1ubuntu0.3_amd64.deb ...
+2025-12-07T20:53:37.3674161Z Unpacking libgstreamer-gl1.0-0:amd64 (1.24.2-1ubuntu0.3) ...
+2025-12-07T20:53:37.3932435Z Selecting previously unselected package libgtk-4-common.
+2025-12-07T20:53:37.4070035Z Preparing to unpack .../135-libgtk-4-common_4.14.5+ds-0ubuntu0.7_all.deb ...
+2025-12-07T20:53:37.4080324Z Unpacking libgtk-4-common (4.14.5+ds-0ubuntu0.7) ...
+2025-12-07T20:53:37.4628075Z Selecting previously unselected package libgtk-4-1:amd64.
+2025-12-07T20:53:37.4764291Z Preparing to unpack .../136-libgtk-4-1_4.14.5+ds-0ubuntu0.7_amd64.deb ...
+2025-12-07T20:53:37.4778028Z Unpacking libgtk-4-1:amd64 (4.14.5+ds-0ubuntu0.7) ...
+2025-12-07T20:53:37.5534001Z Selecting previously unselected package libgupnp-1.6-0:amd64.
+2025-12-07T20:53:37.5668981Z Preparing to unpack .../137-libgupnp-1.6-0_1.6.6-1build3_amd64.deb ...
+2025-12-07T20:53:37.5690181Z Unpacking libgupnp-1.6-0:amd64 (1.6.6-1build3) ...
+2025-12-07T20:53:37.5969896Z Selecting previously unselected package libgupnp-igd-1.6-0:amd64.
+2025-12-07T20:53:37.6105093Z Preparing to unpack .../138-libgupnp-igd-1.6-0_1.6.0-3build3_amd64.deb ...
+2025-12-07T20:53:37.6130056Z Unpacking libgupnp-igd-1.6-0:amd64 (1.6.0-3build3) ...
+2025-12-07T20:53:37.6404034Z Selecting previously unselected package libharfbuzz-icu0:amd64.
+2025-12-07T20:53:37.6538806Z Preparing to unpack .../139-libharfbuzz-icu0_8.3.0-2build2_amd64.deb ...
+2025-12-07T20:53:37.6549432Z Unpacking libharfbuzz-icu0:amd64 (8.3.0-2build2) ...
+2025-12-07T20:53:37.6841501Z Selecting previously unselected package libhyphen0:amd64.
+2025-12-07T20:53:37.6975606Z Preparing to unpack .../140-libhyphen0_2.8.8-7build3_amd64.deb ...
+2025-12-07T20:53:37.6991020Z Unpacking libhyphen0:amd64 (2.8.8-7build3) ...
+2025-12-07T20:53:37.7251915Z Selecting previously unselected package libimath-3-1-29t64:amd64.
+2025-12-07T20:53:37.7387552Z Preparing to unpack .../141-libimath-3-1-29t64_3.1.9-3.1ubuntu2_amd64.deb ...
+2025-12-07T20:53:37.7403379Z Unpacking libimath-3-1-29t64:amd64 (3.1.9-3.1ubuntu2) ...
+2025-12-07T20:53:37.7705254Z Selecting previously unselected package liblc3-1:amd64.
+2025-12-07T20:53:37.7840286Z Preparing to unpack .../142-liblc3-1_1.0.4-3build1_amd64.deb ...
+2025-12-07T20:53:37.7853978Z Unpacking liblc3-1:amd64 (1.0.4-3build1) ...
+2025-12-07T20:53:37.8112853Z Selecting previously unselected package libldacbt-enc2:amd64.
+2025-12-07T20:53:37.8248102Z Preparing to unpack .../143-libldacbt-enc2_2.0.2.3+git20200429+ed310a0-4ubuntu2_amd64.deb ...
+2025-12-07T20:53:37.8268756Z Unpacking libldacbt-enc2:amd64 (2.0.2.3+git20200429+ed310a0-4ubuntu2) ...
+2025-12-07T20:53:37.8523369Z Selecting previously unselected package libraptor2-0:amd64.
+2025-12-07T20:53:37.8658458Z Preparing to unpack .../144-libraptor2-0_2.0.16-3ubuntu0.1_amd64.deb ...
+2025-12-07T20:53:37.8682363Z Unpacking libraptor2-0:amd64 (2.0.16-3ubuntu0.1) ...
+2025-12-07T20:53:37.8944209Z Selecting previously unselected package liblrdf0:amd64.
+2025-12-07T20:53:37.9078341Z Preparing to unpack .../145-liblrdf0_0.6.1-4build1_amd64.deb ...
+2025-12-07T20:53:37.9097327Z Unpacking liblrdf0:amd64 (0.6.1-4build1) ...
+2025-12-07T20:53:37.9358670Z Selecting previously unselected package libltc11:amd64.
+2025-12-07T20:53:37.9494938Z Preparing to unpack .../146-libltc11_1.3.2-1build1_amd64.deb ...
+2025-12-07T20:53:37.9507462Z Unpacking libltc11:amd64 (1.3.2-1build1) ...
+2025-12-07T20:53:37.9754538Z Selecting previously unselected package libmanette-0.2-0:amd64.
+2025-12-07T20:53:37.9891635Z Preparing to unpack .../147-libmanette-0.2-0_0.2.7-1build2_amd64.deb ...
+2025-12-07T20:53:37.9913574Z Unpacking libmanette-0.2-0:amd64 (0.2.7-1build2) ...
+2025-12-07T20:53:38.0155649Z Selecting previously unselected package libmfx1:amd64.
+2025-12-07T20:53:38.0290489Z Preparing to unpack .../148-libmfx1_22.5.4-1_amd64.deb ...
+2025-12-07T20:53:38.0298997Z Unpacking libmfx1:amd64 (22.5.4-1) ...
+2025-12-07T20:53:38.1339356Z Selecting previously unselected package libmjpegutils-2.1-0t64:amd64.
+2025-12-07T20:53:38.1474230Z Preparing to unpack .../149-libmjpegutils-2.1-0t64_1%3a2.1.0+debian-8.1build1_amd64.deb ...
+2025-12-07T20:53:38.1487874Z Unpacking libmjpegutils-2.1-0t64:amd64 (1:2.1.0+debian-8.1build1) ...
+2025-12-07T20:53:38.1736693Z Selecting previously unselected package libmodplug1:amd64.
+2025-12-07T20:53:38.1874917Z Preparing to unpack .../150-libmodplug1_1%3a0.8.9.0-3build1_amd64.deb ...
+2025-12-07T20:53:38.1887533Z Unpacking libmodplug1:amd64 (1:0.8.9.0-3build1) ...
+2025-12-07T20:53:38.2141833Z Selecting previously unselected package libmpcdec6:amd64.
+2025-12-07T20:53:38.2277126Z Preparing to unpack .../151-libmpcdec6_2%3a0.1~r495-2build1_amd64.deb ...
+2025-12-07T20:53:38.2287846Z Unpacking libmpcdec6:amd64 (2:0.1~r495-2build1) ...
+2025-12-07T20:53:38.2513696Z Selecting previously unselected package libmpeg2encpp-2.1-0t64:amd64.
+2025-12-07T20:53:38.2648964Z Preparing to unpack .../152-libmpeg2encpp-2.1-0t64_1%3a2.1.0+debian-8.1build1_amd64.deb ...
+2025-12-07T20:53:38.2663204Z Unpacking libmpeg2encpp-2.1-0t64:amd64 (1:2.1.0+debian-8.1build1) ...
+2025-12-07T20:53:38.2928088Z Selecting previously unselected package libmplex2-2.1-0t64:amd64.
+2025-12-07T20:53:38.3065274Z Preparing to unpack .../153-libmplex2-2.1-0t64_1%3a2.1.0+debian-8.1build1_amd64.deb ...
+2025-12-07T20:53:38.3078122Z Unpacking libmplex2-2.1-0t64:amd64 (1:2.1.0+debian-8.1build1) ...
+2025-12-07T20:53:38.3341724Z Selecting previously unselected package libneon27t64:amd64.
+2025-12-07T20:53:38.3478114Z Preparing to unpack .../154-libneon27t64_0.33.0-1.1build3_amd64.deb ...
+2025-12-07T20:53:38.3489367Z Unpacking libneon27t64:amd64 (0.33.0-1.1build3) ...
+2025-12-07T20:53:38.3765167Z Selecting previously unselected package libnice10:amd64.
+2025-12-07T20:53:38.3903437Z Preparing to unpack .../155-libnice10_0.1.21-2build3_amd64.deb ...
+2025-12-07T20:53:38.3918559Z Unpacking libnice10:amd64 (0.1.21-2build3) ...
+2025-12-07T20:53:38.4189970Z Selecting previously unselected package libopenal-data.
+2025-12-07T20:53:38.4326056Z Preparing to unpack .../156-libopenal-data_1%3a1.23.1-4build1_all.deb ...
+2025-12-07T20:53:38.4340042Z Unpacking libopenal-data (1:1.23.1-4build1) ...
+2025-12-07T20:53:38.4611147Z Selecting previously unselected package libopenexr-3-1-30:amd64.
+2025-12-07T20:53:38.4745396Z Preparing to unpack .../157-libopenexr-3-1-30_3.1.5-5.1build3_amd64.deb ...
+2025-12-07T20:53:38.4762865Z Unpacking libopenexr-3-1-30:amd64 (3.1.5-5.1build3) ...
+2025-12-07T20:53:38.5193614Z Selecting previously unselected package libopenh264-7:amd64.
+2025-12-07T20:53:38.5329069Z Preparing to unpack .../158-libopenh264-7_2.4.1+dfsg-1_amd64.deb ...
+2025-12-07T20:53:38.5350194Z Unpacking libopenh264-7:amd64 (2.4.1+dfsg-1) ...
+2025-12-07T20:53:38.5703833Z Selecting previously unselected package libopenni2-0:amd64.
+2025-12-07T20:53:38.5840535Z Preparing to unpack .../159-libopenni2-0_2.2.0.33+dfsg-18_amd64.deb ...
+2025-12-07T20:53:38.5876764Z Unpacking libopenni2-0:amd64 (2.2.0.33+dfsg-18) ...
+2025-12-07T20:53:38.6194585Z Selecting previously unselected package libqrencode4:amd64.
+2025-12-07T20:53:38.6330808Z Preparing to unpack .../160-libqrencode4_4.1.1-1build2_amd64.deb ...
+2025-12-07T20:53:38.6348135Z Unpacking libqrencode4:amd64 (4.1.1-1build2) ...
+2025-12-07T20:53:38.6577399Z Selecting previously unselected package libsecret-common.
+2025-12-07T20:53:38.6713843Z Preparing to unpack .../161-libsecret-common_0.21.4-1build3_all.deb ...
+2025-12-07T20:53:38.6851376Z Unpacking libsecret-common (0.21.4-1build3) ...
+2025-12-07T20:53:38.7098594Z Selecting previously unselected package libsecret-1-0:amd64.
+2025-12-07T20:53:38.7234297Z Preparing to unpack .../162-libsecret-1-0_0.21.4-1build3_amd64.deb ...
+2025-12-07T20:53:38.7246041Z Unpacking libsecret-1-0:amd64 (0.21.4-1build3) ...
+2025-12-07T20:53:38.7512736Z Selecting previously unselected package libsndio7.0:amd64.
+2025-12-07T20:53:38.7647943Z Preparing to unpack .../163-libsndio7.0_1.9.0-0.3build3_amd64.deb ...
+2025-12-07T20:53:38.7664114Z Unpacking libsndio7.0:amd64 (1.9.0-0.3build3) ...
+2025-12-07T20:53:38.7907009Z Selecting previously unselected package libsoundtouch1:amd64.
+2025-12-07T20:53:38.8041948Z Preparing to unpack .../164-libsoundtouch1_2.3.2+ds1-1build1_amd64.deb ...
+2025-12-07T20:53:38.8052479Z Unpacking libsoundtouch1:amd64 (2.3.2+ds1-1build1) ...
+2025-12-07T20:53:38.8303175Z Selecting previously unselected package libspandsp2t64:amd64.
+2025-12-07T20:53:38.8440030Z Preparing to unpack .../165-libspandsp2t64_0.0.6+dfsg-2.1build1_amd64.deb ...
+2025-12-07T20:53:38.8452619Z Unpacking libspandsp2t64:amd64 (0.0.6+dfsg-2.1build1) ...
+2025-12-07T20:53:38.8756382Z Selecting previously unselected package libsrtp2-1:amd64.
+2025-12-07T20:53:38.8894193Z Preparing to unpack .../166-libsrtp2-1_2.5.0-3build1_amd64.deb ...
+2025-12-07T20:53:38.8904433Z Unpacking libsrtp2-1:amd64 (2.5.0-3build1) ...
+2025-12-07T20:53:38.9293361Z Preparing to unpack .../167-libssh-4_0.10.6-2ubuntu0.2_amd64.deb ...
+2025-12-07T20:53:38.9399679Z Unpacking libssh-4:amd64 (0.10.6-2ubuntu0.2) over (0.10.6-2ubuntu0.1) ...
+2025-12-07T20:53:38.9756933Z Selecting previously unselected package libwildmidi2:amd64.
+2025-12-07T20:53:38.9893349Z Preparing to unpack .../168-libwildmidi2_0.4.3-1build3_amd64.deb ...
+2025-12-07T20:53:38.9904548Z Unpacking libwildmidi2:amd64 (0.4.3-1build3) ...
+2025-12-07T20:53:39.0151838Z Selecting previously unselected package libwoff1:amd64.
+2025-12-07T20:53:39.0286507Z Preparing to unpack .../169-libwoff1_1.0.2-2build1_amd64.deb ...
+2025-12-07T20:53:39.0300210Z Unpacking libwoff1:amd64 (1.0.2-2build1) ...
+2025-12-07T20:53:39.0553748Z Selecting previously unselected package libxcb-xkb1:amd64.
+2025-12-07T20:53:39.0691894Z Preparing to unpack .../170-libxcb-xkb1_1.15-1ubuntu2_amd64.deb ...
+2025-12-07T20:53:39.0705469Z Unpacking libxcb-xkb1:amd64 (1.15-1ubuntu2) ...
+2025-12-07T20:53:39.1012063Z Selecting previously unselected package libxkbcommon-x11-0:amd64.
+2025-12-07T20:53:39.1147010Z Preparing to unpack .../171-libxkbcommon-x11-0_1.6.0-1build1_amd64.deb ...
+2025-12-07T20:53:39.1158096Z Unpacking libxkbcommon-x11-0:amd64 (1.6.0-1build1) ...
+2025-12-07T20:53:39.1401298Z Selecting previously unselected package libzbar0t64:amd64.
+2025-12-07T20:53:39.1536200Z Preparing to unpack .../172-libzbar0t64_0.23.93-4build3_amd64.deb ...
+2025-12-07T20:53:39.1545732Z Unpacking libzbar0t64:amd64 (0.23.93-4build3) ...
+2025-12-07T20:53:39.1803401Z Selecting previously unselected package libzxing3:amd64.
+2025-12-07T20:53:39.1942274Z Preparing to unpack .../173-libzxing3_2.2.1-3_amd64.deb ...
+2025-12-07T20:53:39.1964581Z Unpacking libzxing3:amd64 (2.2.1-3) ...
+2025-12-07T20:53:39.2241146Z Selecting previously unselected package xfonts-encodings.
+2025-12-07T20:53:39.2376433Z Preparing to unpack .../174-xfonts-encodings_1%3a1.0.5-0ubuntu2_all.deb ...
+2025-12-07T20:53:39.2387844Z Unpacking xfonts-encodings (1:1.0.5-0ubuntu2) ...
+2025-12-07T20:53:39.2713576Z Selecting previously unselected package xfonts-utils.
+2025-12-07T20:53:39.2848388Z Preparing to unpack .../175-xfonts-utils_1%3a7.7+6build3_amd64.deb ...
+2025-12-07T20:53:39.2858795Z Unpacking xfonts-utils (1:7.7+6build3) ...
+2025-12-07T20:53:39.3573268Z Selecting previously unselected package xfonts-cyrillic.
+2025-12-07T20:53:39.3708476Z Preparing to unpack .../176-xfonts-cyrillic_1%3a1.0.5+nmu1_all.deb ...
+2025-12-07T20:53:39.3718877Z Unpacking xfonts-cyrillic (1:1.0.5+nmu1) ...
+2025-12-07T20:53:39.4122959Z Selecting previously unselected package xfonts-scalable.
+2025-12-07T20:53:39.4260406Z Preparing to unpack .../177-xfonts-scalable_1%3a1.0.3-1.3_all.deb ...
+2025-12-07T20:53:39.4272150Z Unpacking xfonts-scalable (1:1.0.3-1.3) ...
+2025-12-07T20:53:39.4554028Z Selecting previously unselected package libgstreamer-plugins-bad1.0-0:amd64.
+2025-12-07T20:53:39.4690947Z Preparing to unpack .../178-libgstreamer-plugins-bad1.0-0_1.24.2-1ubuntu4_amd64.deb ...
+2025-12-07T20:53:39.4699971Z Unpacking libgstreamer-plugins-bad1.0-0:amd64 (1.24.2-1ubuntu4) ...
+2025-12-07T20:53:39.5101499Z Selecting previously unselected package libdca0:amd64.
+2025-12-07T20:53:39.5236918Z Preparing to unpack .../179-libdca0_0.0.7-2build1_amd64.deb ...
+2025-12-07T20:53:39.5248607Z Unpacking libdca0:amd64 (0.0.7-2build1) ...
+2025-12-07T20:53:39.5491917Z Selecting previously unselected package libopenal1:amd64.
+2025-12-07T20:53:39.5627299Z Preparing to unpack .../180-libopenal1_1%3a1.23.1-4build1_amd64.deb ...
+2025-12-07T20:53:39.5638114Z Unpacking libopenal1:amd64 (1:1.23.1-4build1) ...
+2025-12-07T20:53:39.5936251Z Selecting previously unselected package libsbc1:amd64.
+2025-12-07T20:53:39.6073180Z Preparing to unpack .../181-libsbc1_2.0-1build1_amd64.deb ...
+2025-12-07T20:53:39.6084069Z Unpacking libsbc1:amd64 (2.0-1build1) ...
+2025-12-07T20:53:39.6314135Z Selecting previously unselected package libvo-aacenc0:amd64.
+2025-12-07T20:53:39.6451486Z Preparing to unpack .../182-libvo-aacenc0_0.1.3-2build1_amd64.deb ...
+2025-12-07T20:53:39.6460794Z Unpacking libvo-aacenc0:amd64 (0.1.3-2build1) ...
+2025-12-07T20:53:39.6691609Z Selecting previously unselected package libvo-amrwbenc0:amd64.
+2025-12-07T20:53:39.6826757Z Preparing to unpack .../183-libvo-amrwbenc0_0.1.3-2build1_amd64.deb ...
+2025-12-07T20:53:39.6835702Z Unpacking libvo-amrwbenc0:amd64 (0.1.3-2build1) ...
+2025-12-07T20:53:39.7059616Z Selecting previously unselected package gstreamer1.0-plugins-bad:amd64.
+2025-12-07T20:53:39.7195722Z Preparing to unpack .../184-gstreamer1.0-plugins-bad_1.24.2-1ubuntu4_amd64.deb ...
+2025-12-07T20:53:39.7206202Z Unpacking gstreamer1.0-plugins-bad:amd64 (1.24.2-1ubuntu4) ...
+2025-12-07T20:53:39.8887283Z Setting up libgme0:amd64 (0.6.3-7build1) ...
+2025-12-07T20:53:39.8921166Z Setting up libchromaprint1:amd64 (1.5.1-5) ...
+2025-12-07T20:53:39.8948639Z Setting up libssh-gcrypt-4:amd64 (0.10.6-2ubuntu0.2) ...
+2025-12-07T20:53:39.8979487Z Setting up libhwy1t64:amd64 (1.0.7-8.1build1) ...
+2025-12-07T20:53:39.9007877Z Setting up libcairo-script-interpreter2:amd64 (1.18.0-3build1) ...
+2025-12-07T20:53:39.9031497Z Setting up libfreeaptx0:amd64 (0.1.1-2build1) ...
+2025-12-07T20:53:39.9058596Z Setting up libdvdread8t64:amd64 (6.1.3-1.1build1) ...
+2025-12-07T20:53:39.9083237Z Setting up libudfread0:amd64 (1.1.2-1build1) ...
+2025-12-07T20:53:39.9108540Z Setting up libmodplug1:amd64 (1:0.8.9.0-3build1) ...
+2025-12-07T20:53:39.9132662Z Setting up libcdparanoia0:amd64 (3.10.2+debian-14build3) ...
+2025-12-07T20:53:39.9167296Z Setting up libvo-amrwbenc0:amd64 (0.1.3-2build1) ...
+2025-12-07T20:53:39.9195516Z Setting up libraw1394-11:amd64 (2.1.2-2build3) ...
+2025-12-07T20:53:39.9225753Z Setting up libsbc1:amd64 (2.0-1build1) ...
+2025-12-07T20:53:39.9260379Z Setting up libneon27t64:amd64 (0.33.0-1.1build3) ...
+2025-12-07T20:53:39.9329683Z Setting up libtag1v5-vanilla:amd64 (1.13.1-1build1) ...
+2025-12-07T20:53:39.9352113Z Setting up libharfbuzz-icu0:amd64 (8.3.0-2build2) ...
+2025-12-07T20:53:39.9378173Z Setting up libopenni2-0:amd64 (2.2.0.33+dfsg-18) ...
+2025-12-07T20:53:39.9638335Z Setting up libspeex1:amd64 (1.2.1-2ubuntu2.24.04.1) ...
+2025-12-07T20:53:39.9659724Z Setting up libshine3:amd64 (3.1.1-2build1) ...
+2025-12-07T20:53:39.9688303Z Setting up libcaca0:amd64 (0.99.beta20-4build2) ...
+2025-12-07T20:53:39.9713474Z Setting up libvpl2 (2023.3.0-1build1) ...
+2025-12-07T20:53:39.9741040Z Setting up libv4lconvert0t64:amd64 (1.26.1-4build3) ...
+2025-12-07T20:53:39.9784106Z Setting up libx264-164:amd64 (2:0.164.3108+git31e19f9-1) ...
+2025-12-07T20:53:39.9822827Z Setting up libtwolame0:amd64 (0.4.0-2build3) ...
+2025-12-07T20:53:39.9851908Z Setting up libmbedcrypto7t64:amd64 (2.28.8-1) ...
+2025-12-07T20:53:39.9882063Z Setting up libwoff1:amd64 (1.0.2-2build1) ...
+2025-12-07T20:53:39.9914271Z Setting up liblc3-1:amd64 (1.0.4-3build1) ...
+2025-12-07T20:53:39.9954875Z Setting up libqrencode4:amd64 (4.1.1-1build2) ...
+2025-12-07T20:53:39.9986293Z Setting up libhyphen0:amd64 (2.8.8-7build3) ...
+2025-12-07T20:53:40.0016671Z Setting up libgsm1:amd64 (1.0.22-1build1) ...
+2025-12-07T20:53:40.0041377Z Setting up libvisual-0.4-0:amd64 (0.4.2-2build1) ...
+2025-12-07T20:53:40.0069921Z Setting up libsoxr0:amd64 (0.1.3-4build3) ...
+2025-12-07T20:53:40.0098529Z Setting up libzix-0-0:amd64 (0.4.2-2build1) ...
+2025-12-07T20:53:40.0121974Z Setting up libcodec2-1.2:amd64 (1.2.0-2build1) ...
+2025-12-07T20:53:40.0156506Z Setting up libsrtp2-1:amd64 (2.5.0-3build1) ...
+2025-12-07T20:53:40.0184079Z Setting up libmysofa1:amd64 (1.3.2+dfsg-2ubuntu2) ...
+2025-12-07T20:53:40.0213089Z Setting up libraptor2-0:amd64 (2.0.16-3ubuntu0.1) ...
+2025-12-07T20:53:40.0236944Z Setting up libldacbt-enc2:amd64 (2.0.2.3+git20200429+ed310a0-4ubuntu2) ...
+2025-12-07T20:53:40.0274303Z Setting up fonts-wqy-zenhei (0.9.45-8) ...
+2025-12-07T20:53:40.0427155Z Setting up libwebrtc-audio-processing1:amd64 (0.3.1-0ubuntu6) ...
+2025-12-07T20:53:40.0454311Z Setting up fonts-freefont-ttf (20211204+svn4273-2) ...
+2025-12-07T20:53:40.0489926Z Setting up libevent-2.1-7t64:amd64 (2.1.12-stable-9ubuntu2) ...
+2025-12-07T20:53:40.0518574Z Setting up libsvtav1enc1d1:amd64 (1.7.0+dfsg-2build1) ...
+2025-12-07T20:53:40.0542398Z Setting up libsoup-3.0-common (3.4.4-5ubuntu0.5) ...
+2025-12-07T20:53:40.0576612Z Setting up libmpg123-0t64:amd64 (1.32.5-1ubuntu1.1) ...
+2025-12-07T20:53:40.0622121Z Setting up libcjson1:amd64 (1.7.17-1) ...
+2025-12-07T20:53:40.0660349Z Setting up libxvidcore4:amd64 (2:1.3.7-1build1) ...
+2025-12-07T20:53:40.0705643Z Setting up libmpcdec6:amd64 (2:0.1~r495-2build1) ...
+2025-12-07T20:53:40.0751440Z Setting up libmjpegutils-2.1-0t64:amd64 (1:2.1.0+debian-8.1build1) ...
+2025-12-07T20:53:40.0773691Z Setting up librav1e0:amd64 (0.7.1-2) ...
+2025-12-07T20:53:40.0818394Z Setting up liborc-0.4-0t64:amd64 (1:0.4.38-1ubuntu0.1) ...
+2025-12-07T20:53:40.0844928Z Setting up libxcb-xkb1:amd64 (1.15-1ubuntu2) ...
+2025-12-07T20:53:40.0872796Z Setting up libvo-aacenc0:amd64 (0.1.3-2build1) ...
+2025-12-07T20:53:40.0910791Z Setting up librist4:amd64 (0.2.10+dfsg-2) ...
+2025-12-07T20:53:40.0940074Z Setting up libglib2.0-0t64:amd64 (2.80.0-6ubuntu3.5) ...
+2025-12-07T20:53:40.1238349Z Setting up libblas3:amd64 (3.12.0-3build1.1) ...
+2025-12-07T20:53:40.1303008Z update-alternatives: using /usr/lib/x86_64-linux-gnu/blas/libblas.so.3 to provide /usr/lib/x86_64-linux-gnu/libblas.so.3 (libblas.so.3-x86_64-linux-gnu) in auto mode
+2025-12-07T20:53:40.1324969Z Setting up libegl-mesa0:amd64 (25.0.7-0ubuntu0.24.04.2) ...
+2025-12-07T20:53:40.1347841Z Setting up libsoundtouch1:amd64 (2.3.2+ds1-1build1) ...
+2025-12-07T20:53:40.1383569Z Setting up libglib2.0-data (2.80.0-6ubuntu3.5) ...
+2025-12-07T20:53:40.1419644Z Setting up libplacebo338:amd64 (6.338.2-2build1) ...
+2025-12-07T20:53:40.1445066Z Setting up libgles2:amd64 (1.7.0-1build1) ...
+2025-12-07T20:53:40.1477224Z Setting up fonts-tlwg-loma-otf (1:0.7.3-1) ...
+2025-12-07T20:53:40.1505109Z Setting up libva2:amd64 (2.20.0-2build1) ...
+2025-12-07T20:53:40.1539326Z Setting up libspa-0.2-modules:amd64 (1.0.5-1ubuntu3.1) ...
+2025-12-07T20:53:40.1571453Z Setting up libzxing3:amd64 (2.2.1-3) ...
+2025-12-07T20:53:40.1610867Z Setting up xfonts-encodings (1:1.0.5-0ubuntu2) ...
+2025-12-07T20:53:40.1646063Z Setting up libopus0:amd64 (1.4-1build1) ...
+2025-12-07T20:53:40.1684908Z Setting up libfaad2:amd64 (2.11.1-1build1) ...
+2025-12-07T20:53:40.1730348Z Setting up libxkbcommon-x11-0:amd64 (1.6.0-1build1) ...
+2025-12-07T20:53:40.1756508Z Setting up libdc1394-25:amd64 (2.2.6-4build1) ...
+2025-12-07T20:53:40.1781592Z Setting up libimath-3-1-29t64:amd64 (3.1.9-3.1ubuntu2) ...
+2025-12-07T20:53:40.1813511Z Setting up libunibreak5:amd64 (5.1-2build1) ...
+2025-12-07T20:53:40.1848780Z Setting up libdv4t64:amd64 (1.0.0-17.1build1) ...
+2025-12-07T20:53:40.1902340Z Setting up gir1.2-glib-2.0:amd64 (2.80.0-6ubuntu3.5) ...
+2025-12-07T20:53:40.1932898Z Setting up libjxl0.7:amd64 (0.7.0-10.2ubuntu6.1) ...
+2025-12-07T20:53:40.1963800Z Setting up libssh-4:amd64 (0.10.6-2ubuntu0.2) ...
+2025-12-07T20:53:40.1997096Z Setting up libopenh264-7:amd64 (2.4.1+dfsg-1) ...
+2025-12-07T20:53:40.2027562Z Setting up libltc11:amd64 (1.3.2-1build1) ...
+2025-12-07T20:53:40.2055943Z Setting up libx265-199:amd64 (3.5-2build1) ...
+2025-12-07T20:53:40.2084658Z Setting up libv4l-0t64:amd64 (1.26.1-4build3) ...
+2025-12-07T20:53:40.2111863Z Setting up libavtp0:amd64 (0.2.0-1build1) ...
+2025-12-07T20:53:40.2139761Z Setting up libsndio7.0:amd64 (1.9.0-0.3build3) ...
+2025-12-07T20:53:40.2168801Z Setting up libdirectfb-1.7-7t64:amd64 (1.7.7-11.1ubuntu2) ...
+2025-12-07T20:53:40.2319852Z Setting up libspandsp2t64:amd64 (0.0.6+dfsg-2.1build1) ...
+2025-12-07T20:53:40.2354077Z Setting up libvidstab1.1:amd64 (1.1.0-2build1) ...
+2025-12-07T20:53:40.2381919Z Setting up libvpx9:amd64 (1.14.0-1ubuntu2.2) ...
+2025-12-07T20:53:40.2404382Z Setting up libsrt1.5-gnutls:amd64 (1.5.3-1build2) ...
+2025-12-07T20:53:40.2430900Z Setting up libtag1v5:amd64 (1.13.1-1build1) ...
+2025-12-07T20:53:40.2461598Z Setting up libflite1:amd64 (2.2-6build3) ...
+2025-12-07T20:53:40.2491892Z Setting up libdav1d7:amd64 (1.4.1-1build1) ...
+2025-12-07T20:53:40.2522335Z Setting up libva-drm2:amd64 (2.20.0-2build1) ...
+2025-12-07T20:53:40.2548214Z Setting up fonts-ipafont-gothic (00303-21ubuntu1) ...
+2025-12-07T20:53:40.2623174Z update-alternatives: using /usr/share/fonts/opentype/ipafont-gothic/ipag.ttf to provide /usr/share/fonts/truetype/fonts-japanese-gothic.ttf (fonts-japanese-gothic.ttf) in auto mode
+2025-12-07T20:53:40.2645927Z Setting up ocl-icd-libopencl1:amd64 (2.3.2-1build1) ...
+2025-12-07T20:53:40.2676016Z Setting up libasyncns0:amd64 (0.8-6build4) ...
+2025-12-07T20:53:40.2704921Z Setting up libwildmidi2:amd64 (0.4.3-1build3) ...
+2025-12-07T20:53:40.2742207Z Setting up libvdpau1:amd64 (1.5-2build1) ...
+2025-12-07T20:53:40.2788624Z Setting up libwavpack1:amd64 (5.6.0-1build1) ...
+2025-12-07T20:53:40.2817052Z Setting up libbs2b0:amd64 (3.1.0+dfsg-7build1) ...
+2025-12-07T20:53:40.2849008Z Setting up libtheora0:amd64 (1.1.1+dfsg.1-16.1build3) ...
+2025-12-07T20:53:40.2876046Z Setting up libegl1:amd64 (1.7.0-1build1) ...
+2025-12-07T20:53:40.2906424Z Setting up libdecor-0-0:amd64 (0.2.2-1build2) ...
+2025-12-07T20:53:40.2946757Z Setting up libdca0:amd64 (0.0.7-2build1) ...
+2025-12-07T20:53:40.2986249Z Setting up libzimg2:amd64 (3.0.5+ds1-1build1) ...
+2025-12-07T20:53:40.3010952Z Setting up libopenal-data (1:1.23.1-4build1) ...
+2025-12-07T20:53:40.3052005Z Setting up libabsl20220623t64:amd64 (20220623.1-3.1ubuntu3.2) ...
+2025-12-07T20:53:40.3076519Z Setting up libflac12t64:amd64 (1.4.3+ds-2.1ubuntu2) ...
+2025-12-07T20:53:40.3105352Z Setting up libgtk-4-common (4.14.5+ds-0ubuntu0.7) ...
+2025-12-07T20:53:40.3130262Z Setting up libmpeg2encpp-2.1-0t64:amd64 (1:2.1.0+debian-8.1build1) ...
+2025-12-07T20:53:40.3160409Z Setting up glib-networking-common (2.80.0-1build1) ...
+2025-12-07T20:53:40.3189856Z Setting up libmfx1:amd64 (22.5.4-1) ...
+2025-12-07T20:53:40.3213447Z Setting up libbluray2:amd64 (1:1.3.4-1build1) ...
+2025-12-07T20:53:40.3240346Z Setting up libsamplerate0:amd64 (0.2.2-4build1) ...
+2025-12-07T20:53:40.3262194Z Setting up timgm6mb-soundfont (1.3-5) ...
+2025-12-07T20:53:40.3350498Z update-alternatives: using /usr/share/sounds/sf2/TimGM6mb.sf2 to provide /usr/share/sounds/sf2/default-GM.sf2 (default-GM.sf2) in auto mode
+2025-12-07T20:53:40.3394191Z update-alternatives: using /usr/share/sounds/sf2/TimGM6mb.sf2 to provide /usr/share/sounds/sf3/default-GM.sf3 (default-GM.sf3) in auto mode
+2025-12-07T20:53:40.3418155Z Setting up libva-x11-2:amd64 (2.20.0-2build1) ...
+2025-12-07T20:53:40.3443340Z Setting up libyuv0:amd64 (0.0~git202401110.af6ac82-1) ...
+2025-12-07T20:53:40.3473127Z Setting up libmplex2-2.1-0t64:amd64 (1:2.1.0+debian-8.1build1) ...
+2025-12-07T20:53:40.3502114Z Setting up libpipewire-0.3-0t64:amd64 (1.0.5-1ubuntu3.1) ...
+2025-12-07T20:53:40.3529781Z Setting up libcups2t64:amd64 (2.4.7-1.2ubuntu7.9) ...
+2025-12-07T20:53:40.3567159Z Setting up libopenmpt0t64:amd64 (0.7.3-1.1build3) ...
+2025-12-07T20:53:40.3592693Z Setting up libzvbi-common (0.2.42-2) ...
+2025-12-07T20:53:40.3620704Z Setting up libsecret-common (0.21.4-1build3) ...
+2025-12-07T20:53:40.3655430Z Setting up libmp3lame0:amd64 (3.100-6build1) ...
+2025-12-07T20:53:40.3686471Z Setting up libgraphene-1.0-0:amd64 (1.10.8-3build2) ...
+2025-12-07T20:53:40.3713429Z Setting up libvorbisenc2:amd64 (1.3.7-1build3) ...
+2025-12-07T20:53:40.3747215Z Setting up libdvdnav4:amd64 (6.1.1-3build1) ...
+2025-12-07T20:53:40.3776239Z Setting up fonts-unifont (1:15.1.01-1build1) ...
+2025-12-07T20:53:40.3802969Z Setting up libaa1:amd64 (1.4p5-51.1) ...
+2025-12-07T20:53:40.3831406Z Setting up libiec61883-0:amd64 (1.2.0-6build1) ...
+2025-12-07T20:53:40.3862751Z Setting up libserd-0-0:amd64 (0.32.2-1) ...
+2025-12-07T20:53:40.3895029Z Setting up libavc1394-0:amd64 (0.5.4-5build3) ...
+2025-12-07T20:53:40.3919442Z Setting up session-migration (0.3.9build1) ...
+2025-12-07T20:53:40.5160649Z Created symlink /etc/systemd/user/graphical-session-pre.target.wants/session-migration.service → /usr/lib/systemd/user/session-migration.service.
+2025-12-07T20:53:40.5161251Z 
+2025-12-07T20:53:40.5192010Z Setting up liblapack3:amd64 (3.12.0-3build1.1) ...
+2025-12-07T20:53:40.5281393Z update-alternatives: using /usr/lib/x86_64-linux-gnu/lapack/liblapack.so.3 to provide /usr/lib/x86_64-linux-gnu/liblapack.so.3 (liblapack.so.3-x86_64-linux-gnu) in auto mode
+2025-12-07T20:53:40.5307026Z Setting up libproxy1v5:amd64 (0.5.4-4build1) ...
+2025-12-07T20:53:40.5335604Z Setting up libzvbi0t64:amd64 (0.2.42-2) ...
+2025-12-07T20:53:40.5374963Z Setting up liblrdf0:amd64 (0.6.1-4build1) ...
+2025-12-07T20:53:40.5407541Z Setting up libmanette-0.2-0:amd64 (0.2.7-1build2) ...
+2025-12-07T20:53:40.5440308Z Setting up libglib2.0-bin (2.80.0-6ubuntu3.5) ...
+2025-12-07T20:53:40.5474103Z Setting up libzbar0t64:amd64 (0.23.93-4build3) ...
+2025-12-07T20:53:40.5502795Z Setting up libgstreamer-plugins-base1.0-0:amd64 (1.24.2-1ubuntu0.3) ...
+2025-12-07T20:53:40.5531352Z Setting up libavutil58:amd64 (7:6.1.1-3ubuntu5) ...
+2025-12-07T20:53:40.5564009Z Setting up libopenal1:amd64 (1:1.23.1-4build1) ...
+2025-12-07T20:53:40.5591581Z Setting up xfonts-utils (1:7.7+6build3) ...
+2025-12-07T20:53:40.5644173Z Setting up librsvg2-2:amd64 (2.58.0+dfsg-1build1) ...
+2025-12-07T20:53:40.5682401Z Setting up libsecret-1-0:amd64 (0.21.4-1build3) ...
+2025-12-07T20:53:40.5713337Z Setting up libgstreamer-plugins-good1.0-0:amd64 (1.24.2-1ubuntu1.2) ...
+2025-12-07T20:53:40.5748517Z Setting up libgstreamer-gl1.0-0:amd64 (1.24.2-1ubuntu0.3) ...
+2025-12-07T20:53:40.5783610Z Setting up gstreamer1.0-plugins-base:amd64 (1.24.2-1ubuntu0.3) ...
+2025-12-07T20:53:40.5812287Z Setting up libass9:amd64 (1:0.17.1-2build1) ...
+2025-12-07T20:53:40.5841227Z Setting up libswresample4:amd64 (7:6.1.1-3ubuntu5) ...
+2025-12-07T20:53:40.5870047Z Setting up libopenexr-3-1-30:amd64 (3.1.5-5.1build3) ...
+2025-12-07T20:53:40.5902194Z Setting up libshout3:amd64 (2.4.6-1build2) ...
+2025-12-07T20:53:40.5930044Z Setting up libgav1-1:amd64 (0.18.0-1build3) ...
+2025-12-07T20:53:40.5961237Z Setting up libavcodec60:amd64 (7:6.1.1-3ubuntu5) ...
+2025-12-07T20:53:40.5998931Z Setting up librubberband2:amd64 (3.3.0+dfsg-2build1) ...
+2025-12-07T20:53:40.6026047Z Setting up libjack-jackd2-0:amd64 (1.9.21~dfsg-3ubuntu3) ...
+2025-12-07T20:53:40.6059588Z Setting up libsord-0-0:amd64 (0.16.16-2build1) ...
+2025-12-07T20:53:40.6093011Z Setting up xfonts-cyrillic (1:1.0.5+nmu1) ...
+2025-12-07T20:53:40.6548337Z Setting up libpostproc57:amd64 (7:6.1.1-3ubuntu5) ...
+2025-12-07T20:53:40.6580869Z Setting up libsratom-0-0:amd64 (0.6.16-1build1) ...
+2025-12-07T20:53:40.6611934Z Setting up libgtk-4-1:amd64 (4.14.5+ds-0ubuntu0.7) ...
+2025-12-07T20:53:40.8705092Z Setting up libsndfile1:amd64 (1.2.2-1ubuntu5.24.04.1) ...
+2025-12-07T20:53:40.8728290Z Setting up liblilv-0-0:amd64 (0.24.22-1build1) ...
+2025-12-07T20:53:40.8764242Z Setting up libinstpatch-1.0-2:amd64 (1.1.6-1build2) ...
+2025-12-07T20:53:40.8796576Z Setting up xfonts-scalable (1:1.0.3-1.3) ...
+2025-12-07T20:53:40.9241677Z Setting up libswscale7:amd64 (7:6.1.1-3ubuntu5) ...
+2025-12-07T20:53:40.9272736Z Setting up gsettings-desktop-schemas (46.1-0ubuntu1) ...
+2025-12-07T20:53:40.9312119Z Setting up glib-networking-services (2.80.0-1build1) ...
+2025-12-07T20:53:40.9335177Z Setting up libavif16:amd64 (1.0.4-1ubuntu3) ...
+2025-12-07T20:53:40.9370981Z Setting up libpulse0:amd64 (1:16.1+dfsg1-2ubuntu10.1) ...
+2025-12-07T20:53:40.9448887Z Setting up libavformat60:amd64 (7:6.1.1-3ubuntu5) ...
+2025-12-07T20:53:40.9475901Z Setting up libsphinxbase3t64:amd64 (0.8+5prealpha+1-17build2) ...
+2025-12-07T20:53:40.9516182Z Setting up glib-networking:amd64 (2.80.0-1build1) ...
+2025-12-07T20:53:40.9548481Z Setting up libsdl2-2.0-0:amd64 (2.30.0+dfsg-1ubuntu3.1) ...
+2025-12-07T20:53:40.9577459Z Setting up libfluidsynth3:amd64 (2.3.4-1build3) ...
+2025-12-07T20:53:40.9605835Z Setting up libsoup-3.0-0:amd64 (3.4.4-5ubuntu0.5) ...
+2025-12-07T20:53:40.9648484Z Setting up libpocketsphinx3:amd64 (0.8.0+real5prealpha+1-15ubuntu5) ...
+2025-12-07T20:53:40.9681184Z Setting up libgssdp-1.6-0:amd64 (1.6.3-1build3) ...
+2025-12-07T20:53:40.9729891Z Setting up gstreamer1.0-plugins-good:amd64 (1.24.2-1ubuntu1.2) ...
+2025-12-07T20:53:40.9779865Z Setting up libgupnp-1.6-0:amd64 (1.6.6-1build3) ...
+2025-12-07T20:53:40.9813132Z Setting up libavfilter9:amd64 (7:6.1.1-3ubuntu5) ...
+2025-12-07T20:53:40.9846070Z Setting up libgupnp-igd-1.6-0:amd64 (1.6.0-3build3) ...
+2025-12-07T20:53:40.9888469Z Setting up gstreamer1.0-libav:amd64 (1.24.1-1build1) ...
+2025-12-07T20:53:40.9927578Z Setting up libnice10:amd64 (0.1.21-2build3) ...
+2025-12-07T20:53:40.9973287Z Setting up libgstreamer-plugins-bad1.0-0:amd64 (1.24.2-1ubuntu4) ...
+2025-12-07T20:53:41.0013064Z Setting up gstreamer1.0-plugins-bad:amd64 (1.24.2-1ubuntu4) ...
+2025-12-07T20:53:41.0054663Z Processing triggers for libc-bin (2.39-0ubuntu8.6) ...
+2025-12-07T20:53:41.0535764Z Processing triggers for man-db (2.12.0-4build2) ...
+2025-12-07T20:53:41.0640360Z Not building database; man-db/auto-update is not 'true'.
+2025-12-07T20:53:41.0670963Z Processing triggers for fontconfig (2.15.0-1.1ubuntu2) ...
+2025-12-07T20:53:41.8032455Z 
+2025-12-07T20:53:41.8033002Z Running kernel seems to be up-to-date.
+2025-12-07T20:53:41.8033354Z 
+2025-12-07T20:53:41.8033473Z Restarting services...
+2025-12-07T20:53:41.8478286Z  systemctl restart packagekit.service php8.3-fpm.service polkit.service udisks2.service
+2025-12-07T20:53:41.9854416Z 
+2025-12-07T20:53:41.9855428Z Service restarts being deferred:
+2025-12-07T20:53:41.9856165Z  systemctl restart ModemManager.service
+2025-12-07T20:53:41.9856766Z  systemctl restart networkd-dispatcher.service
+2025-12-07T20:53:41.9857139Z 
+2025-12-07T20:53:41.9857386Z No containers need to be restarted.
+2025-12-07T20:53:41.9857852Z 
+2025-12-07T20:53:41.9858154Z No user sessions are running outdated binaries.
+2025-12-07T20:53:41.9858499Z 
+2025-12-07T20:53:41.9858989Z No VM guests are running outdated hypervisor (qemu) binaries on this host.
+2025-12-07T20:53:43.0833572Z Downloading Chromium 141.0.7390.37 (playwright build v1194) from https://cdn.playwright.dev/dbazure/download/playwright/builds/chromium/1194/chromium-linux.zip
+2025-12-07T20:53:43.3555891Z |                                                                                |   0% of 173.9 MiB
+2025-12-07T20:53:43.6155418Z |■■■■■■■■                                                                        |  10% of 173.9 MiB
+2025-12-07T20:53:43.7547463Z |■■■■■■■■■■■■■■■■                                                                |  20% of 173.9 MiB
+2025-12-07T20:53:43.8862495Z |■■■■■■■■■■■■■■■■■■■■■■■■                                                        |  30% of 173.9 MiB
+2025-12-07T20:53:44.0236857Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■                                                |  40% of 173.9 MiB
+2025-12-07T20:53:44.1561827Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■                                        |  50% of 173.9 MiB
+2025-12-07T20:53:44.2899835Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■                                |  60% of 173.9 MiB
+2025-12-07T20:53:44.4328503Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■                        |  70% of 173.9 MiB
+2025-12-07T20:53:44.5896031Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■                |  80% of 173.9 MiB
+2025-12-07T20:53:44.8075549Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■        |  90% of 173.9 MiB
+2025-12-07T20:53:44.9407284Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■| 100% of 173.9 MiB
+2025-12-07T20:53:48.3213039Z Chromium 141.0.7390.37 (playwright build v1194) downloaded to /home/runner/.cache/ms-playwright/chromium-1194
+2025-12-07T20:53:48.3217014Z Downloading Chromium Headless Shell 141.0.7390.37 (playwright build v1194) from https://cdn.playwright.dev/dbazure/download/playwright/builds/chromium/1194/chromium-headless-shell-linux.zip
+2025-12-07T20:53:48.4898754Z |                                                                                |   0% of 104.3 MiB
+2025-12-07T20:53:48.6098569Z |■■■■■■■■                                                                        |  10% of 104.3 MiB
+2025-12-07T20:53:48.6672340Z |■■■■■■■■■■■■■■■■                                                                |  20% of 104.3 MiB
+2025-12-07T20:53:48.7221760Z |■■■■■■■■■■■■■■■■■■■■■■■■                                                        |  30% of 104.3 MiB
+2025-12-07T20:53:48.7691973Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■                                                |  40% of 104.3 MiB
+2025-12-07T20:53:48.8063564Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■                                        |  50% of 104.3 MiB
+2025-12-07T20:53:48.8541218Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■                                |  60% of 104.3 MiB
+2025-12-07T20:53:48.9016919Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■                        |  70% of 104.3 MiB
+2025-12-07T20:53:48.9455778Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■                |  80% of 104.3 MiB
+2025-12-07T20:53:48.9873996Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■        |  90% of 104.3 MiB
+2025-12-07T20:53:49.0276911Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■| 100% of 104.3 MiB
+2025-12-07T20:53:50.7412269Z Chromium Headless Shell 141.0.7390.37 (playwright build v1194) downloaded to /home/runner/.cache/ms-playwright/chromium_headless_shell-1194
+2025-12-07T20:53:50.7416142Z Downloading Firefox 142.0.1 (playwright build v1495) from https://cdn.playwright.dev/dbazure/download/playwright/builds/firefox/1495/firefox-ubuntu-24.04.zip
+2025-12-07T20:53:50.9485358Z |                                                                                |   0% of 96.7 MiB
+2025-12-07T20:53:51.1748324Z |■■■■■■■■                                                                        |  10% of 96.7 MiB
+2025-12-07T20:53:51.2600798Z |■■■■■■■■■■■■■■■■                                                                |  20% of 96.7 MiB
+2025-12-07T20:53:51.3509871Z |■■■■■■■■■■■■■■■■■■■■■■■■                                                        |  30% of 96.7 MiB
+2025-12-07T20:53:51.4432782Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■                                                |  40% of 96.7 MiB
+2025-12-07T20:53:51.5292175Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■                                        |  50% of 96.7 MiB
+2025-12-07T20:53:51.6100946Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■                                |  60% of 96.7 MiB
+2025-12-07T20:53:51.6926878Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■                        |  70% of 96.7 MiB
+2025-12-07T20:53:51.7812957Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■                |  80% of 96.7 MiB
+2025-12-07T20:53:51.8789605Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■        |  90% of 96.7 MiB
+2025-12-07T20:53:52.0179543Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■| 100% of 96.7 MiB
+2025-12-07T20:53:53.6092310Z Firefox 142.0.1 (playwright build v1495) downloaded to /home/runner/.cache/ms-playwright/firefox-1495
+2025-12-07T20:53:53.6096266Z Downloading Webkit 26.0 (playwright build v2215) from https://cdn.playwright.dev/dbazure/download/playwright/builds/webkit/2215/webkit-ubuntu-24.04.zip
+2025-12-07T20:53:53.7938917Z |                                                                                |   0% of 94.6 MiB
+2025-12-07T20:53:53.9790071Z |■■■■■■■■                                                                        |  10% of 94.6 MiB
+2025-12-07T20:53:54.0966891Z |■■■■■■■■■■■■■■■■                                                                |  20% of 94.6 MiB
+2025-12-07T20:53:54.1838479Z |■■■■■■■■■■■■■■■■■■■■■■■■                                                        |  30% of 94.6 MiB
+2025-12-07T20:53:54.2581152Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■                                                |  40% of 94.6 MiB
+2025-12-07T20:53:54.4063582Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■                                        |  50% of 94.6 MiB
+2025-12-07T20:53:54.6692970Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■                                |  60% of 94.6 MiB
+2025-12-07T20:53:54.7481065Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■                        |  70% of 94.6 MiB
+2025-12-07T20:53:54.8977422Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■                |  80% of 94.6 MiB
+2025-12-07T20:53:55.1392295Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■        |  90% of 94.6 MiB
+2025-12-07T20:53:55.2686017Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■| 100% of 94.6 MiB
+2025-12-07T20:53:56.8715241Z Webkit 26.0 (playwright build v2215) downloaded to /home/runner/.cache/ms-playwright/webkit-2215
+2025-12-07T20:53:56.8719513Z Downloading FFMPEG playwright build v1011 from https://cdn.playwright.dev/dbazure/download/playwright/builds/ffmpeg/1011/ffmpeg-linux.zip
+2025-12-07T20:53:57.0988914Z |                                                                                |   0% of 2.3 MiB
+2025-12-07T20:53:57.1503160Z |■■■■■■■■                                                                        |  10% of 2.3 MiB
+2025-12-07T20:53:57.1720738Z |■■■■■■■■■■■■■■■■                                                                |  20% of 2.3 MiB
+2025-12-07T20:53:57.1863028Z |■■■■■■■■■■■■■■■■■■■■■■■■                                                        |  30% of 2.3 MiB
+2025-12-07T20:53:57.1953489Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■                                                |  40% of 2.3 MiB
+2025-12-07T20:53:57.2027175Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■                                        |  50% of 2.3 MiB
+2025-12-07T20:53:57.2087112Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■                                |  60% of 2.3 MiB
+2025-12-07T20:53:57.2164164Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■                        |  70% of 2.3 MiB
+2025-12-07T20:53:57.2204371Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■                |  80% of 2.3 MiB
+2025-12-07T20:53:57.2244662Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■        |  90% of 2.3 MiB
+2025-12-07T20:53:57.2274443Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■| 100% of 2.3 MiB
+2025-12-07T20:53:57.2811652Z FFMPEG playwright build v1011 downloaded to /home/runner/.cache/ms-playwright/ffmpeg-1011
+2025-12-07T20:53:57.7002069Z ##[group]Run npx tsc --noEmit
+2025-12-07T20:53:57.7002366Z [36;1mnpx tsc --noEmit[0m
+2025-12-07T20:53:57.7035070Z shell: /usr/bin/bash -e {0}
+2025-12-07T20:53:57.7035308Z ##[endgroup]
+2025-12-07T20:53:59.2571938Z ##[group]Run npx playwright test --grep "@critical" --reporter=html
+2025-12-07T20:53:59.2572408Z [36;1mnpx playwright test --grep "@critical" --reporter=html[0m
+2025-12-07T20:53:59.2604400Z shell: /usr/bin/bash -e {0}
+2025-12-07T20:53:59.2604630Z env:
+2025-12-07T20:53:59.2604794Z   CI: true
+2025-12-07T20:53:59.2604959Z ##[endgroup]
+2025-12-07T20:54:02.5442816Z 
+2025-12-07T20:54:02.5443386Z Running 20 tests using 1 worker
+2025-12-07T20:54:07.9340000Z ····Course link href: /myFreecodecampLearning/pages/s100101-Certified-Full-Stack-Developer-Curriculum/Home-Certified-Full-Stack-Developer-Curriculum.html
+2025-12-07T20:54:07.9664091Z Navigation response status: [33m200[39m
+2025-12-07T20:54:07.9665307Z Navigation URL: http://localhost:4000/myFreecodecampLearning/pages/s100101-Certified-Full-Stack-Developer-Curriculum/Home-Certified-Full-Stack-Developer-Curriculum.html
+2025-12-07T20:54:14.6324540Z ·····Course link href: /myFreecodecampLearning/pages/s100101-Certified-Full-Stack-Developer-Curriculum/Home-Certified-Full-Stack-Developer-Curriculum.html
+2025-12-07T20:54:14.6959036Z Navigation response status: [33m200[39m
+2025-12-07T20:54:14.6962132Z Navigation URL: http://localhost:4000/myFreecodecampLearning/pages/s100101-Certified-Full-Stack-Developer-Curriculum/Home-Certified-Full-Stack-Developer-Curriculum.html
+2025-12-07T20:54:24.3702215Z ·····Course link href: /myFreecodecampLearning/pages/s100101-Certified-Full-Stack-Developer-Curriculum/Home-Certified-Full-Stack-Developer-Curriculum.html
+2025-12-07T20:54:24.4139042Z Navigation response status: [33m200[39m
+2025-12-07T20:54:24.4140871Z Navigation URL: http://localhost:4000/myFreecodecampLearning/pages/s100101-Certified-Full-Stack-Developer-Curriculum/Home-Certified-Full-Stack-Developer-Curriculum.html
+2025-12-07T20:54:38.6812044Z ·····Course link href: /myFreecodecampLearning/pages/s100101-Certified-Full-Stack-Developer-Curriculum/Home-Certified-Full-Stack-Developer-Curriculum.html
+2025-12-07T20:54:38.7369743Z Navigation response status: [33m200[39m
+2025-12-07T20:54:38.7371874Z Navigation URL: http://localhost:4000/myFreecodecampLearning/pages/s100101-Certified-Full-Stack-Developer-Curriculum/Home-Certified-Full-Stack-Developer-Curriculum.html
+2025-12-07T20:54:46.2529830Z ·
+2025-12-07T20:54:46.2534990Z   20 passed (45.8s)
+2025-12-07T20:54:46.2978294Z ##[group]Run actions/upload-artifact@v4
+2025-12-07T20:54:46.2978587Z with:
+2025-12-07T20:54:46.2978832Z   name: playwright-report-production-pre-deployment
+2025-12-07T20:54:46.2979150Z   path: playwright-report/
+2025-12-07T20:54:46.2979366Z   retention-days: 7
+2025-12-07T20:54:46.2979575Z   if-no-files-found: warn
+2025-12-07T20:54:46.2979802Z   compression-level: 6
+2025-12-07T20:54:46.2980001Z   overwrite: false
+2025-12-07T20:54:46.2980377Z   include-hidden-files: false
+2025-12-07T20:54:46.2980597Z ##[endgroup]
+2025-12-07T20:54:46.5188791Z With the provided path, there will be 1 file uploaded
+2025-12-07T20:54:46.5194915Z Artifact name is valid!
+2025-12-07T20:54:46.5195582Z Root directory input is valid!
+2025-12-07T20:54:46.7177347Z Beginning upload of artifact content to blob storage
+2025-12-07T20:54:46.9736139Z Uploaded bytes 203042
+2025-12-07T20:54:47.0136889Z Finished uploading artifact content to blob storage!
+2025-12-07T20:54:47.0140545Z SHA256 digest of uploaded artifact zip is 50685883bca1bb31ffb63a0df7d511bc2d3e86026838412d9bb0c7a565fcc65a
+2025-12-07T20:54:47.0142103Z Finalizing artifact upload
+2025-12-07T20:54:47.1070794Z Artifact playwright-report-production-pre-deployment.zip successfully finalized. Artifact ID 4791433946
+2025-12-07T20:54:47.1072772Z Artifact playwright-report-production-pre-deployment has been successfully uploaded! Final size is 203042 bytes. Artifact ID is 4791433946
+2025-12-07T20:54:47.1079780Z Artifact download URL: https://github.com/T193R-W00D5/myFreecodecampLearning/actions/runs/20010170515/artifacts/4791433946
+2025-12-07T20:54:47.1208307Z Post job cleanup.
+2025-12-07T20:54:47.2749091Z Cache hit occurred on the primary key node-cache-Linux-x64-npm-e3fade3f30968ac95fccac45edc85cd25eaa881f6a1cdb7268c834223e952c45, not saving cache.
+2025-12-07T20:54:47.2852396Z Post job cleanup.
+2025-12-07T20:54:47.3808513Z [command]/usr/bin/git version
+2025-12-07T20:54:47.3845280Z git version 2.52.0
+2025-12-07T20:54:47.3891232Z Temporarily overriding HOME='/home/runner/work/_temp/a38d47d4-b448-4254-b134-89f05015f907' before making global git config changes
+2025-12-07T20:54:47.3892756Z Adding repository directory to the temporary git global config as a safe directory
+2025-12-07T20:54:47.3898073Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/myFreecodecampLearning/myFreecodecampLearning
+2025-12-07T20:54:47.3935966Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+2025-12-07T20:54:47.3969707Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+2025-12-07T20:54:47.4202646Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+2025-12-07T20:54:47.4223247Z http.https://github.com/.extraheader
+2025-12-07T20:54:47.4235564Z [command]/usr/bin/git config --local --unset-all http.https://github.com/.extraheader
+2025-12-07T20:54:47.4265517Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+2025-12-07T20:54:47.4500287Z [command]/usr/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+2025-12-07T20:54:47.4532518Z [command]/usr/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+2025-12-07T20:54:47.4869545Z Cleaning up orphan processes
+# job=deploy-production
+2025-12-07T20:54:52.1177057Z Current runner version: '2.329.0'
+2025-12-07T20:54:52.1210159Z ##[group]Runner Image Provisioner
+2025-12-07T20:54:52.1211285Z Hosted Compute Agent
+2025-12-07T20:54:52.1212165Z Version: 20251124.448
+2025-12-07T20:54:52.1213306Z Commit: fda5086b43ec66ade217e5fcd18146c879571177
+2025-12-07T20:54:52.1214515Z Build Date: 2025-11-24T21:16:26Z
+2025-12-07T20:54:52.1215529Z ##[endgroup]
+2025-12-07T20:54:52.1216471Z ##[group]Operating System
+2025-12-07T20:54:52.1217500Z Ubuntu
+2025-12-07T20:54:52.1218261Z 24.04.3
+2025-12-07T20:54:52.1219334Z LTS
+2025-12-07T20:54:52.1220112Z ##[endgroup]
+2025-12-07T20:54:52.1220987Z ##[group]Runner Image
+2025-12-07T20:54:52.1222096Z Image: ubuntu-24.04
+2025-12-07T20:54:52.1222947Z Version: 20251126.144.1
+2025-12-07T20:54:52.1224747Z Included Software: https://github.com/actions/runner-images/blob/ubuntu24/20251126.144/images/ubuntu/Ubuntu2404-Readme.md
+2025-12-07T20:54:52.1227543Z Image Release: https://github.com/actions/runner-images/releases/tag/ubuntu24%2F20251126.144
+2025-12-07T20:54:52.1229516Z ##[endgroup]
+2025-12-07T20:54:52.1234095Z ##[group]GITHUB_TOKEN Permissions
+2025-12-07T20:54:52.1237092Z Actions: write
+2025-12-07T20:54:52.1238154Z ArtifactMetadata: write
+2025-12-07T20:54:52.1239445Z Attestations: write
+2025-12-07T20:54:52.1240344Z Checks: write
+2025-12-07T20:54:52.1241337Z Contents: write
+2025-12-07T20:54:52.1242153Z Deployments: write
+2025-12-07T20:54:52.1243021Z Discussions: write
+2025-12-07T20:54:52.1243816Z Issues: write
+2025-12-07T20:54:52.1244643Z Metadata: read
+2025-12-07T20:54:52.1245426Z Models: read
+2025-12-07T20:54:52.1246295Z Packages: write
+2025-12-07T20:54:52.1247093Z Pages: write
+2025-12-07T20:54:52.1247859Z PullRequests: write
+2025-12-07T20:54:52.1249065Z RepositoryProjects: write
+2025-12-07T20:54:52.1250119Z SecurityEvents: write
+2025-12-07T20:54:52.1250973Z Statuses: write
+2025-12-07T20:54:52.1251752Z ##[endgroup]
+2025-12-07T20:54:52.1254697Z Secret source: Actions
+2025-12-07T20:54:52.1255796Z Prepare workflow directory
+2025-12-07T20:54:52.1700926Z Prepare all required actions
+2025-12-07T20:54:52.1755444Z Getting action download info
+2025-12-07T20:54:52.4813465Z Download action repository 'actions/checkout@v4' (SHA:34e114876b0b11c390a56381ad16ebd13914f8d5)
+2025-12-07T20:54:52.7076497Z Download action repository 'ruby/setup-ruby@v1' (SHA:d697be2f83c6234b20877c3b5eac7a7f342f0d0c)
+2025-12-07T20:54:52.8936094Z Download action repository 'peaceiris/actions-gh-pages@v4' (SHA:4f9cc6602d3f66b9c108549d475ec49e8ef4d45e)
+2025-12-07T20:54:53.1515777Z Complete job name: deploy-production
+2025-12-07T20:54:53.2335939Z ##[group]Run actions/checkout@v4
+2025-12-07T20:54:53.2337178Z with:
+2025-12-07T20:54:53.2337816Z   ref: main
+2025-12-07T20:54:53.2338615Z   repository: T193R-W00D5/myFreecodecampLearning
+2025-12-07T20:54:53.2340082Z   token: ***
+2025-12-07T20:54:53.2340760Z   ssh-strict: true
+2025-12-07T20:54:53.2341452Z   ssh-user: git
+2025-12-07T20:54:53.2342166Z   persist-credentials: true
+2025-12-07T20:54:53.2342980Z   clean: true
+2025-12-07T20:54:53.2343705Z   sparse-checkout-cone-mode: true
+2025-12-07T20:54:53.2344620Z   fetch-depth: 1
+2025-12-07T20:54:53.2345306Z   fetch-tags: false
+2025-12-07T20:54:53.2346029Z   show-progress: true
+2025-12-07T20:54:53.2346768Z   lfs: false
+2025-12-07T20:54:53.2347424Z   submodules: false
+2025-12-07T20:54:53.2348175Z   set-safe-directory: true
+2025-12-07T20:54:53.2349363Z ##[endgroup]
+2025-12-07T20:54:53.3459069Z Syncing repository: T193R-W00D5/myFreecodecampLearning
+2025-12-07T20:54:53.3462720Z ##[group]Getting Git version info
+2025-12-07T20:54:53.3464457Z Working directory is '/home/runner/work/myFreecodecampLearning/myFreecodecampLearning'
+2025-12-07T20:54:53.3466625Z [command]/usr/bin/git version
+2025-12-07T20:54:53.3515225Z git version 2.52.0
+2025-12-07T20:54:53.3542704Z ##[endgroup]
+2025-12-07T20:54:53.3558618Z Temporarily overriding HOME='/home/runner/work/_temp/8ee3b0d6-240f-4d71-a630-ffd8a91f755b' before making global git config changes
+2025-12-07T20:54:53.3563602Z Adding repository directory to the temporary git global config as a safe directory
+2025-12-07T20:54:53.3572948Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/myFreecodecampLearning/myFreecodecampLearning
+2025-12-07T20:54:53.3616714Z Deleting the contents of '/home/runner/work/myFreecodecampLearning/myFreecodecampLearning'
+2025-12-07T20:54:53.3621019Z ##[group]Initializing the repository
+2025-12-07T20:54:53.3625677Z [command]/usr/bin/git init /home/runner/work/myFreecodecampLearning/myFreecodecampLearning
+2025-12-07T20:54:53.3721606Z hint: Using 'master' as the name for the initial branch. This default branch name
+2025-12-07T20:54:53.3723823Z hint: will change to "main" in Git 3.0. To configure the initial branch name
+2025-12-07T20:54:53.3726381Z hint: to use in all of your new repositories, which will suppress this warning,
+2025-12-07T20:54:53.3728815Z hint: call:
+2025-12-07T20:54:53.3730206Z hint:
+2025-12-07T20:54:53.3731747Z hint: 	git config --global init.defaultBranch <name>
+2025-12-07T20:54:53.3733639Z hint:
+2025-12-07T20:54:53.3735415Z hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
+2025-12-07T20:54:53.3738592Z hint: 'development'. The just-created branch can be renamed via this command:
+2025-12-07T20:54:53.3741250Z hint:
+2025-12-07T20:54:53.3742343Z hint: 	git branch -m <name>
+2025-12-07T20:54:53.3743696Z hint:
+2025-12-07T20:54:53.3745024Z hint: Disable this message with "git config set advice.defaultBranchName false"
+2025-12-07T20:54:53.3747394Z Initialized empty Git repository in /home/runner/work/myFreecodecampLearning/myFreecodecampLearning/.git/
+2025-12-07T20:54:53.3752990Z [command]/usr/bin/git remote add origin https://github.com/T193R-W00D5/myFreecodecampLearning
+2025-12-07T20:54:53.3773417Z ##[endgroup]
+2025-12-07T20:54:53.3775670Z ##[group]Disabling automatic garbage collection
+2025-12-07T20:54:53.3777831Z [command]/usr/bin/git config --local gc.auto 0
+2025-12-07T20:54:53.3806622Z ##[endgroup]
+2025-12-07T20:54:53.3808721Z ##[group]Setting up auth
+2025-12-07T20:54:53.3814221Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+2025-12-07T20:54:53.3846136Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+2025-12-07T20:54:53.4213133Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+2025-12-07T20:54:53.4243282Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+2025-12-07T20:54:53.4458050Z [command]/usr/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+2025-12-07T20:54:53.4486475Z [command]/usr/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+2025-12-07T20:54:53.4714685Z [command]/usr/bin/git config --local http.https://github.com/.extraheader AUTHORIZATION: basic ***
+2025-12-07T20:54:53.4748763Z ##[endgroup]
+2025-12-07T20:54:53.4750341Z ##[group]Fetching the repository
+2025-12-07T20:54:53.4757968Z [command]/usr/bin/git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +refs/heads/main*:refs/remotes/origin/main* +refs/tags/main*:refs/tags/main*
+2025-12-07T20:54:53.7290492Z From https://github.com/T193R-W00D5/myFreecodecampLearning
+2025-12-07T20:54:53.7291912Z  * [new branch]      main       -> origin/main
+2025-12-07T20:54:53.7322705Z ##[endgroup]
+2025-12-07T20:54:53.7324773Z ##[group]Determining the checkout info
+2025-12-07T20:54:53.7329841Z [command]/usr/bin/git branch --list --remote origin/main
+2025-12-07T20:54:53.7352485Z   origin/main
+2025-12-07T20:54:53.7357874Z ##[endgroup]
+2025-12-07T20:54:53.7361369Z [command]/usr/bin/git sparse-checkout disable
+2025-12-07T20:54:53.7397864Z [command]/usr/bin/git config --local --unset-all extensions.worktreeConfig
+2025-12-07T20:54:53.7423306Z ##[group]Checking out the ref
+2025-12-07T20:54:53.7426210Z [command]/usr/bin/git checkout --progress --force -B main refs/remotes/origin/main
+2025-12-07T20:54:53.7750806Z Switched to a new branch 'main'
+2025-12-07T20:54:53.7753443Z branch 'main' set up to track 'origin/main'.
+2025-12-07T20:54:53.7763371Z ##[endgroup]
+2025-12-07T20:54:53.7795480Z [command]/usr/bin/git log -1 --format=%H
+2025-12-07T20:54:53.7816307Z 56eaffe66dbbb15d766743e78067cb82f61dfdc6
+2025-12-07T20:54:53.8006484Z ##[group]Run echo "📦 PRODUCTION DEPLOYMENT" >> $GITHUB_STEP_SUMMARY
+2025-12-07T20:54:53.8008155Z [36;1mecho "📦 PRODUCTION DEPLOYMENT" >> $GITHUB_STEP_SUMMARY[0m
+2025-12-07T20:54:53.8010063Z [36;1mecho "**Commit being deployed:** $(git rev-parse HEAD)" >> $GITHUB_STEP_SUMMARY[0m
+2025-12-07T20:54:53.8011928Z [36;1mecho "**Commit details:** $(git log --oneline -n 1)" >> $GITHUB_STEP_SUMMARY[0m
+2025-12-07T20:54:53.8049145Z shell: /usr/bin/bash -e {0}
+2025-12-07T20:54:53.8050066Z ##[endgroup]
+2025-12-07T20:54:53.8271448Z ##[group]Run ruby/setup-ruby@v1
+2025-12-07T20:54:53.8272364Z with:
+2025-12-07T20:54:53.8273030Z   ruby-version: 3.3
+2025-12-07T20:54:53.8273779Z   bundler-cache: false
+2025-12-07T20:54:53.8274539Z ##[endgroup]
+2025-12-07T20:54:54.0151314Z ##[group]Modifying PATH
+2025-12-07T20:54:54.0155847Z Entries added to PATH to use selected Ruby:
+2025-12-07T20:54:54.0160027Z   /opt/hostedtoolcache/Ruby/3.3.10/x64/bin
+2025-12-07T20:54:54.0167758Z ##[endgroup]
+2025-12-07T20:54:54.0170285Z ##[group]Print Ruby version
+2025-12-07T20:54:54.0293261Z [command]/opt/hostedtoolcache/Ruby/3.3.10/x64/bin/ruby --version
+2025-12-07T20:54:54.2414000Z ruby 3.3.10 (2025-10-23 revision 343ea05002) [x86_64-linux]
+2025-12-07T20:54:54.2446253Z Took   0.23 seconds
+2025-12-07T20:54:54.2448788Z ##[endgroup]
+2025-12-07T20:54:54.2451318Z ##[group]Installing Bundler
+2025-12-07T20:54:54.2455896Z Using Bundler 2.7.2 from Gemfile.lock BUNDLED WITH 2.7.2
+2025-12-07T20:54:54.2461103Z [command]/opt/hostedtoolcache/Ruby/3.3.10/x64/bin/gem install bundler -v 2.7.2
+2025-12-07T20:54:55.4538706Z Successfully installed bundler-2.7.2
+2025-12-07T20:54:55.4540675Z 1 gem installed
+2025-12-07T20:54:55.4591022Z Took   1.21 seconds
+2025-12-07T20:54:55.4592399Z ##[endgroup]
+2025-12-07T20:54:55.4675367Z ##[group]Run rm -rf _site
+2025-12-07T20:54:55.4675743Z [36;1mrm -rf _site[0m
+2025-12-07T20:54:55.4676029Z [36;1mrm -rf .sass-cache[0m
+2025-12-07T20:54:55.4676443Z [36;1mecho "Cleaned existing build artifacts" >> $GITHUB_STEP_SUMMARY[0m
+2025-12-07T20:54:55.4713714Z shell: /usr/bin/bash -e {0}
+2025-12-07T20:54:55.4714042Z ##[endgroup]
+2025-12-07T20:54:55.4886730Z ##[group]Run bundle config set --local frozen false
+2025-12-07T20:54:55.4887228Z [36;1mbundle config set --local frozen false[0m
+2025-12-07T20:54:55.4887597Z [36;1mbundle install[0m
+2025-12-07T20:54:55.4887878Z [36;1m[0m
+2025-12-07T20:54:55.4888155Z [36;1m# Debug Jekyll environment[0m
+2025-12-07T20:54:55.4888642Z [36;1mecho "Jekyll version: $(bundle exec jekyll --version)" >> $GITHUB_STEP_SUMMARY[0m
+2025-12-07T20:54:55.4889561Z [36;1mecho "Ruby version: $(ruby --version)" >> $GITHUB_STEP_SUMMARY[0m
+2025-12-07T20:54:55.4890112Z [36;1mecho "Bundler version: $(bundle --version)" >> $GITHUB_STEP_SUMMARY[0m
+2025-12-07T20:54:55.4890640Z [36;1mecho "Current directory: $(pwd)" >> $GITHUB_STEP_SUMMARY[0m
+2025-12-07T20:54:55.4891249Z [36;1mecho "Config file exists: $(test -f _config.yml && echo 'YES' || echo 'NO')" >> $GITHUB_STEP_SUMMARY[0m
+2025-12-07T20:54:55.4891759Z [36;1m[0m
+2025-12-07T20:54:55.4892017Z [36;1m# Show config before build[0m
+2025-12-07T20:54:55.4892474Z [36;1mecho "Jekyll config baseurl before build:" >> $GITHUB_STEP_SUMMARY[0m
+2025-12-07T20:54:55.4893120Z [36;1mgrep "baseurl:" _config.yml >> $GITHUB_STEP_SUMMARY || echo "No baseurl in config" >> $GITHUB_STEP_SUMMARY[0m
+2025-12-07T20:54:55.4893648Z [36;1m[0m
+2025-12-07T20:54:55.4893955Z [36;1m# Build with production baseurl and verbose output[0m
+2025-12-07T20:54:55.4894471Z [36;1mecho "Starting Jekyll build with verbose output..." >> $GITHUB_STEP_SUMMARY[0m
+2025-12-07T20:54:55.4895354Z [36;1mbundle exec jekyll build --baseurl "/myFreecodecampLearning" --verbose --trace[0m
+2025-12-07T20:54:55.4895833Z [36;1m[0m
+2025-12-07T20:54:55.4896270Z [36;1mecho "Jekyll production build completed. Contents of _site:" >> $GITHUB_STEP_SUMMARY[0m
+2025-12-07T20:54:55.4896829Z [36;1mls -la _site/ >> $GITHUB_STEP_SUMMARY[0m
+2025-12-07T20:54:55.4897159Z [36;1m[0m
+2025-12-07T20:54:55.4897490Z [36;1mecho "Full generated index.html:" >> $GITHUB_STEP_SUMMARY[0m
+2025-12-07T20:54:55.4897938Z [36;1mcat _site/index.html >> $GITHUB_STEP_SUMMARY[0m
+2025-12-07T20:54:55.4898282Z [36;1m[0m
+2025-12-07T20:54:55.4898654Z [36;1mecho "Checking for Liquid syntax in generated files:" >> $GITHUB_STEP_SUMMARY[0m
+2025-12-07T20:54:55.4899559Z [36;1mgrep -n "{{" _site/index.html || echo "✅ No unprocessed Liquid syntax found" >> $GITHUB_STEP_SUMMARY[0m
+2025-12-07T20:54:55.4900068Z [36;1m[0m
+2025-12-07T20:54:55.4900404Z [36;1mecho "Checking navigation links:" >> $GITHUB_STEP_SUMMARY[0m
+2025-12-07T20:54:55.4901093Z [36;1mgrep -n "href.*pages" _site/index.html >> $GITHUB_STEP_SUMMARY || echo "No page links found" >> $GITHUB_STEP_SUMMARY[0m
+2025-12-07T20:54:55.4933295Z shell: /usr/bin/bash -e {0}
+2025-12-07T20:54:55.4933619Z ##[endgroup]
+2025-12-07T20:54:57.4163422Z Fetching gem metadata from https://rubygems.org/..........
+2025-12-07T20:54:57.4210970Z Fetching rake 13.3.1
+2025-12-07T20:54:57.4840068Z Installing rake 13.3.1
+2025-12-07T20:54:57.4984168Z Fetching public_suffix 7.0.0
+2025-12-07T20:54:57.4987594Z Fetching base64 0.3.0
+2025-12-07T20:54:57.4987982Z Fetching bigdecimal 3.3.1
+2025-12-07T20:54:57.4988377Z Fetching colorator 1.1.0
+2025-12-07T20:54:57.5070265Z Installing base64 0.3.0
+2025-12-07T20:54:57.5125497Z Installing public_suffix 7.0.0
+2025-12-07T20:54:57.5156461Z Installing colorator 1.1.0
+2025-12-07T20:54:57.5209596Z Fetching concurrent-ruby 1.3.5
+2025-12-07T20:54:57.5236584Z Installing bigdecimal 3.3.1 with native extensions
+2025-12-07T20:54:57.5314221Z Fetching csv 3.3.5
+2025-12-07T20:54:57.5438232Z Installing csv 3.3.5
+2025-12-07T20:54:57.5470469Z Fetching eventmachine 1.2.7
+2025-12-07T20:54:57.5723698Z Installing concurrent-ruby 1.3.5
+2025-12-07T20:54:57.5866061Z Installing eventmachine 1.2.7 with native extensions
+2025-12-07T20:54:57.6252309Z Fetching http_parser.rb 0.8.0
+2025-12-07T20:54:57.6554229Z Installing http_parser.rb 0.8.0 with native extensions
+2025-12-07T20:54:57.7538477Z Fetching ffi 1.17.2 (x86_64-linux-gnu)
+2025-12-07T20:54:57.7933470Z Installing ffi 1.17.2 (x86_64-linux-gnu)
+2025-12-07T20:54:57.8638058Z Fetching forwardable-extended 2.6.0
+2025-12-07T20:54:57.8687825Z Installing forwardable-extended 2.6.0
+2025-12-07T20:54:57.8723375Z Fetching rb-fsevent 0.11.2
+2025-12-07T20:54:57.8917168Z Installing rb-fsevent 0.11.2
+2025-12-07T20:54:57.9035879Z Fetching json 2.17.1
+2025-12-07T20:54:57.9139768Z Installing json 2.17.1 with native extensions
+2025-12-07T20:54:59.5101424Z Fetching liquid 4.0.4
+2025-12-07T20:54:59.5272755Z Installing liquid 4.0.4
+2025-12-07T20:54:59.5873741Z Fetching mercenary 0.4.0
+2025-12-07T20:54:59.6187201Z Installing mercenary 0.4.0
+2025-12-07T20:54:59.6323833Z Fetching rouge 4.6.1
+2025-12-07T20:54:59.6681260Z Installing rouge 4.6.1
+2025-12-07T20:54:59.8223365Z Fetching safe_yaml 1.0.5
+2025-12-07T20:54:59.8321882Z Installing safe_yaml 1.0.5
+2025-12-07T20:54:59.8516553Z Fetching unicode-display_width 2.6.0
+2025-12-07T20:54:59.8571375Z Installing unicode-display_width 2.6.0
+2025-12-07T20:54:59.8620749Z Fetching webrick 1.9.2
+2025-12-07T20:54:59.8696071Z Installing webrick 1.9.2
+2025-12-07T20:54:59.8933251Z Fetching addressable 2.8.8
+2025-12-07T20:54:59.9039617Z Installing addressable 2.8.8
+2025-12-07T20:54:59.9189859Z Fetching i18n 1.14.7
+2025-12-07T20:54:59.9267670Z Installing i18n 1.14.7
+2025-12-07T20:54:59.9429564Z Fetching rb-inotify 0.11.1
+2025-12-07T20:54:59.9483574Z Installing rb-inotify 0.11.1
+2025-12-07T20:54:59.9551415Z Fetching pathutil 0.16.2
+2025-12-07T20:54:59.9619348Z Installing pathutil 0.16.2
+2025-12-07T20:54:59.9657140Z Fetching kramdown 2.5.1
+2025-12-07T20:54:59.9822931Z Installing kramdown 2.5.1
+2025-12-07T20:55:00.1159728Z Fetching terminal-table 3.0.2
+2025-12-07T20:55:00.1227309Z Installing terminal-table 3.0.2
+2025-12-07T20:55:00.1313465Z Fetching listen 3.9.0
+2025-12-07T20:55:00.1374565Z Installing listen 3.9.0
+2025-12-07T20:55:00.1490736Z Fetching kramdown-parser-gfm 1.1.0
+2025-12-07T20:55:00.1569435Z Installing kramdown-parser-gfm 1.1.0
+2025-12-07T20:55:00.1650772Z Fetching jekyll-watch 2.2.1
+2025-12-07T20:55:00.1722883Z Installing jekyll-watch 2.2.1
+2025-12-07T20:55:07.0896999Z Fetching google-protobuf 4.33.1 (x86_64-linux-gnu)
+2025-12-07T20:55:07.1309765Z Installing google-protobuf 4.33.1 (x86_64-linux-gnu)
+2025-12-07T20:55:07.1871655Z Fetching sass-embedded 1.94.2 (x86_64-linux-gnu)
+2025-12-07T20:55:07.2911420Z Installing sass-embedded 1.94.2 (x86_64-linux-gnu)
+2025-12-07T20:55:07.3917709Z Fetching jekyll-sass-converter 3.1.0
+2025-12-07T20:55:07.3979512Z Installing jekyll-sass-converter 3.1.0
+2025-12-07T20:55:13.4855939Z Fetching em-websocket 0.5.3
+2025-12-07T20:55:13.4956171Z Installing em-websocket 0.5.3
+2025-12-07T20:55:13.5059442Z Fetching jekyll 4.4.1
+2025-12-07T20:55:13.5182351Z Installing jekyll 4.4.1
+2025-12-07T20:55:13.5560579Z Fetching jekyll-feed 0.17.0
+2025-12-07T20:55:13.5568748Z Fetching jekyll-seo-tag 2.8.0
+2025-12-07T20:55:13.5569573Z Fetching jekyll-sitemap 1.4.0
+2025-12-07T20:55:13.5664380Z Installing jekyll-feed 0.17.0
+2025-12-07T20:55:13.5753854Z Installing jekyll-seo-tag 2.8.0
+2025-12-07T20:55:13.5813685Z Installing jekyll-sitemap 1.4.0
+2025-12-07T20:55:13.6150400Z Bundle complete! 9 Gemfile dependencies, 38 gems now installed.
+2025-12-07T20:55:13.6151084Z Use `bundle info [gemname]` to see where a bundled gem is installed.
+2025-12-07T20:55:14.8225864Z   Logging at level: debug
+2025-12-07T20:55:14.8226311Z     Jekyll Version: 4.4.1
+2025-12-07T20:55:14.8234842Z Configuration file: /home/runner/work/myFreecodecampLearning/myFreecodecampLearning/_config.yml
+2025-12-07T20:55:14.8325138Z          Requiring: jekyll-feed
+2025-12-07T20:55:14.8325815Z          Requiring: jekyll-sitemap
+2025-12-07T20:55:14.8326143Z          Requiring: jekyll-seo-tag
+2025-12-07T20:55:14.8326965Z             Source: /home/runner/work/myFreecodecampLearning/myFreecodecampLearning
+2025-12-07T20:55:14.8327750Z        Destination: /home/runner/work/myFreecodecampLearning/myFreecodecampLearning/_site
+2025-12-07T20:55:14.8328432Z  Incremental build: disabled. Enable with --incremental
+2025-12-07T20:55:14.8328838Z       Generating... 
+2025-12-07T20:55:14.8340526Z            Reading: /_layouts/default.html
+2025-12-07T20:55:14.8357450Z        EntryFilter: excluded /jest.config.js
+2025-12-07T20:55:14.8357911Z        EntryFilter: excluded /.jekyll-cache
+2025-12-07T20:55:14.8358498Z        EntryFilter: excluded /playwright.config.ts
+2025-12-07T20:55:14.8359213Z        EntryFilter: excluded /Gemfile
+2025-12-07T20:55:14.8360402Z        EntryFilter: excluded /package-lock.json
+2025-12-07T20:55:14.8361584Z        EntryFilter: excluded /Gemfile.lock
+2025-12-07T20:55:14.8365794Z        EntryFilter: excluded /package.json
+2025-12-07T20:55:14.8369624Z        EntryFilter: excluded /__tests__
+2025-12-07T20:55:14.8400078Z            Reading: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100201-Lecture-Welcome-Message-from-Quincy-Larson.html
+2025-12-07T20:55:14.8410147Z            Reading: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Home-Basic-HTML.html
+2025-12-07T20:55:14.8412208Z            Reading: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100901-Lecture-HTML-Fundamentals.html
+2025-12-07T20:55:14.8415622Z            Reading: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100601-Lecture-Understanding-the-HTML-Boilerplate.html
+2025-12-07T20:55:14.8418210Z            Reading: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100101-Workshop-Build-a-Curriculum-Outline.html
+2025-12-07T20:55:14.8420957Z            Reading: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100401-Lecture-Understanding-HTML-Attributes.html
+2025-12-07T20:55:14.8433082Z            Reading: pages/s100101-Certified-Full-Stack-Developer-Curriculum/Home-Certified-Full-Stack-Developer-Curriculum.html
+2025-12-07T20:55:14.8434208Z            Reading: pages/interactive-features.html
+2025-12-07T20:55:14.8492733Z            Reading: index.html
+2025-12-07T20:55:14.8504604Z        Jekyll Feed: Generating feed for posts
+2025-12-07T20:55:14.8514343Z         Generating: JekyllFeed::Generator finished in 0.00052835 seconds.
+2025-12-07T20:55:14.8532756Z         Generating: Jekyll::JekyllSitemap finished in 0.002241761 seconds.
+2025-12-07T20:55:14.8534072Z          Rendering: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100101-Workshop-Build-a-Curriculum-Outline.html
+2025-12-07T20:55:14.8536015Z   Pre-Render Hooks: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100101-Workshop-Build-a-Curriculum-Outline.html
+2025-12-07T20:55:14.8537978Z   Rendering Liquid: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100101-Workshop-Build-a-Curriculum-Outline.html
+2025-12-07T20:55:14.8876182Z   Rendering Markup: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100101-Workshop-Build-a-Curriculum-Outline.html
+2025-12-07T20:55:14.8878040Z Post-Convert Hooks: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100101-Workshop-Build-a-Curriculum-Outline.html
+2025-12-07T20:55:14.8880132Z   Rendering Layout: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100101-Workshop-Build-a-Curriculum-Outline.html
+2025-12-07T20:55:14.8900530Z          Rendering: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100201-Lecture-Welcome-Message-from-Quincy-Larson.html
+2025-12-07T20:55:14.8902685Z   Pre-Render Hooks: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100201-Lecture-Welcome-Message-from-Quincy-Larson.html
+2025-12-07T20:55:14.8904822Z   Rendering Markup: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100201-Lecture-Welcome-Message-from-Quincy-Larson.html
+2025-12-07T20:55:14.8907291Z Post-Convert Hooks: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100201-Lecture-Welcome-Message-from-Quincy-Larson.html
+2025-12-07T20:55:14.8909724Z   Rendering Layout: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100201-Lecture-Welcome-Message-from-Quincy-Larson.html
+2025-12-07T20:55:14.8911793Z          Rendering: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100401-Lecture-Understanding-HTML-Attributes.html
+2025-12-07T20:55:14.8913809Z   Pre-Render Hooks: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100401-Lecture-Understanding-HTML-Attributes.html
+2025-12-07T20:55:14.8915876Z   Rendering Markup: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100401-Lecture-Understanding-HTML-Attributes.html
+2025-12-07T20:55:14.8917930Z Post-Convert Hooks: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100401-Lecture-Understanding-HTML-Attributes.html
+2025-12-07T20:55:14.8920140Z   Rendering Layout: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100401-Lecture-Understanding-HTML-Attributes.html
+2025-12-07T20:55:14.8922203Z          Rendering: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100601-Lecture-Understanding-the-HTML-Boilerplate.html
+2025-12-07T20:55:14.8924303Z   Pre-Render Hooks: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100601-Lecture-Understanding-the-HTML-Boilerplate.html
+2025-12-07T20:55:14.8926706Z   Rendering Markup: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100601-Lecture-Understanding-the-HTML-Boilerplate.html
+2025-12-07T20:55:14.8928840Z Post-Convert Hooks: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100601-Lecture-Understanding-the-HTML-Boilerplate.html
+2025-12-07T20:55:14.8931180Z   Rendering Layout: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100601-Lecture-Understanding-the-HTML-Boilerplate.html
+2025-12-07T20:55:14.8933151Z          Rendering: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100901-Lecture-HTML-Fundamentals.html
+2025-12-07T20:55:14.8934964Z   Pre-Render Hooks: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100901-Lecture-HTML-Fundamentals.html
+2025-12-07T20:55:14.8936800Z   Rendering Markup: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100901-Lecture-HTML-Fundamentals.html
+2025-12-07T20:55:14.8938672Z Post-Convert Hooks: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100901-Lecture-HTML-Fundamentals.html
+2025-12-07T20:55:14.8940760Z   Rendering Layout: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100901-Lecture-HTML-Fundamentals.html
+2025-12-07T20:55:14.8942373Z          Rendering: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Home-Basic-HTML.html
+2025-12-07T20:55:14.8943735Z   Pre-Render Hooks: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Home-Basic-HTML.html
+2025-12-07T20:55:14.8945167Z   Rendering Liquid: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Home-Basic-HTML.html
+2025-12-07T20:55:14.8946617Z   Rendering Markup: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Home-Basic-HTML.html
+2025-12-07T20:55:14.8948051Z Post-Convert Hooks: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Home-Basic-HTML.html
+2025-12-07T20:55:14.8949646Z   Rendering Layout: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Home-Basic-HTML.html
+2025-12-07T20:55:14.8951114Z          Rendering: pages/s100101-Certified-Full-Stack-Developer-Curriculum/Home-Certified-Full-Stack-Developer-Curriculum.html
+2025-12-07T20:55:14.8952980Z   Pre-Render Hooks: pages/s100101-Certified-Full-Stack-Developer-Curriculum/Home-Certified-Full-Stack-Developer-Curriculum.html
+2025-12-07T20:55:14.8954685Z   Rendering Liquid: pages/s100101-Certified-Full-Stack-Developer-Curriculum/Home-Certified-Full-Stack-Developer-Curriculum.html
+2025-12-07T20:55:14.8956367Z   Rendering Markup: pages/s100101-Certified-Full-Stack-Developer-Curriculum/Home-Certified-Full-Stack-Developer-Curriculum.html
+2025-12-07T20:55:14.8958041Z Post-Convert Hooks: pages/s100101-Certified-Full-Stack-Developer-Curriculum/Home-Certified-Full-Stack-Developer-Curriculum.html
+2025-12-07T20:55:14.8959883Z   Rendering Layout: pages/s100101-Certified-Full-Stack-Developer-Curriculum/Home-Certified-Full-Stack-Developer-Curriculum.html
+2025-12-07T20:55:14.8960937Z          Rendering: index.html
+2025-12-07T20:55:14.8961340Z   Pre-Render Hooks: index.html
+2025-12-07T20:55:14.8961732Z   Rendering Liquid: index.html
+2025-12-07T20:55:14.8962104Z   Rendering Markup: index.html
+2025-12-07T20:55:14.8962491Z Post-Convert Hooks: index.html
+2025-12-07T20:55:14.8962900Z   Rendering Layout: index.html
+2025-12-07T20:55:14.8963339Z          Rendering: pages/interactive-features.html
+2025-12-07T20:55:14.8963904Z   Pre-Render Hooks: pages/interactive-features.html
+2025-12-07T20:55:14.8964467Z   Rendering Liquid: pages/interactive-features.html
+2025-12-07T20:55:14.8965039Z   Rendering Markup: pages/interactive-features.html
+2025-12-07T20:55:14.8965607Z Post-Convert Hooks: pages/interactive-features.html
+2025-12-07T20:55:14.8966173Z   Rendering Layout: pages/interactive-features.html
+2025-12-07T20:55:14.8966908Z          Rendering: feed.xml
+2025-12-07T20:55:14.8967287Z   Pre-Render Hooks: feed.xml
+2025-12-07T20:55:14.8967665Z   Rendering Liquid: feed.xml
+2025-12-07T20:55:14.9276131Z   Rendering Markup: feed.xml
+2025-12-07T20:55:14.9276579Z Post-Convert Hooks: feed.xml
+2025-12-07T20:55:14.9276972Z   Rendering Layout: feed.xml
+2025-12-07T20:55:14.9277359Z          Rendering: sitemap.xml
+2025-12-07T20:55:14.9277763Z   Pre-Render Hooks: sitemap.xml
+2025-12-07T20:55:14.9278149Z   Rendering Liquid: sitemap.xml
+2025-12-07T20:55:14.9331675Z   Rendering Markup: sitemap.xml
+2025-12-07T20:55:14.9332126Z Post-Convert Hooks: sitemap.xml
+2025-12-07T20:55:14.9332542Z   Rendering Layout: sitemap.xml
+2025-12-07T20:55:14.9332936Z          Rendering: robots.txt
+2025-12-07T20:55:14.9333342Z   Pre-Render Hooks: robots.txt
+2025-12-07T20:55:14.9333742Z   Rendering Liquid: robots.txt
+2025-12-07T20:55:14.9335859Z   Rendering Markup: robots.txt
+2025-12-07T20:55:14.9336287Z Post-Convert Hooks: robots.txt
+2025-12-07T20:55:14.9336711Z   Rendering Layout: robots.txt
+2025-12-07T20:55:14.9359744Z            Writing: /home/runner/work/myFreecodecampLearning/myFreecodecampLearning/_site/pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100101-Workshop-Build-a-Curriculum-Outline.html
+2025-12-07T20:55:14.9362863Z            Writing: /home/runner/work/myFreecodecampLearning/myFreecodecampLearning/_site/pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100201-Lecture-Welcome-Message-from-Quincy-Larson.html
+2025-12-07T20:55:14.9365907Z            Writing: /home/runner/work/myFreecodecampLearning/myFreecodecampLearning/_site/pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100401-Lecture-Understanding-HTML-Attributes.html
+2025-12-07T20:55:14.9369104Z            Writing: /home/runner/work/myFreecodecampLearning/myFreecodecampLearning/_site/pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100601-Lecture-Understanding-the-HTML-Boilerplate.html
+2025-12-07T20:55:14.9372085Z            Writing: /home/runner/work/myFreecodecampLearning/myFreecodecampLearning/_site/pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100901-Lecture-HTML-Fundamentals.html
+2025-12-07T20:55:14.9374755Z            Writing: /home/runner/work/myFreecodecampLearning/myFreecodecampLearning/_site/pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Home-Basic-HTML.html
+2025-12-07T20:55:14.9377127Z            Writing: /home/runner/work/myFreecodecampLearning/myFreecodecampLearning/_site/pages/s100101-Certified-Full-Stack-Developer-Curriculum/Home-Certified-Full-Stack-Developer-Curriculum.html
+2025-12-07T20:55:14.9379118Z            Writing: /home/runner/work/myFreecodecampLearning/myFreecodecampLearning/_site/index.html
+2025-12-07T20:55:14.9380377Z            Writing: /home/runner/work/myFreecodecampLearning/myFreecodecampLearning/_site/pages/interactive-features.html
+2025-12-07T20:55:14.9381592Z            Writing: /home/runner/work/myFreecodecampLearning/myFreecodecampLearning/_site/feed.xml
+2025-12-07T20:55:14.9382632Z            Writing: /home/runner/work/myFreecodecampLearning/myFreecodecampLearning/_site/sitemap.xml
+2025-12-07T20:55:14.9383676Z            Writing: /home/runner/work/myFreecodecampLearning/myFreecodecampLearning/_site/robots.txt
+2025-12-07T20:55:14.9492574Z                     done in 0.117 seconds.
+2025-12-07T20:55:14.9493109Z  Auto-regeneration: disabled. Use --watch to enable.
+2025-12-07T20:55:14.9678189Z ##[group]Run touch _site/.nojekyll
+2025-12-07T20:55:14.9678490Z [36;1mtouch _site/.nojekyll[0m
+2025-12-07T20:55:14.9679144Z [36;1mecho "✅ Added .nojekyll file to prevent GitHub Pages Jekyll processing" >> $GITHUB_STEP_SUMMARY[0m
+2025-12-07T20:55:14.9710482Z shell: /usr/bin/bash -e {0}
+2025-12-07T20:55:14.9710699Z ##[endgroup]
+2025-12-07T20:55:14.9791865Z ##[group]Run echo "📋 DEPLOYMENT VERIFICATION" >> $GITHUB_STEP_SUMMARY
+2025-12-07T20:55:14.9792450Z [36;1mecho "📋 DEPLOYMENT VERIFICATION" >> $GITHUB_STEP_SUMMARY[0m
+2025-12-07T20:55:14.9792811Z [36;1mecho "Files to be deployed:" >> $GITHUB_STEP_SUMMARY[0m
+2025-12-07T20:55:14.9793201Z [36;1mfind _site -type f -name "*.html" | head -10 >> $GITHUB_STEP_SUMMARY[0m
+2025-12-07T20:55:14.9793559Z [36;1mecho "" >> $GITHUB_STEP_SUMMARY[0m
+2025-12-07T20:55:14.9793920Z [36;1mecho "Final check of index.html navigation links:" >> $GITHUB_STEP_SUMMARY[0m
+2025-12-07T20:55:14.9794543Z [36;1mgrep -n "href.*Certified.*Full.*Stack" _site/index.html >> $GITHUB_STEP_SUMMARY || echo "No navigation links found" >> $GITHUB_STEP_SUMMARY[0m
+2025-12-07T20:55:14.9822747Z shell: /usr/bin/bash -e {0}
+2025-12-07T20:55:14.9822969Z ##[endgroup]
+2025-12-07T20:55:14.9969831Z ##[group]Run peaceiris/actions-gh-pages@v4
+2025-12-07T20:55:14.9970118Z with:
+2025-12-07T20:55:14.9970548Z   github_token: ***
+2025-12-07T20:55:14.9970750Z   publish_dir: ./_site
+2025-12-07T20:55:14.9970944Z   enable_jekyll: false
+2025-12-07T20:55:14.9971153Z   force_orphan: true
+2025-12-07T20:55:14.9971342Z   publish_branch: gh-pages
+2025-12-07T20:55:14.9971554Z   allow_empty_commit: false
+2025-12-07T20:55:14.9971751Z   keep_files: false
+2025-12-07T20:55:14.9971927Z   disable_nojekyll: false
+2025-12-07T20:55:14.9972124Z   exclude_assets: .github
+2025-12-07T20:55:14.9972310Z ##[endgroup]
+2025-12-07T20:55:15.0567787Z [INFO] Usage https://github.com/peaceiris/actions-gh-pages#readme
+2025-12-07T20:55:15.0572597Z ##[group]Dump inputs
+2025-12-07T20:55:15.0572989Z [INFO] GithubToken: true
+2025-12-07T20:55:15.0573379Z [INFO] PublishBranch: gh-pages
+2025-12-07T20:55:15.0573734Z [INFO] PublishDir: ./_site
+2025-12-07T20:55:15.0573986Z [INFO] DestinationDir: 
+2025-12-07T20:55:15.0574292Z [INFO] ExternalRepository: 
+2025-12-07T20:55:15.0574552Z [INFO] AllowEmptyCommit: false
+2025-12-07T20:55:15.0574819Z [INFO] KeepFiles: false
+2025-12-07T20:55:15.0575051Z [INFO] ForceOrphan: true
+2025-12-07T20:55:15.0575285Z [INFO] UserName: 
+2025-12-07T20:55:15.0575500Z [INFO] UserEmail: 
+2025-12-07T20:55:15.0575798Z [INFO] CommitMessage: 
+2025-12-07T20:55:15.0576104Z [INFO] FullCommitMessage: 
+2025-12-07T20:55:15.0576405Z [INFO] TagName: 
+2025-12-07T20:55:15.0576617Z [INFO] TagMessage: 
+2025-12-07T20:55:15.0576863Z [INFO] EnableJekyll (DisableNoJekyll): false
+2025-12-07T20:55:15.0577160Z [INFO] CNAME: 
+2025-12-07T20:55:15.0577450Z [INFO] ExcludeAssets .github
+2025-12-07T20:55:15.0577668Z 
+2025-12-07T20:55:15.0578043Z ##[endgroup]
+2025-12-07T20:55:15.0578409Z ##[group]Setup auth token
+2025-12-07T20:55:15.0578646Z [INFO] setup GITHUB_TOKEN
+2025-12-07T20:55:15.0579998Z ##[endgroup]
+2025-12-07T20:55:15.0580378Z ##[group]Prepare publishing assets
+2025-12-07T20:55:15.0583631Z [INFO] ForceOrphan: true
+2025-12-07T20:55:15.0603544Z [INFO] chdir /home/runner/actions_github_pages_1765140915057
+2025-12-07T20:55:15.0632508Z [command]/usr/bin/git init
+2025-12-07T20:55:15.0692377Z hint: Using 'master' as the name for the initial branch. This default branch name
+2025-12-07T20:55:15.0693256Z hint: will change to "main" in Git 3.0. To configure the initial branch name
+2025-12-07T20:55:15.0694067Z hint: to use in all of your new repositories, which will suppress this warning,
+2025-12-07T20:55:15.0694672Z hint: call:
+2025-12-07T20:55:15.0694963Z hint:
+2025-12-07T20:55:15.0695346Z hint: 	git config --global init.defaultBranch <name>
+2025-12-07T20:55:15.0695822Z hint:
+2025-12-07T20:55:15.0696274Z hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
+2025-12-07T20:55:15.0697090Z hint: 'development'. The just-created branch can be renamed via this command:
+2025-12-07T20:55:15.0697707Z hint:
+2025-12-07T20:55:15.0698017Z hint: 	git branch -m <name>
+2025-12-07T20:55:15.0698378Z hint:
+2025-12-07T20:55:15.0699141Z hint: Disable this message with "git config set advice.defaultBranchName false"
+2025-12-07T20:55:15.0707954Z Initialized empty Git repository in /home/runner/actions_github_pages_1765140915057/.git/
+2025-12-07T20:55:15.0730819Z [command]/usr/bin/git checkout --orphan gh-pages
+2025-12-07T20:55:15.0753486Z Switched to a new branch 'gh-pages'
+2025-12-07T20:55:15.0758782Z [INFO] prepare publishing assets
+2025-12-07T20:55:15.0760046Z [INFO] copy /home/runner/work/myFreecodecampLearning/myFreecodecampLearning/_site to /home/runner/actions_github_pages_1765140915057
+2025-12-07T20:55:15.1036445Z [INFO] delete excluded assets
+2025-12-07T20:55:15.1068332Z rm: no paths given
+2025-12-07T20:55:15.1072025Z ##[endgroup]
+2025-12-07T20:55:15.1072468Z ##[group]Setup Git config
+2025-12-07T20:55:15.1086279Z [command]/usr/bin/git remote rm origin
+2025-12-07T20:55:15.1109128Z error: No such remote: 'origin'
+2025-12-07T20:55:15.1115047Z [INFO] The process '/usr/bin/git' failed with exit code 2
+2025-12-07T20:55:15.1129306Z [command]/usr/bin/git remote add origin ***github.com/T193R-W00D5/myFreecodecampLearning.git
+2025-12-07T20:55:15.1172360Z [command]/usr/bin/git add --all
+2025-12-07T20:55:15.2785780Z [command]/usr/bin/git config user.name T193R-W00D5
+2025-12-07T20:55:15.2830397Z [command]/usr/bin/git config user.email T193R-W00D5@users.noreply.github.com
+2025-12-07T20:55:15.2857409Z ##[endgroup]
+2025-12-07T20:55:15.2858018Z ##[group]Create a commit
+2025-12-07T20:55:15.2872576Z [command]/usr/bin/git commit -m deploy: 56eaffe66dbbb15d766743e78067cb82f61dfdc6
+2025-12-07T20:55:15.3166010Z [gh-pages (root-commit) 523123e] deploy: 56eaffe66dbbb15d766743e78067cb82f61dfdc6
+2025-12-07T20:55:15.3166728Z  89 files changed, 30620 insertions(+)
+2025-12-07T20:55:15.3167139Z  create mode 100644 .nojekyll
+2025-12-07T20:55:15.3167393Z  create mode 100644 LICENSE
+2025-12-07T20:55:15.3167766Z  create mode 100644 ReadMe.md
+2025-12-07T20:55:15.3168191Z  create mode 100644 assets/audio/Duck.mp3
+2025-12-07T20:55:15.3168718Z  create mode 100644 assets/favicon/Wizard.ico
+2025-12-07T20:55:15.3169551Z  create mode 100644 assets/favicon/orange_inc_logo 00.jpg
+2025-12-07T20:55:15.3170194Z  create mode 100644 assets/favicon/orange_inc_logo 00.xcf
+2025-12-07T20:55:15.3170807Z  create mode 100644 assets/favicon/orange_inc_logo.ico
+2025-12-07T20:55:15.3171401Z  create mode 100644 assets/images/bg-techy-003.svg
+2025-12-07T20:55:15.3172000Z  create mode 100644 assets/images/eggs-whisk-flour-milk.jpg
+2025-12-07T20:55:15.3172776Z  create mode 100644 assets/images/kids-making-a-mud-pie - Copy.jpg
+2025-12-07T20:55:15.3173561Z  create mode 100644 assets/images/kids-making-a-mud-pie-400x267.avif
+2025-12-07T20:55:15.3174335Z  create mode 100644 assets/images/kids-making-a-mud-pie-400x267.jpg
+2025-12-07T20:55:15.3175117Z  create mode 100644 assets/images/kids-making-a-mud-pie-400x267.webp
+2025-12-07T20:55:15.3175872Z  create mode 100644 assets/images/kids-making-a-mud-pie.jpg
+2025-12-07T20:55:15.3176545Z  create mode 100644 assets/images/kids-making-a-mud-pie.xcf
+2025-12-07T20:55:15.3177176Z  create mode 100644 assets/images/triangle-icon.svg
+2025-12-07T20:55:15.3177783Z  create mode 100644 auto-staging-modern_yml_DELETE_ME.txt
+2025-12-07T20:55:15.3178336Z  create mode 100644 bin/jekyll
+2025-12-07T20:55:15.3178743Z  create mode 100644 bin/jekyll.cmd
+2025-12-07T20:55:15.3179363Z  create mode 100644 css/prism.css
+2025-12-07T20:55:15.3179767Z  create mode 100644 css/styles-center.css
+2025-12-07T20:55:15.3180272Z  create mode 100644 css/styles-freecodecamp.css
+2025-12-07T20:55:15.3180873Z  create mode 100644 css/styles-iframe-html-examples.css
+2025-12-07T20:55:15.3181428Z  create mode 100644 css/styles-left.css
+2025-12-07T20:55:15.3181881Z  create mode 100644 css/styles.css
+2025-12-07T20:55:15.3182638Z  create mode 100644 docs/Ai_chats/20251023a Volta setup and add project to new Github repo CoPilot .md
+2025-12-07T20:55:15.3183668Z  create mode 100644 docs/Ai_chats/20251025a Add Playwright tests and Git help.md
+2025-12-07T20:55:15.3184586Z  create mode 100644 docs/Ai_chats/20251026 Playwright Installation Success Summary.md
+2025-12-07T20:55:15.3185522Z  create mode 100644 docs/Ai_chats/20251105a Refactor project to use TypeScript.md
+2025-12-07T20:55:15.3186346Z  create mode 100644 docs/Ai_chats/20251108a CD and scheduled E2E tests.md
+2025-12-07T20:55:15.3187541Z  create mode 100644 docs/Ai_chats/20251113a playwright shared constants and test utilities functions .md
+2025-12-07T20:55:15.3188680Z  create mode 100644 docs/Ai_chats/20251115a express server, fixes Lighthouse performance, discuss React.md
+2025-12-07T20:55:15.3189993Z  create mode 100644 docs/Ai_chats/20251119a GitHub CoPilot - fix parallel worker tests using same port.md
+2025-12-07T20:55:15.3191087Z  create mode 100644 docs/Ai_chats/20251119a workflow defensive free port 3010 Github copilot.md
+2025-12-07T20:55:15.3191860Z  create mode 100644 docs/Ai_chats/VS Code help.md
+2025-12-07T20:55:15.3192339Z  create mode 100644 docs/Ai_chats/daemon.md
+2025-12-07T20:55:15.3192862Z  create mode 100644 docs/Ai_chats/toolchain Gai 20251024a .md
+2025-12-07T20:55:15.3193643Z  create mode 100644 docs/DEBUG_CONSOLE_GUIDE.md
+2025-12-07T20:55:15.3194127Z  create mode 100644 docs/DEPLOYMENT_GUIDE.md
+2025-12-07T20:55:15.3194572Z  create mode 100644 docs/PLAYWRIGHT_GUIDE.md
+2025-12-07T20:55:15.3195088Z  create mode 100644 docs/PROFESSIONAL_DEPLOYMENT_GUIDE.md
+2025-12-07T20:55:15.3195603Z  create mode 100644 docs/PR_changes.md
+2025-12-07T20:55:15.3196070Z  create mode 100644 docs/TESTING_BEST_PRACTICES.md
+2025-12-07T20:55:15.3196437Z  create mode 100644 docs/TWO_TRACK_STAGING_GUIDE.md
+2025-12-07T20:55:15.3196728Z  create mode 100644 docs/TYPESCRIPT_GUIDE.md
+2025-12-07T20:55:15.3197021Z  create mode 100644 docs/TYPESCRIPT_MIGRATION_COMMIT.md
+2025-12-07T20:55:15.3197288Z  create mode 100644 docs/ci.md
+2025-12-07T20:55:15.3197604Z  create mode 100644 docs/debug_dox/Deploy to Production 1 20251207_0349UTC.txt
+2025-12-07T20:55:15.3198098Z  create mode 100644 docs/debug_dox/GitHub deploy.yml deploy no. 15 to production 20251207_1040.txt
+2025-12-07T20:55:15.3198567Z  create mode 100644 docs/git-workflow-branching-strategy.md
+2025-12-07T20:55:15.3199089Z  create mode 100644 feed.xml
+2025-12-07T20:55:15.3199362Z  create mode 100644 freecodecampOrg.code-workspace
+2025-12-07T20:55:15.3199631Z  create mode 100644 index.html
+2025-12-07T20:55:15.3199847Z  create mode 100644 pages/about.html
+2025-12-07T20:55:15.3200084Z  create mode 100644 pages/audio.html
+2025-12-07T20:55:15.3200319Z  create mode 100644 pages/cafe-menu.html
+2025-12-07T20:55:15.3200592Z  create mode 100644 pages/interactive-features.html
+2025-12-07T20:55:15.3200862Z  create mode 100644 pages/recipes.html
+2025-12-07T20:55:15.3201772Z  create mode 100644 pages/s100101-Certified-Full-Stack-Developer-Curriculum/Home-Certified-Full-Stack-Developer-Curriculum.html
+2025-12-07T20:55:15.3203513Z  create mode 100644 pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100101-10101-example-page-h1-h2-p.html
+2025-12-07T20:55:15.3205037Z  create mode 100644 pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100101-10201-example-page-final-page.html
+2025-12-07T20:55:15.3206077Z  create mode 100644 pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100101-Workshop-Build-a-Curriculum-Outline.html
+2025-12-07T20:55:15.3207169Z  create mode 100644 pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100201-Lecture-Welcome-Message-from-Quincy-Larson.html
+2025-12-07T20:55:15.3208247Z  create mode 100644 pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100401-Lecture-Understanding-HTML-Attributes.html
+2025-12-07T20:55:15.3209579Z  create mode 100644 pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100601-Lecture-Understanding-the-HTML-Boilerplate.html
+2025-12-07T20:55:15.3210607Z  create mode 100644 pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100901-Lecture-HTML-Fundamentals.html
+2025-12-07T20:55:15.3211558Z  create mode 100644 pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p700101-Review-Basic-HTML-Review.html
+2025-12-07T20:55:15.3228775Z  create mode 100644 pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Home-Basic-HTML.html
+2025-12-07T20:55:15.3230040Z  create mode 100644 pages/svg-heart-icon.html
+2025-12-07T20:55:15.3230336Z  create mode 100644 pages/videos.html
+2025-12-07T20:55:15.3230587Z  create mode 100644 robots.txt
+2025-12-07T20:55:15.3230801Z  create mode 100644 sitemap.xml
+2025-12-07T20:55:15.3231047Z  create mode 100644 src/components/Snackbar.js
+2025-12-07T20:55:15.3231308Z  create mode 100644 src/script.js
+2025-12-07T20:55:15.3231566Z  create mode 100644 src/scripts/consoleLogHandler.js
+2025-12-07T20:55:15.3231864Z  create mode 100644 src/scripts/css-loader.js
+2025-12-07T20:55:15.3232134Z  create mode 100644 src/scripts/debug-console.js
+2025-12-07T20:55:15.3232403Z  create mode 100644 src/scripts/prism.js
+2025-12-07T20:55:15.3232894Z  create mode 100644 src/scripts/sharedConstants-CFSD-basic-html-helper.js
+2025-12-07T20:55:15.3233312Z  create mode 100644 src/scripts/sharedConstants-__main.js
+2025-12-07T20:55:15.3233611Z  create mode 100644 test-staging.html
+2025-12-07T20:55:15.3233882Z  create mode 100644 tests/e2e/homepage.spec.ts
+2025-12-07T20:55:15.3234192Z  create mode 100644 tests/e2e/interactive-features.spec.ts
+2025-12-07T20:55:15.3234546Z  create mode 100644 tests/e2e/navigation/home-navigation.spec.ts
+2025-12-07T20:55:15.3234916Z  create mode 100644 tests/e2e/navigation/nav-CFSD-pages.spec.ts
+2025-12-07T20:55:15.3235242Z  create mode 100644 tests/fixtures/test-fixtures.ts
+2025-12-07T20:55:15.3235558Z  create mode 100644 tests/utils/helpers-page-navigation.ts
+2025-12-07T20:55:15.3235842Z  create mode 100644 tsconfig.json
+2025-12-07T20:55:15.3236268Z ##[endgroup]
+2025-12-07T20:55:15.3236587Z ##[group]Push the commit or tag
+2025-12-07T20:55:15.3236843Z [command]/usr/bin/git push origin --force gh-pages
+2025-12-07T20:55:16.1828488Z To https://github.com/T193R-W00D5/myFreecodecampLearning.git
+2025-12-07T20:55:16.1829458Z  + c8df2fc...523123e gh-pages -> gh-pages (forced update)
+2025-12-07T20:55:16.1879961Z ##[endgroup]
+2025-12-07T20:55:16.1880289Z [INFO] Action successfully completed
+2025-12-07T20:55:16.2000233Z Post job cleanup.
+2025-12-07T20:55:16.2916669Z [command]/usr/bin/git version
+2025-12-07T20:55:16.2952297Z git version 2.52.0
+2025-12-07T20:55:16.2996344Z Temporarily overriding HOME='/home/runner/work/_temp/04784269-7baa-4e70-bf99-24ffba579008' before making global git config changes
+2025-12-07T20:55:16.2997590Z Adding repository directory to the temporary git global config as a safe directory
+2025-12-07T20:55:16.3009578Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/myFreecodecampLearning/myFreecodecampLearning
+2025-12-07T20:55:16.3043244Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+2025-12-07T20:55:16.3075150Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+2025-12-07T20:55:16.3296030Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+2025-12-07T20:55:16.3315983Z http.https://github.com/.extraheader
+2025-12-07T20:55:16.3328039Z [command]/usr/bin/git config --local --unset-all http.https://github.com/.extraheader
+2025-12-07T20:55:16.3358258Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+2025-12-07T20:55:16.3573942Z [command]/usr/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+2025-12-07T20:55:16.3605463Z [command]/usr/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+2025-12-07T20:55:16.3923477Z Evaluate and set environment url
+2025-12-07T20:55:16.3926236Z Evaluated environment url: https://t193r-w00d5.github.io/myFreecodecampLearning
+2025-12-07T20:55:16.3927126Z Cleaning up orphan processes
+# job2025-12-07T20:55:20.9730081Z Current runner version: '2.329.0'
+2025-12-07T20:55:20.9768275Z ##[group]Runner Image Provisioner
+2025-12-07T20:55:20.9769708Z Hosted Compute Agent
+2025-12-07T20:55:20.9770552Z Version: 20251124.448
+2025-12-07T20:55:20.9771866Z Commit: fda5086b43ec66ade217e5fcd18146c879571177
+2025-12-07T20:55:20.9773186Z Build Date: 2025-11-24T21:16:26Z
+2025-12-07T20:55:20.9774110Z ##[endgroup]
+2025-12-07T20:55:20.9775001Z ##[group]Operating System
+2025-12-07T20:55:20.9776020Z Ubuntu
+2025-12-07T20:55:20.9776800Z 24.04.3
+2025-12-07T20:55:20.9777537Z LTS
+2025-12-07T20:55:20.9778516Z ##[endgroup]
+2025-12-07T20:55:20.9779302Z ##[group]Runner Image
+2025-12-07T20:55:20.9780287Z Image: ubuntu-24.04
+2025-12-07T20:55:20.9781629Z Version: 20251126.144.1
+2025-12-07T20:55:20.9783433Z Included Software: https://github.com/actions/runner-images/blob/ubuntu24/20251126.144/images/ubuntu/Ubuntu2404-Readme.md
+2025-12-07T20:55:20.9786356Z Image Release: https://github.com/actions/runner-images/releases/tag/ubuntu24%2F20251126.144
+2025-12-07T20:55:20.9788054Z ##[endgroup]
+2025-12-07T20:55:20.9793252Z ##[group]GITHUB_TOKEN Permissions
+2025-12-07T20:55:20.9796316Z Actions: write
+2025-12-07T20:55:20.9797155Z ArtifactMetadata: write
+2025-12-07T20:55:20.9798223Z Attestations: write
+2025-12-07T20:55:20.9799153Z Checks: write
+2025-12-07T20:55:20.9800048Z Contents: write
+2025-12-07T20:55:20.9801246Z Deployments: write
+2025-12-07T20:55:20.9802195Z Discussions: write
+2025-12-07T20:55:20.9803085Z Issues: write
+2025-12-07T20:55:20.9803995Z Metadata: read
+2025-12-07T20:55:20.9804917Z Models: read
+2025-12-07T20:55:20.9805686Z Packages: write
+2025-12-07T20:55:20.9806596Z Pages: write
+2025-12-07T20:55:20.9807419Z PullRequests: write
+2025-12-07T20:55:20.9808327Z RepositoryProjects: write
+2025-12-07T20:55:20.9809447Z SecurityEvents: write
+2025-12-07T20:55:20.9810330Z Statuses: write
+2025-12-07T20:55:20.9811466Z ##[endgroup]
+2025-12-07T20:55:20.9814171Z Secret source: Actions
+2025-12-07T20:55:20.9815703Z Prepare workflow directory
+2025-12-07T20:55:21.0298194Z Prepare all required actions
+2025-12-07T20:55:21.0437957Z Complete job name: deployment-success
+2025-12-07T20:55:21.1548484Z ##[group]Run echo "## 🚀 Production Deployment Successful!" >> $GITHUB_STEP_SUMMARY
+2025-12-07T20:55:21.1550500Z [36;1mecho "## 🚀 Production Deployment Successful!" >> $GITHUB_STEP_SUMMARY[0m
+2025-12-07T20:55:21.1552322Z [36;1mecho "" >> $GITHUB_STEP_SUMMARY[0m
+2025-12-07T20:55:21.1553833Z [36;1mecho "**Environment:** Production" >> $GITHUB_STEP_SUMMARY[0m
+2025-12-07T20:55:21.1555633Z [36;1mecho "**Commit:** 56eaffe66dbbb15d766743e78067cb82f61dfdc6" >> $GITHUB_STEP_SUMMARY[0m
+2025-12-07T20:55:21.1557569Z [36;1mecho "**Deployed by:** T193R-W00D5" >> $GITHUB_STEP_SUMMARY[0m
+2025-12-07T20:55:21.1558914Z [36;1mecho "" >> $GITHUB_STEP_SUMMARY[0m
+2025-12-07T20:55:21.1560697Z [36;1mecho "**Live URL:** https://t193r-w00d5.github.io/myFreecodecampLearning" >> $GITHUB_STEP_SUMMARY[0m
+2025-12-07T20:55:21.1562725Z [36;1mecho "" >> $GITHUB_STEP_SUMMARY[0m
+2025-12-07T20:55:21.1564444Z [36;1mecho "Please allow 5-10 minutes for GitHub Pages to update." >> $GITHUB_STEP_SUMMARY[0m
+2025-12-07T20:55:21.2273566Z shell: /usr/bin/bash -e {0}
+2025-12-07T20:55:21.2275033Z ##[endgroup]
+2025-12-07T20:55:21.2599816Z Cleaning up orphan processes


### PR DESCRIPTION
ANALYSIS: Found the root cause! Jekyll builds correctly and generates proper URLs like '/myFreecodecampLearning/pages/...' but GitHub Pages is ignoring the .nojekyll file and double-processing the files.

FIX: Explicitly set disable_nojekyll: false in peaceiris action to ensure .nojekyll file is properly created and respected.

Evidence from logs shows Jekyll generating correct URLs: 'Course link href: /myFreecodecampLearning/pages/s100101-Certified-Full-Stack-Developer-Curriculum/Home-Certified-Full-Stack-Developer-Curriculum.html'