### PR TITLE
Try GitHub native Pages deployment instead of peaceiris

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -92,9 +92,12 @@ jobs:
       needs.pre-deployment-tests.result == 'success'
     needs: pre-deployment-tests
     runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
     environment: 
-      name: production
-      url: https://t193r-w00d5.github.io/myFreecodecampLearning
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Checkout specific commit for production
         uses: actions/checkout@v4
@@ -164,14 +167,14 @@ jobs:
           echo "Final check of index.html navigation links:" >> $GITHUB_STEP_SUMMARY
           grep -n "href.*Certified.*Full.*Stack" _site/index.html >> $GITHUB_STEP_SUMMARY || echo "No navigation links found" >> $GITHUB_STEP_SUMMARY
 
-      - name: Deploy to GitHub Pages (production)
-        uses: peaceiris/actions-gh-pages@v4
+      - name: Upload site artifacts
+        uses: actions/upload-pages-artifact@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./_site
-          enable_jekyll: false
-          force_orphan: true
-          disable_nojekyll: false  # Ensure .nojekyll file is created
+          path: ./_site
+
+      - name: Deploy to GitHub Pages (production)
+        id: deployment
+        uses: actions/deploy-pages@v4
 
   # Deployment success notification
   deployment-success:

--- a/docs/debug_dox/Deploy to Production 2 20251207_2411UTC.txt
+++ b/docs/debug_dox/Deploy to Production 2 20251207_2411UTC.txt
@@ -1,0 +1,2239 @@
+2025-12-07T21:21:18.7447461Z Current runner version: '2.329.0'
+2025-12-07T21:21:18.7471813Z ##[group]Runner Image Provisioner
+2025-12-07T21:21:18.7472720Z Hosted Compute Agent
+2025-12-07T21:21:18.7473227Z Version: 20251124.448
+2025-12-07T21:21:18.7473828Z Commit: fda5086b43ec66ade217e5fcd18146c879571177
+2025-12-07T21:21:18.7474711Z Build Date: 2025-11-24T21:16:26Z
+2025-12-07T21:21:18.7475285Z ##[endgroup]
+2025-12-07T21:21:18.7475812Z ##[group]Operating System
+2025-12-07T21:21:18.7476404Z Ubuntu
+2025-12-07T21:21:18.7476910Z 24.04.3
+2025-12-07T21:21:18.7477342Z LTS
+2025-12-07T21:21:18.7477885Z ##[endgroup]
+2025-12-07T21:21:18.7478359Z ##[group]Runner Image
+2025-12-07T21:21:18.7478925Z Image: ubuntu-24.04
+2025-12-07T21:21:18.7479466Z Version: 20251126.144.1
+2025-12-07T21:21:18.7480459Z Included Software: https://github.com/actions/runner-images/blob/ubuntu24/20251126.144/images/ubuntu/Ubuntu2404-Readme.md
+2025-12-07T21:21:18.7482111Z Image Release: https://github.com/actions/runner-images/releases/tag/ubuntu24%2F20251126.144
+2025-12-07T21:21:18.7483206Z ##[endgroup]
+2025-12-07T21:21:18.7485680Z ##[group]GITHUB_TOKEN Permissions
+2025-12-07T21:21:18.7488088Z Actions: write
+2025-12-07T21:21:18.7488629Z ArtifactMetadata: write
+2025-12-07T21:21:18.7489183Z Attestations: write
+2025-12-07T21:21:18.7489805Z Checks: write
+2025-12-07T21:21:18.7490268Z Contents: write
+2025-12-07T21:21:18.7490756Z Deployments: write
+2025-12-07T21:21:18.7491348Z Discussions: write
+2025-12-07T21:21:18.7492029Z Issues: write
+2025-12-07T21:21:18.7492498Z Metadata: read
+2025-12-07T21:21:18.7493042Z Models: read
+2025-12-07T21:21:18.7493493Z Packages: write
+2025-12-07T21:21:18.7494009Z Pages: write
+2025-12-07T21:21:18.7494548Z PullRequests: write
+2025-12-07T21:21:18.7495105Z RepositoryProjects: write
+2025-12-07T21:21:18.7495773Z SecurityEvents: write
+2025-12-07T21:21:18.7496318Z Statuses: write
+2025-12-07T21:21:18.7496846Z ##[endgroup]
+2025-12-07T21:21:18.7498882Z Secret source: Actions
+2025-12-07T21:21:18.7500139Z Prepare workflow directory
+2025-12-07T21:21:18.7831322Z Prepare all required actions
+2025-12-07T21:21:18.7871266Z Getting action download info
+2025-12-07T21:21:19.1327472Z Download action repository 'actions/checkout@v4' (SHA:34e114876b0b11c390a56381ad16ebd13914f8d5)
+2025-12-07T21:21:19.5154928Z Download action repository 'actions/setup-node@v4' (SHA:49933ea5288caeca8642d1e84afbd3f7d6820020)
+2025-12-07T21:21:19.6076349Z Download action repository 'ruby/setup-ruby@v1' (SHA:d697be2f83c6234b20877c3b5eac7a7f342f0d0c)
+2025-12-07T21:21:19.9363312Z Download action repository 'actions/upload-artifact@v4' (SHA:ea165f8d65b6e75b540449e92b4886f43607fa02)
+2025-12-07T21:21:20.1463721Z Complete job name: pre-deployment-tests
+2025-12-07T21:21:20.2252080Z ##[group]Run actions/checkout@v4
+2025-12-07T21:21:20.2253211Z with:
+2025-12-07T21:21:20.2253666Z   ref: main
+2025-12-07T21:21:20.2254249Z   repository: T193R-W00D5/myFreecodecampLearning
+2025-12-07T21:21:20.2255303Z   token: ***
+2025-12-07T21:21:20.2255783Z   ssh-strict: true
+2025-12-07T21:21:20.2256275Z   ssh-user: git
+2025-12-07T21:21:20.2256832Z   persist-credentials: true
+2025-12-07T21:21:20.2257437Z   clean: true
+2025-12-07T21:21:20.2257975Z   sparse-checkout-cone-mode: true
+2025-12-07T21:21:20.2258650Z   fetch-depth: 1
+2025-12-07T21:21:20.2259144Z   fetch-tags: false
+2025-12-07T21:21:20.2259721Z   show-progress: true
+2025-12-07T21:21:20.2260257Z   lfs: false
+2025-12-07T21:21:20.2260744Z   submodules: false
+2025-12-07T21:21:20.2261272Z   set-safe-directory: true
+2025-12-07T21:21:20.2262371Z ##[endgroup]
+2025-12-07T21:21:20.3335633Z Syncing repository: T193R-W00D5/myFreecodecampLearning
+2025-12-07T21:21:20.3339046Z ##[group]Getting Git version info
+2025-12-07T21:21:20.3341640Z Working directory is '/home/runner/work/myFreecodecampLearning/myFreecodecampLearning'
+2025-12-07T21:21:20.3344421Z [command]/usr/bin/git version
+2025-12-07T21:21:20.3405813Z git version 2.52.0
+2025-12-07T21:21:20.3432026Z ##[endgroup]
+2025-12-07T21:21:20.3447175Z Temporarily overriding HOME='/home/runner/work/_temp/f13edf33-4030-4713-8403-8ed9e2299414' before making global git config changes
+2025-12-07T21:21:20.3450227Z Adding repository directory to the temporary git global config as a safe directory
+2025-12-07T21:21:20.3454034Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/myFreecodecampLearning/myFreecodecampLearning
+2025-12-07T21:21:20.3493179Z Deleting the contents of '/home/runner/work/myFreecodecampLearning/myFreecodecampLearning'
+2025-12-07T21:21:20.3496112Z ##[group]Initializing the repository
+2025-12-07T21:21:20.3500357Z [command]/usr/bin/git init /home/runner/work/myFreecodecampLearning/myFreecodecampLearning
+2025-12-07T21:21:20.3606959Z hint: Using 'master' as the name for the initial branch. This default branch name
+2025-12-07T21:21:20.3609379Z hint: will change to "main" in Git 3.0. To configure the initial branch name
+2025-12-07T21:21:20.3612045Z hint: to use in all of your new repositories, which will suppress this warning,
+2025-12-07T21:21:20.3613502Z hint: call:
+2025-12-07T21:21:20.3613938Z hint:
+2025-12-07T21:21:20.3614593Z hint: 	git config --global init.defaultBranch <name>
+2025-12-07T21:21:20.3615724Z hint:
+2025-12-07T21:21:20.3616597Z hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
+2025-12-07T21:21:20.3618042Z hint: 'development'. The just-created branch can be renamed via this command:
+2025-12-07T21:21:20.3619112Z hint:
+2025-12-07T21:21:20.3619595Z hint: 	git branch -m <name>
+2025-12-07T21:21:20.3620230Z hint:
+2025-12-07T21:21:20.3621918Z hint: Disable this message with "git config set advice.defaultBranchName false"
+2025-12-07T21:21:20.3623954Z Initialized empty Git repository in /home/runner/work/myFreecodecampLearning/myFreecodecampLearning/.git/
+2025-12-07T21:21:20.3626843Z [command]/usr/bin/git remote add origin https://github.com/T193R-W00D5/myFreecodecampLearning
+2025-12-07T21:21:20.3656072Z ##[endgroup]
+2025-12-07T21:21:20.3657012Z ##[group]Disabling automatic garbage collection
+2025-12-07T21:21:20.3660079Z [command]/usr/bin/git config --local gc.auto 0
+2025-12-07T21:21:20.3689643Z ##[endgroup]
+2025-12-07T21:21:20.3691322Z ##[group]Setting up auth
+2025-12-07T21:21:20.3697665Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+2025-12-07T21:21:20.3729582Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+2025-12-07T21:21:20.4055827Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+2025-12-07T21:21:20.4087504Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+2025-12-07T21:21:20.4302875Z [command]/usr/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+2025-12-07T21:21:20.4331787Z [command]/usr/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+2025-12-07T21:21:20.4549522Z [command]/usr/bin/git config --local http.https://github.com/.extraheader AUTHORIZATION: basic ***
+2025-12-07T21:21:20.4583589Z ##[endgroup]
+2025-12-07T21:21:20.4585285Z ##[group]Fetching the repository
+2025-12-07T21:21:20.4594546Z [command]/usr/bin/git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +refs/heads/main*:refs/remotes/origin/main* +refs/tags/main*:refs/tags/main*
+2025-12-07T21:21:20.9053232Z From https://github.com/T193R-W00D5/myFreecodecampLearning
+2025-12-07T21:21:20.9054538Z  * [new branch]      main       -> origin/main
+2025-12-07T21:21:20.9085810Z ##[endgroup]
+2025-12-07T21:21:20.9086762Z ##[group]Determining the checkout info
+2025-12-07T21:21:20.9093328Z [command]/usr/bin/git branch --list --remote origin/main
+2025-12-07T21:21:20.9117485Z   origin/main
+2025-12-07T21:21:20.9122328Z ##[endgroup]
+2025-12-07T21:21:20.9126317Z [command]/usr/bin/git sparse-checkout disable
+2025-12-07T21:21:20.9163985Z [command]/usr/bin/git config --local --unset-all extensions.worktreeConfig
+2025-12-07T21:21:20.9190185Z ##[group]Checking out the ref
+2025-12-07T21:21:20.9193467Z [command]/usr/bin/git checkout --progress --force -B main refs/remotes/origin/main
+2025-12-07T21:21:20.9524814Z Switched to a new branch 'main'
+2025-12-07T21:21:20.9526871Z branch 'main' set up to track 'origin/main'.
+2025-12-07T21:21:20.9535919Z ##[endgroup]
+2025-12-07T21:21:20.9572864Z [command]/usr/bin/git log -1 --format=%H
+2025-12-07T21:21:20.9595225Z 9d93fc766a566e22c60ab7248e1c0d43405514ba
+2025-12-07T21:21:20.9804661Z ##[group]Run echo "🚀 PRODUCTION DEPLOYMENT INFORMATION" >> $GITHUB_STEP_SUMMARY
+2025-12-07T21:21:20.9806023Z [36;1mecho "🚀 PRODUCTION DEPLOYMENT INFORMATION" >> $GITHUB_STEP_SUMMARY[0m
+2025-12-07T21:21:20.9807194Z [36;1mecho "**Environment:** Production" >> $GITHUB_STEP_SUMMARY[0m
+2025-12-07T21:21:20.9808229Z [36;1mecho "**Branch:** main" >> $GITHUB_STEP_SUMMARY[0m
+2025-12-07T21:21:20.9809264Z [36;1mecho "**Commit:** $(git rev-parse HEAD)" >> $GITHUB_STEP_SUMMARY[0m
+2025-12-07T21:21:20.9810421Z [36;1mecho "**Commit Message:** $(git log --oneline -n 1)" >> $GITHUB_STEP_SUMMARY[0m
+2025-12-07T21:21:20.9811700Z [36;1mecho "**Triggered by:** T193R-W00D5" >> $GITHUB_STEP_SUMMARY[0m
+2025-12-07T21:21:20.9812745Z [36;1mecho "**Timestamp:** $(date)" >> $GITHUB_STEP_SUMMARY[0m
+2025-12-07T21:21:20.9851977Z shell: /usr/bin/bash -e {0}
+2025-12-07T21:21:20.9852859Z ##[endgroup]
+2025-12-07T21:21:21.0102634Z ##[group]Run actions/setup-node@v4
+2025-12-07T21:21:21.0103475Z with:
+2025-12-07T21:21:21.0104181Z   node-version: 22
+2025-12-07T21:21:21.0104898Z   cache: npm
+2025-12-07T21:21:21.0105605Z   always-auth: false
+2025-12-07T21:21:21.0106334Z   check-latest: false
+2025-12-07T21:21:21.0107218Z   token: ***
+2025-12-07T21:21:21.0107907Z ##[endgroup]
+2025-12-07T21:21:21.1888761Z Found in cache @ /opt/hostedtoolcache/node/22.21.1/x64
+2025-12-07T21:21:21.1893841Z ##[group]Environment details
+2025-12-07T21:21:23.6051726Z node: v22.21.1
+2025-12-07T21:21:23.6052210Z npm: 10.9.4
+2025-12-07T21:21:23.6052509Z yarn: 1.22.22
+2025-12-07T21:21:23.6054040Z ##[endgroup]
+2025-12-07T21:21:23.6075176Z [command]/opt/hostedtoolcache/node/22.21.1/x64/bin/npm config get cache
+2025-12-07T21:21:23.8538186Z /home/runner/.npm
+2025-12-07T21:21:24.0283768Z Cache hit for: node-cache-Linux-x64-npm-e3fade3f30968ac95fccac45edc85cd25eaa881f6a1cdb7268c834223e952c45
+2025-12-07T21:21:24.5699811Z Received 20062804 of 20062804 (100.0%), 44.2 MBs/sec
+2025-12-07T21:21:24.5700308Z Cache Size: ~19 MB (20062804 B)
+2025-12-07T21:21:24.5727759Z [command]/usr/bin/tar -xf /home/runner/work/_temp/6495308f-1ec3-4049-afee-1bc8f7f8b567/cache.tzst -P -C /home/runner/work/myFreecodecampLearning/myFreecodecampLearning --use-compress-program unzstd
+2025-12-07T21:21:24.6747685Z Cache restored successfully
+2025-12-07T21:21:24.6794470Z Cache restored from key: node-cache-Linux-x64-npm-e3fade3f30968ac95fccac45edc85cd25eaa881f6a1cdb7268c834223e952c45
+2025-12-07T21:21:24.6949148Z ##[group]Run ruby/setup-ruby@v1
+2025-12-07T21:21:24.6949483Z with:
+2025-12-07T21:21:24.6949681Z   ruby-version: 3.3
+2025-12-07T21:21:24.6949894Z   bundler-cache: false
+2025-12-07T21:21:24.6950109Z ##[endgroup]
+2025-12-07T21:21:24.8656734Z ##[group]Modifying PATH
+2025-12-07T21:21:24.8667718Z Entries added to PATH to use selected Ruby:
+2025-12-07T21:21:24.8668228Z   /opt/hostedtoolcache/Ruby/3.3.10/x64/bin
+2025-12-07T21:21:24.8672177Z ##[endgroup]
+2025-12-07T21:21:24.8673274Z ##[group]Print Ruby version
+2025-12-07T21:21:24.8791800Z [command]/opt/hostedtoolcache/Ruby/3.3.10/x64/bin/ruby --version
+2025-12-07T21:21:25.0573478Z ruby 3.3.10 (2025-10-23 revision 343ea05002) [x86_64-linux]
+2025-12-07T21:21:25.0608245Z Took   0.19 seconds
+2025-12-07T21:21:25.0608963Z ##[endgroup]
+2025-12-07T21:21:25.0611043Z ##[group]Installing Bundler
+2025-12-07T21:21:25.0616294Z Using Bundler 2.7.2 from Gemfile.lock BUNDLED WITH 2.7.2
+2025-12-07T21:21:25.0620487Z [command]/opt/hostedtoolcache/Ruby/3.3.10/x64/bin/gem install bundler -v 2.7.2
+2025-12-07T21:21:26.1920752Z Successfully installed bundler-2.7.2
+2025-12-07T21:21:26.1921639Z 1 gem installed
+2025-12-07T21:21:26.1976238Z Took   1.14 seconds
+2025-12-07T21:21:26.1976970Z ##[endgroup]
+2025-12-07T21:21:26.2067652Z ##[group]Run npm ci
+2025-12-07T21:21:26.2067915Z [36;1mnpm ci[0m
+2025-12-07T21:21:26.2105258Z shell: /usr/bin/bash -e {0}
+2025-12-07T21:21:26.2105505Z ##[endgroup]
+2025-12-07T21:21:27.7843582Z npm warn EBADENGINE Unsupported engine {
+2025-12-07T21:21:27.7844595Z npm warn EBADENGINE   package: 'freecodecamporg-website-copies@1.0.0',
+2025-12-07T21:21:27.7845493Z npm warn EBADENGINE   required: { node: '>=18 <=22.21.0' },
+2025-12-07T21:21:27.7846257Z npm warn EBADENGINE   current: { node: 'v22.21.1', npm: '10.9.4' }
+2025-12-07T21:21:27.7846730Z npm warn EBADENGINE }
+2025-12-07T21:21:28.9563012Z npm warn deprecated inflight@1.0.6: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
+2025-12-07T21:21:29.1600689Z npm warn deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported
+2025-12-07T21:21:30.1070611Z 
+2025-12-07T21:21:30.1071351Z added 557 packages, and audited 558 packages in 4s
+2025-12-07T21:21:30.1072333Z 
+2025-12-07T21:21:30.1072736Z 68 packages are looking for funding
+2025-12-07T21:21:30.1073819Z   run `npm fund` for details
+2025-12-07T21:21:30.1093468Z 
+2025-12-07T21:21:30.1094129Z 1 moderate severity vulnerability
+2025-12-07T21:21:30.1094785Z 
+2025-12-07T21:21:30.1095272Z To address all issues, run:
+2025-12-07T21:21:30.1096056Z   npm audit fix
+2025-12-07T21:21:30.1096579Z 
+2025-12-07T21:21:30.1106094Z Run `npm audit` for details.
+2025-12-07T21:21:30.1727209Z ##[group]Run bundle config set --local frozen false
+2025-12-07T21:21:30.1727611Z [36;1mbundle config set --local frozen false[0m
+2025-12-07T21:21:30.1727895Z [36;1mbundle install[0m
+2025-12-07T21:21:30.1761847Z shell: /usr/bin/bash -e {0}
+2025-12-07T21:21:30.1762098Z ##[endgroup]
+2025-12-07T21:21:32.2568329Z Fetching gem metadata from https://rubygems.org/..........
+2025-12-07T21:21:32.2617559Z Fetching rake 13.3.1
+2025-12-07T21:21:32.3228223Z Installing rake 13.3.1
+2025-12-07T21:21:32.3376259Z Fetching public_suffix 7.0.0
+2025-12-07T21:21:32.3378713Z Fetching base64 0.3.0
+2025-12-07T21:21:32.3379171Z Fetching bigdecimal 3.3.1
+2025-12-07T21:21:32.3379604Z Fetching colorator 1.1.0
+2025-12-07T21:21:32.3482558Z Installing base64 0.3.0
+2025-12-07T21:21:32.3492145Z Installing public_suffix 7.0.0
+2025-12-07T21:21:32.3577662Z Fetching concurrent-ruby 1.3.5
+2025-12-07T21:21:32.3604384Z Installing colorator 1.1.0
+2025-12-07T21:21:32.3696991Z Installing bigdecimal 3.3.1 with native extensions
+2025-12-07T21:21:32.3744937Z Fetching csv 3.3.5
+2025-12-07T21:21:32.3812439Z Fetching eventmachine 1.2.7
+2025-12-07T21:21:32.3906634Z Installing csv 3.3.5
+2025-12-07T21:21:32.4075872Z Installing concurrent-ruby 1.3.5
+2025-12-07T21:21:32.4241981Z Installing eventmachine 1.2.7 with native extensions
+2025-12-07T21:21:32.4713725Z Fetching http_parser.rb 0.8.0
+2025-12-07T21:21:32.5044020Z Installing http_parser.rb 0.8.0 with native extensions
+2025-12-07T21:21:32.6018698Z Fetching ffi 1.17.2 (x86_64-linux-gnu)
+2025-12-07T21:21:32.6404781Z Installing ffi 1.17.2 (x86_64-linux-gnu)
+2025-12-07T21:21:32.7119495Z Fetching forwardable-extended 2.6.0
+2025-12-07T21:21:32.7190651Z Installing forwardable-extended 2.6.0
+2025-12-07T21:21:32.7220765Z Fetching rb-fsevent 0.11.2
+2025-12-07T21:21:32.7312834Z Installing rb-fsevent 0.11.2
+2025-12-07T21:21:32.7473750Z Fetching json 2.17.1
+2025-12-07T21:21:32.7631646Z Installing json 2.17.1 with native extensions
+2025-12-07T21:21:35.2003671Z Fetching liquid 4.0.4
+2025-12-07T21:21:35.2263190Z Installing liquid 4.0.4
+2025-12-07T21:21:35.2933696Z Fetching mercenary 0.4.0
+2025-12-07T21:21:35.3117032Z Installing mercenary 0.4.0
+2025-12-07T21:21:35.3541086Z Fetching rouge 4.6.1
+2025-12-07T21:21:35.3900211Z Installing rouge 4.6.1
+2025-12-07T21:21:35.5432148Z Fetching safe_yaml 1.0.5
+2025-12-07T21:21:35.5531724Z Installing safe_yaml 1.0.5
+2025-12-07T21:21:35.5687849Z Fetching unicode-display_width 2.6.0
+2025-12-07T21:21:35.5744841Z Installing unicode-display_width 2.6.0
+2025-12-07T21:21:35.5789384Z Fetching webrick 1.9.2
+2025-12-07T21:21:35.5932266Z Installing webrick 1.9.2
+2025-12-07T21:21:35.6124462Z Fetching addressable 2.8.8
+2025-12-07T21:21:35.6272420Z Installing addressable 2.8.8
+2025-12-07T21:21:35.6402080Z Fetching i18n 1.14.7
+2025-12-07T21:21:35.6504204Z Installing i18n 1.14.7
+2025-12-07T21:21:35.6661827Z Fetching rb-inotify 0.11.1
+2025-12-07T21:21:35.6751164Z Installing rb-inotify 0.11.1
+2025-12-07T21:21:35.6824038Z Fetching pathutil 0.16.2
+2025-12-07T21:21:35.6890749Z Installing pathutil 0.16.2
+2025-12-07T21:21:35.6931897Z Fetching kramdown 2.5.1
+2025-12-07T21:21:35.7127458Z Installing kramdown 2.5.1
+2025-12-07T21:21:35.8436182Z Fetching terminal-table 3.0.2
+2025-12-07T21:21:35.8519349Z Installing terminal-table 3.0.2
+2025-12-07T21:21:35.8603143Z Fetching listen 3.9.0
+2025-12-07T21:21:35.8667397Z Installing listen 3.9.0
+2025-12-07T21:21:35.8772055Z Fetching kramdown-parser-gfm 1.1.0
+2025-12-07T21:21:35.8841760Z Installing kramdown-parser-gfm 1.1.0
+2025-12-07T21:21:35.8949445Z Fetching jekyll-watch 2.2.1
+2025-12-07T21:21:35.9030784Z Installing jekyll-watch 2.2.1
+2025-12-07T21:21:42.8197438Z Fetching google-protobuf 4.33.1 (x86_64-linux-gnu)
+2025-12-07T21:21:42.8678643Z Installing google-protobuf 4.33.1 (x86_64-linux-gnu)
+2025-12-07T21:21:42.9269343Z Fetching sass-embedded 1.94.2 (x86_64-linux-gnu)
+2025-12-07T21:21:43.0338436Z Installing sass-embedded 1.94.2 (x86_64-linux-gnu)
+2025-12-07T21:21:43.1372542Z Fetching jekyll-sass-converter 3.1.0
+2025-12-07T21:21:43.1450079Z Installing jekyll-sass-converter 3.1.0
+2025-12-07T21:21:49.7532137Z Fetching em-websocket 0.5.3
+2025-12-07T21:21:49.7637211Z Installing em-websocket 0.5.3
+2025-12-07T21:21:49.7739176Z Fetching jekyll 4.4.1
+2025-12-07T21:21:49.7867226Z Installing jekyll 4.4.1
+2025-12-07T21:21:49.8256377Z Fetching jekyll-feed 0.17.0
+2025-12-07T21:21:49.8266618Z Fetching jekyll-seo-tag 2.8.0
+2025-12-07T21:21:49.8267249Z Fetching jekyll-sitemap 1.4.0
+2025-12-07T21:21:49.8376509Z Installing jekyll-feed 0.17.0
+2025-12-07T21:21:49.8435305Z Installing jekyll-seo-tag 2.8.0
+2025-12-07T21:21:49.8495939Z Installing jekyll-sitemap 1.4.0
+2025-12-07T21:21:49.8827717Z Bundle complete! 9 Gemfile dependencies, 38 gems now installed.
+2025-12-07T21:21:49.8828537Z Use `bundle info [gemname]` to see where a bundled gem is installed.
+2025-12-07T21:21:49.9331601Z ##[group]Run npx playwright install --with-deps
+2025-12-07T21:21:49.9331999Z [36;1mnpx playwright install --with-deps[0m
+2025-12-07T21:21:49.9364735Z shell: /usr/bin/bash -e {0}
+2025-12-07T21:21:49.9364981Z ##[endgroup]
+2025-12-07T21:21:50.7587734Z Installing dependencies...
+2025-12-07T21:21:50.7681130Z Switching to root user to install dependencies...
+2025-12-07T21:21:50.8540504Z Get:1 file:/etc/apt/apt-mirrors.txt Mirrorlist [144 B]
+2025-12-07T21:21:50.8809796Z Get:6 https://packages.microsoft.com/repos/azure-cli noble InRelease [3564 B]
+2025-12-07T21:21:50.8911894Z Get:7 https://packages.microsoft.com/ubuntu/24.04/prod noble InRelease [3600 B]
+2025-12-07T21:21:50.8935000Z Hit:2 http://azure.archive.ubuntu.com/ubuntu noble InRelease
+2025-12-07T21:21:50.8947666Z Get:3 http://azure.archive.ubuntu.com/ubuntu noble-updates InRelease [126 kB]
+2025-12-07T21:21:50.8993730Z Get:4 http://azure.archive.ubuntu.com/ubuntu noble-backports InRelease [126 kB]
+2025-12-07T21:21:50.9016060Z Get:5 http://azure.archive.ubuntu.com/ubuntu noble-security InRelease [126 kB]
+2025-12-07T21:21:50.9612783Z Get:8 https://packages.microsoft.com/repos/azure-cli noble/main amd64 Packages [1822 B]
+2025-12-07T21:21:51.0100338Z Get:9 https://packages.microsoft.com/ubuntu/24.04/prod noble/main amd64 Packages [73.9 kB]
+2025-12-07T21:21:51.0146977Z Get:10 https://packages.microsoft.com/ubuntu/24.04/prod noble/main arm64 Packages [55.6 kB]
+2025-12-07T21:21:51.0227530Z Get:11 https://packages.microsoft.com/ubuntu/24.04/prod noble/main armhf Packages [11.2 kB]
+2025-12-07T21:21:51.1090503Z Get:12 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 Packages [1627 kB]
+2025-12-07T21:21:51.1195571Z Get:13 http://azure.archive.ubuntu.com/ubuntu noble-updates/main Translation-en [305 kB]
+2025-12-07T21:21:51.1219725Z Get:14 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 Components [175 kB]
+2025-12-07T21:21:51.1235308Z Get:15 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 c-n-f Metadata [15.7 kB]
+2025-12-07T21:21:51.1248620Z Get:16 http://azure.archive.ubuntu.com/ubuntu noble-updates/universe amd64 Packages [1501 kB]
+2025-12-07T21:21:51.1343696Z Get:17 http://azure.archive.ubuntu.com/ubuntu noble-updates/universe Translation-en [304 kB]
+2025-12-07T21:21:51.1365145Z Get:18 http://azure.archive.ubuntu.com/ubuntu noble-updates/universe amd64 Components [377 kB]
+2025-12-07T21:21:51.1393952Z Get:19 http://azure.archive.ubuntu.com/ubuntu noble-updates/universe amd64 c-n-f Metadata [31.4 kB]
+2025-12-07T21:21:51.1411655Z Get:20 http://azure.archive.ubuntu.com/ubuntu noble-updates/restricted amd64 Packages [2309 kB]
+2025-12-07T21:21:51.1522736Z Get:21 http://azure.archive.ubuntu.com/ubuntu noble-updates/restricted Translation-en [526 kB]
+2025-12-07T21:21:51.1967950Z Get:22 http://azure.archive.ubuntu.com/ubuntu noble-updates/restricted amd64 Components [212 B]
+2025-12-07T21:21:51.1976654Z Get:23 http://azure.archive.ubuntu.com/ubuntu noble-updates/multiverse amd64 Components [940 B]
+2025-12-07T21:21:51.1987094Z Get:24 http://azure.archive.ubuntu.com/ubuntu noble-backports/main amd64 Components [7136 B]
+2025-12-07T21:21:51.1997703Z Get:25 http://azure.archive.ubuntu.com/ubuntu noble-backports/universe amd64 Packages [29.2 kB]
+2025-12-07T21:21:51.2007473Z Get:26 http://azure.archive.ubuntu.com/ubuntu noble-backports/universe Translation-en [17.6 kB]
+2025-12-07T21:21:51.2017073Z Get:27 http://azure.archive.ubuntu.com/ubuntu noble-backports/universe amd64 Components [11.0 kB]
+2025-12-07T21:21:51.2027676Z Get:28 http://azure.archive.ubuntu.com/ubuntu noble-backports/restricted amd64 Components [212 B]
+2025-12-07T21:21:51.2037272Z Get:29 http://azure.archive.ubuntu.com/ubuntu noble-backports/multiverse amd64 Components [212 B]
+2025-12-07T21:21:51.2258049Z Get:30 http://azure.archive.ubuntu.com/ubuntu noble-security/main amd64 Packages [1349 kB]
+2025-12-07T21:21:51.2327910Z Get:31 http://azure.archive.ubuntu.com/ubuntu noble-security/main Translation-en [221 kB]
+2025-12-07T21:21:51.2346743Z Get:32 http://azure.archive.ubuntu.com/ubuntu noble-security/main amd64 Components [21.6 kB]
+2025-12-07T21:21:51.2356438Z Get:33 http://azure.archive.ubuntu.com/ubuntu noble-security/main amd64 c-n-f Metadata [9448 B]
+2025-12-07T21:21:51.2367630Z Get:34 http://azure.archive.ubuntu.com/ubuntu noble-security/universe amd64 Packages [915 kB]
+2025-12-07T21:21:51.2413569Z Get:35 http://azure.archive.ubuntu.com/ubuntu noble-security/universe Translation-en [206 kB]
+2025-12-07T21:21:51.2850613Z Get:36 http://azure.archive.ubuntu.com/ubuntu noble-security/universe amd64 Components [71.5 kB]
+2025-12-07T21:21:51.2867130Z Get:37 http://azure.archive.ubuntu.com/ubuntu noble-security/universe amd64 c-n-f Metadata [19.4 kB]
+2025-12-07T21:21:51.2883683Z Get:38 http://azure.archive.ubuntu.com/ubuntu noble-security/restricted amd64 Packages [2205 kB]
+2025-12-07T21:21:51.3076209Z Get:39 http://azure.archive.ubuntu.com/ubuntu noble-security/restricted Translation-en [503 kB]
+2025-12-07T21:21:51.3104298Z Get:40 http://azure.archive.ubuntu.com/ubuntu noble-security/restricted amd64 Components [208 B]
+2025-12-07T21:21:51.3114674Z Get:41 http://azure.archive.ubuntu.com/ubuntu noble-security/multiverse amd64 Components [208 B]
+2025-12-07T21:21:59.7710132Z Fetched 13.3 MB in 2s (8443 kB/s)
+2025-12-07T21:22:00.5210349Z Reading package lists...
+2025-12-07T21:22:00.5465772Z Reading package lists...
+2025-12-07T21:22:00.7171891Z Building dependency tree...
+2025-12-07T21:22:00.7178907Z Reading state information...
+2025-12-07T21:22:00.7341794Z libasound2t64 is already the newest version (1.2.11-1ubuntu0.1).
+2025-12-07T21:22:00.7343174Z libasound2t64 set to manually installed.
+2025-12-07T21:22:00.7344087Z libatk-bridge2.0-0t64 is already the newest version (2.52.0-1build1).
+2025-12-07T21:22:00.7344750Z libatk-bridge2.0-0t64 set to manually installed.
+2025-12-07T21:22:00.7345346Z libatk1.0-0t64 is already the newest version (2.52.0-1build1).
+2025-12-07T21:22:00.7346052Z libatk1.0-0t64 set to manually installed.
+2025-12-07T21:22:00.7346642Z libatspi2.0-0t64 is already the newest version (2.52.0-1build1).
+2025-12-07T21:22:00.7347505Z libatspi2.0-0t64 set to manually installed.
+2025-12-07T21:22:00.7348393Z libcairo2 is already the newest version (1.18.0-3build1).
+2025-12-07T21:22:00.7349191Z libcairo2 set to manually installed.
+2025-12-07T21:22:00.7350033Z libdbus-1-3 is already the newest version (1.14.10-4ubuntu4.1).
+2025-12-07T21:22:00.7350839Z libdbus-1-3 set to manually installed.
+2025-12-07T21:22:00.7351904Z libdrm2 is already the newest version (2.4.122-1~ubuntu0.24.04.2).
+2025-12-07T21:22:00.7352714Z libdrm2 set to manually installed.
+2025-12-07T21:22:00.7353409Z libgbm1 is already the newest version (25.0.7-0ubuntu0.24.04.2).
+2025-12-07T21:22:00.7353811Z libgbm1 set to manually installed.
+2025-12-07T21:22:00.7354214Z libnspr4 is already the newest version (2:4.35-1.1build1).
+2025-12-07T21:22:00.7354605Z libnspr4 set to manually installed.
+2025-12-07T21:22:00.7354990Z libnss3 is already the newest version (2:3.98-1build1).
+2025-12-07T21:22:00.7355363Z libnss3 set to manually installed.
+2025-12-07T21:22:00.7355777Z libpango-1.0-0 is already the newest version (1.52.1+ds-1build1).
+2025-12-07T21:22:00.7356197Z libpango-1.0-0 set to manually installed.
+2025-12-07T21:22:00.7356605Z libx11-6 is already the newest version (2:1.8.7-1build1).
+2025-12-07T21:22:00.7356980Z libx11-6 set to manually installed.
+2025-12-07T21:22:00.7357347Z libxcb1 is already the newest version (1.15-1ubuntu2).
+2025-12-07T21:22:00.7357712Z libxcb1 set to manually installed.
+2025-12-07T21:22:00.7358136Z libxcomposite1 is already the newest version (1:0.4.5-1build3).
+2025-12-07T21:22:00.7358567Z libxcomposite1 set to manually installed.
+2025-12-07T21:22:00.7358998Z libxdamage1 is already the newest version (1:1.1.6-1build1).
+2025-12-07T21:22:00.7359395Z libxdamage1 set to manually installed.
+2025-12-07T21:22:00.7359796Z libxext6 is already the newest version (2:1.3.4-1build2).
+2025-12-07T21:22:00.7360171Z libxext6 set to manually installed.
+2025-12-07T21:22:00.7360805Z libxfixes3 is already the newest version (1:6.0.0-2build1).
+2025-12-07T21:22:00.7361214Z libxfixes3 set to manually installed.
+2025-12-07T21:22:00.7361861Z libxkbcommon0 is already the newest version (1.6.0-1build1).
+2025-12-07T21:22:00.7362274Z libxkbcommon0 set to manually installed.
+2025-12-07T21:22:00.7362692Z libxrandr2 is already the newest version (2:1.5.2-2build1).
+2025-12-07T21:22:00.7363079Z libxrandr2 set to manually installed.
+2025-12-07T21:22:00.7363528Z libcairo-gobject2 is already the newest version (1.18.0-3build1).
+2025-12-07T21:22:00.7363968Z libcairo-gobject2 set to manually installed.
+2025-12-07T21:22:00.7364394Z libfontconfig1 is already the newest version (2.15.0-1.1ubuntu2).
+2025-12-07T21:22:00.7364798Z libfontconfig1 set to manually installed.
+2025-12-07T21:22:00.7365200Z libfreetype6 is already the newest version (2.13.2+dfsg-1build3).
+2025-12-07T21:22:00.7365585Z libfreetype6 set to manually installed.
+2025-12-07T21:22:00.7366043Z libgdk-pixbuf-2.0-0 is already the newest version (2.42.10+dfsg-3ubuntu3.2).
+2025-12-07T21:22:00.7366504Z libgdk-pixbuf-2.0-0 set to manually installed.
+2025-12-07T21:22:00.7366939Z libgtk-3-0t64 is already the newest version (3.24.41-4ubuntu1.3).
+2025-12-07T21:22:00.7367332Z libgtk-3-0t64 set to manually installed.
+2025-12-07T21:22:00.7367761Z libpangocairo-1.0-0 is already the newest version (1.52.1+ds-1build1).
+2025-12-07T21:22:00.7368185Z libpangocairo-1.0-0 set to manually installed.
+2025-12-07T21:22:00.7368584Z libx11-xcb1 is already the newest version (2:1.8.7-1build1).
+2025-12-07T21:22:00.7368944Z libx11-xcb1 set to manually installed.
+2025-12-07T21:22:00.7369445Z libxcb-shm0 is already the newest version (1.15-1ubuntu2).
+2025-12-07T21:22:00.7369790Z libxcb-shm0 set to manually installed.
+2025-12-07T21:22:00.7370166Z libxcursor1 is already the newest version (1:1.2.1-1build1).
+2025-12-07T21:22:00.7370521Z libxcursor1 set to manually installed.
+2025-12-07T21:22:00.7370877Z libxi6 is already the newest version (2:1.8.1-1build1).
+2025-12-07T21:22:00.7371211Z libxi6 set to manually installed.
+2025-12-07T21:22:00.7371792Z libxrender1 is already the newest version (1:0.9.10-1.1build1).
+2025-12-07T21:22:00.7372153Z libxrender1 set to manually installed.
+2025-12-07T21:22:00.7372514Z libicu74 is already the newest version (74.2-1ubuntu3.1).
+2025-12-07T21:22:00.7373012Z libatomic1 is already the newest version (14.2.0-4ubuntu2~24.04).
+2025-12-07T21:22:00.7373416Z libatomic1 set to manually installed.
+2025-12-07T21:22:00.7373785Z libenchant-2-2 is already the newest version (2.3.3-2build2).
+2025-12-07T21:22:00.7374147Z libenchant-2-2 set to manually installed.
+2025-12-07T21:22:00.7374522Z libepoxy0 is already the newest version (1.5.10-1build1).
+2025-12-07T21:22:00.7374866Z libepoxy0 set to manually installed.
+2025-12-07T21:22:00.7375264Z libgstreamer1.0-0 is already the newest version (1.24.2-1ubuntu0.1).
+2025-12-07T21:22:00.7375670Z libgstreamer1.0-0 set to manually installed.
+2025-12-07T21:22:00.7376050Z libharfbuzz0b is already the newest version (8.3.0-2build2).
+2025-12-07T21:22:00.7376423Z libharfbuzz0b set to manually installed.
+2025-12-07T21:22:00.7376810Z libjpeg-turbo8 is already the newest version (2.1.5-2ubuntu2).
+2025-12-07T21:22:00.7377190Z libjpeg-turbo8 set to manually installed.
+2025-12-07T21:22:00.7377549Z liblcms2-2 is already the newest version (2.14-2build1).
+2025-12-07T21:22:00.7377892Z liblcms2-2 set to manually installed.
+2025-12-07T21:22:00.7378274Z libpng16-16t64 is already the newest version (1.6.43-5build1).
+2025-12-07T21:22:00.7378752Z libpng16-16t64 set to manually installed.
+2025-12-07T21:22:00.7379180Z libwayland-client0 is already the newest version (1.22.0-2.1build1).
+2025-12-07T21:22:00.7379601Z libwayland-client0 set to manually installed.
+2025-12-07T21:22:00.8850508Z libwayland-egl1 is already the newest version (1.22.0-2.1build1).
+2025-12-07T21:22:00.8851714Z libwayland-egl1 set to manually installed.
+2025-12-07T21:22:00.8852678Z libwayland-server0 is already the newest version (1.22.0-2.1build1).
+2025-12-07T21:22:00.8854059Z libwayland-server0 set to manually installed.
+2025-12-07T21:22:00.8854937Z libwebp7 is already the newest version (1.3.2-0.4build3).
+2025-12-07T21:22:00.8855697Z libwebp7 set to manually installed.
+2025-12-07T21:22:00.8856244Z libwebpdemux2 is already the newest version (1.3.2-0.4build3).
+2025-12-07T21:22:00.8856752Z libwebpdemux2 set to manually installed.
+2025-12-07T21:22:00.8857443Z libxml2 is already the newest version (2.9.14+dfsg-1.3ubuntu3.6).
+2025-12-07T21:22:00.8858000Z libxml2 set to manually installed.
+2025-12-07T21:22:00.8858456Z libxslt1.1 is already the newest version (1.1.39-0exp1ubuntu0.24.04.2).
+2025-12-07T21:22:00.8858916Z libxslt1.1 set to manually installed.
+2025-12-07T21:22:00.8859334Z xvfb is already the newest version (2:21.1.12-1ubuntu1.5).
+2025-12-07T21:22:00.8859901Z fonts-noto-color-emoji is already the newest version (2.047-0ubuntu0.24.04.1).
+2025-12-07T21:22:00.8860466Z fonts-liberation is already the newest version (1:2.1.5-3).
+2025-12-07T21:22:00.8860888Z fonts-liberation set to manually installed.
+2025-12-07T21:22:00.8861320Z The following additional packages will be installed:
+2025-12-07T21:22:00.8862014Z   gir1.2-glib-2.0 glib-networking glib-networking-common
+2025-12-07T21:22:00.8862552Z   glib-networking-services gsettings-desktop-schemas libaa1 libabsl20220623t64
+2025-12-07T21:22:00.8863160Z   libass9 libasyncns0 libavc1394-0 libavcodec60 libavfilter9 libavformat60
+2025-12-07T21:22:00.8863682Z   libavtp0 libavutil58 libblas3 libbluray2 libbs2b0 libcaca0
+2025-12-07T21:22:00.8864206Z   libcairo-script-interpreter2 libcdparanoia0 libchromaprint1 libcjson1
+2025-12-07T21:22:00.8865260Z   libcodec2-1.2 libdav1d7 libdc1394-25 libdca0 libdecor-0-0
+2025-12-07T21:22:00.8865859Z   libdirectfb-1.7-7t64 libdv4t64 libdvdnav4 libdvdread8t64 libegl-mesa0
+2025-12-07T21:22:00.8866405Z   libegl1 libfaad2 libflac12t64 libfluidsynth3 libfreeaptx0 libgav1-1
+2025-12-07T21:22:00.8866921Z   libglib2.0-bin libglib2.0-data libgme0 libgraphene-1.0-0 libgsm1
+2025-12-07T21:22:00.8867444Z   libgssdp-1.6-0 libgstreamer-plugins-good1.0-0 libgtk-4-common libgupnp-1.6-0
+2025-12-07T21:22:00.8867955Z   libgupnp-igd-1.6-0 libhwy1t64 libiec61883-0 libimath-3-1-29t64
+2025-12-07T21:22:00.8868411Z   libinstpatch-1.0-2 libjack-jackd2-0 libjxl0.7 liblapack3 liblc3-1
+2025-12-07T21:22:00.8868903Z   libldacbt-enc2 liblilv-0-0 liblrdf0 libltc11 libmbedcrypto7t64 libmfx1
+2025-12-07T21:22:00.8869381Z   libmjpegutils-2.1-0t64 libmodplug1 libmp3lame0 libmpcdec6
+2025-12-07T21:22:00.8869841Z   libmpeg2encpp-2.1-0t64 libmpg123-0t64 libmplex2-2.1-0t64 libmysofa1
+2025-12-07T21:22:00.8870315Z   libneon27t64 libnice10 libopenal-data libopenal1 libopenexr-3-1-30
+2025-12-07T21:22:00.8870767Z   libopenh264-7 libopenmpt0t64 libopenni2-0 liborc-0.4-0t64
+2025-12-07T21:22:00.8871225Z   libpipewire-0.3-0t64 libplacebo338 libpocketsphinx3 libpostproc57
+2025-12-07T21:22:00.8871896Z   libproxy1v5 libpulse0 libqrencode4 libraptor2-0 librav1e0 libraw1394-11
+2025-12-07T21:22:00.8872427Z   librist4 librsvg2-2 librubberband2 libsamplerate0 libsbc1 libsdl2-2.0-0
+2025-12-07T21:22:00.8872956Z   libsecret-common libserd-0-0 libshine3 libshout3 libsndfile1 libsndio7.0
+2025-12-07T21:22:00.8873454Z   libsord-0-0 libsoundtouch1 libsoup-3.0-0 libsoup-3.0-common libsoxr0
+2025-12-07T21:22:00.8873972Z   libspa-0.2-modules libspandsp2t64 libspeex1 libsphinxbase3t64 libsratom-0-0
+2025-12-07T21:22:00.8874491Z   libsrt1.5-gnutls libsrtp2-1 libssh-4 libssh-gcrypt-4 libsvtav1enc1d1
+2025-12-07T21:22:00.8875013Z   libswresample4 libswscale7 libtag1v5 libtag1v5-vanilla libtheora0
+2025-12-07T21:22:00.8875494Z   libtwolame0 libudfread0 libunibreak5 libv4l-0t64 libv4lconvert0t64
+2025-12-07T21:22:00.8875970Z   libva-drm2 libva-x11-2 libva2 libvdpau1 libvidstab1.1 libvisual-0.4-0
+2025-12-07T21:22:00.8876449Z   libvo-aacenc0 libvo-amrwbenc0 libvorbisenc2 libvpl2 libwavpack1
+2025-12-07T21:22:00.8876917Z   libwebrtc-audio-processing1 libwildmidi2 libx265-199 libxcb-xkb1
+2025-12-07T21:22:00.8877412Z   libxkbcommon-x11-0 libxvidcore4 libyuv0 libzbar0t64 libzimg2 libzix-0-0
+2025-12-07T21:22:00.8878099Z   libzvbi-common libzvbi0t64 libzxing3 ocl-icd-libopencl1 session-migration
+2025-12-07T21:22:00.8878565Z   timgm6mb-soundfont xfonts-encodings xfonts-utils
+2025-12-07T21:22:00.8878876Z Suggested packages:
+2025-12-07T21:22:00.8879239Z   frei0r-plugins gvfs libcuda1 libnvcuvid1 libnvidia-encode1 libbluray-bdj
+2025-12-07T21:22:00.8879730Z   cups-common libdirectfb-extra libdv-bin oss-compat libdvdcss2
+2025-12-07T21:22:00.8880234Z   low-memory-monitor libvisual-0.4-plugins jackd2 liblrdf0-dev libportaudio2
+2025-12-07T21:22:00.8880766Z   opus-tools pipewire pulseaudio raptor2-utils libraw1394-doc librsvg2-bin
+2025-12-07T21:22:00.8881295Z   serdi sndiod sordi speex libwildmidi-config opencl-icd fluid-soundfont-gm
+2025-12-07T21:22:00.8881804Z Recommended packages:
+2025-12-07T21:22:00.8882133Z   fonts-ipafont-mincho fonts-tlwg-loma gstreamer1.0-x libaacs0
+2025-12-07T21:22:00.8882605Z   default-libdecor-0-plugin-1 | libdecor-0-plugin-1 gstreamer1.0-gl
+2025-12-07T21:22:00.8883144Z   libgtk-4-bin librsvg2-common libgtk-4-media-gstreamer libpipewire-0.3-common
+2025-12-07T21:22:00.8883707Z   pocketsphinx-en-us va-driver-all | va-driver vdpau-driver-all | vdpau-driver
+2025-12-07T21:22:00.8884102Z   libmagickcore-6.q16-7-extra
+2025-12-07T21:22:00.9578904Z The following NEW packages will be installed:
+2025-12-07T21:22:00.9580018Z   fonts-freefont-ttf fonts-ipafont-gothic fonts-tlwg-loma-otf fonts-unifont
+2025-12-07T21:22:00.9581110Z   fonts-wqy-zenhei glib-networking glib-networking-common
+2025-12-07T21:22:00.9582416Z   glib-networking-services gsettings-desktop-schemas gstreamer1.0-libav
+2025-12-07T21:22:00.9584175Z   gstreamer1.0-plugins-bad gstreamer1.0-plugins-base gstreamer1.0-plugins-good
+2025-12-07T21:22:00.9585442Z   libaa1 libabsl20220623t64 libass9 libasyncns0 libavc1394-0 libavcodec60
+2025-12-07T21:22:00.9586301Z   libavfilter9 libavformat60 libavif16 libavtp0 libavutil58 libblas3
+2025-12-07T21:22:00.9587134Z   libbluray2 libbs2b0 libcaca0 libcairo-script-interpreter2 libcdparanoia0
+2025-12-07T21:22:00.9588172Z   libchromaprint1 libcjson1 libcodec2-1.2 libdav1d7 libdc1394-25 libdca0
+2025-12-07T21:22:00.9589093Z   libdecor-0-0 libdirectfb-1.7-7t64 libdv4t64 libdvdnav4 libdvdread8t64
+2025-12-07T21:22:00.9589832Z   libegl-mesa0 libegl1 libevent-2.1-7t64 libfaad2 libflac12t64 libflite1
+2025-12-07T21:22:00.9611241Z   libfluidsynth3 libfreeaptx0 libgav1-1 libgles2 libgme0 libgraphene-1.0-0
+2025-12-07T21:22:00.9612371Z   libgsm1 libgssdp-1.6-0 libgstreamer-gl1.0-0 libgstreamer-plugins-bad1.0-0
+2025-12-07T21:22:00.9613299Z   libgstreamer-plugins-base1.0-0 libgstreamer-plugins-good1.0-0 libgtk-4-1
+2025-12-07T21:22:00.9614205Z   libgtk-4-common libgupnp-1.6-0 libgupnp-igd-1.6-0 libharfbuzz-icu0
+2025-12-07T21:22:00.9615069Z   libhwy1t64 libhyphen0 libiec61883-0 libimath-3-1-29t64 libinstpatch-1.0-2
+2025-12-07T21:22:00.9615631Z   libjack-jackd2-0 libjxl0.7 liblapack3 liblc3-1 libldacbt-enc2 liblilv-0-0
+2025-12-07T21:22:00.9616124Z   liblrdf0 libltc11 libmanette-0.2-0 libmbedcrypto7t64 libmfx1
+2025-12-07T21:22:00.9616572Z   libmjpegutils-2.1-0t64 libmodplug1 libmp3lame0 libmpcdec6
+2025-12-07T21:22:00.9617044Z   libmpeg2encpp-2.1-0t64 libmpg123-0t64 libmplex2-2.1-0t64 libmysofa1
+2025-12-07T21:22:00.9617534Z   libneon27t64 libnice10 libopenal-data libopenal1 libopenexr-3-1-30
+2025-12-07T21:22:00.9618006Z   libopenh264-7 libopenmpt0t64 libopenni2-0 libopus0 liborc-0.4-0t64
+2025-12-07T21:22:00.9618496Z   libpipewire-0.3-0t64 libplacebo338 libpocketsphinx3 libpostproc57
+2025-12-07T21:22:00.9619002Z   libproxy1v5 libpulse0 libqrencode4 libraptor2-0 librav1e0 libraw1394-11
+2025-12-07T21:22:00.9619554Z   librist4 librsvg2-2 librubberband2 libsamplerate0 libsbc1 libsdl2-2.0-0
+2025-12-07T21:22:00.9620084Z   libsecret-1-0 libsecret-common libserd-0-0 libshine3 libshout3 libsndfile1
+2025-12-07T21:22:00.9620605Z   libsndio7.0 libsord-0-0 libsoundtouch1 libsoup-3.0-0 libsoup-3.0-common
+2025-12-07T21:22:00.9621101Z   libsoxr0 libspa-0.2-modules libspandsp2t64 libspeex1 libsphinxbase3t64
+2025-12-07T21:22:00.9622107Z   libsratom-0-0 libsrt1.5-gnutls libsrtp2-1 libssh-gcrypt-4 libsvtav1enc1d1
+2025-12-07T21:22:00.9622649Z   libswresample4 libswscale7 libtag1v5 libtag1v5-vanilla libtheora0
+2025-12-07T21:22:00.9623145Z   libtwolame0 libudfread0 libunibreak5 libv4l-0t64 libv4lconvert0t64
+2025-12-07T21:22:00.9623634Z   libva-drm2 libva-x11-2 libva2 libvdpau1 libvidstab1.1 libvisual-0.4-0
+2025-12-07T21:22:00.9624125Z   libvo-aacenc0 libvo-amrwbenc0 libvorbisenc2 libvpl2 libvpx9 libwavpack1
+2025-12-07T21:22:00.9624661Z   libwebrtc-audio-processing1 libwildmidi2 libwoff1 libx264-164 libx265-199
+2025-12-07T21:22:00.9625217Z   libxcb-xkb1 libxkbcommon-x11-0 libxvidcore4 libyuv0 libzbar0t64 libzimg2
+2025-12-07T21:22:00.9625720Z   libzix-0-0 libzvbi-common libzvbi0t64 libzxing3 ocl-icd-libopencl1
+2025-12-07T21:22:00.9626216Z   session-migration timgm6mb-soundfont xfonts-cyrillic xfonts-encodings
+2025-12-07T21:22:00.9626618Z   xfonts-scalable xfonts-utils
+2025-12-07T21:22:00.9626926Z The following packages will be upgraded:
+2025-12-07T21:22:00.9627348Z   gir1.2-glib-2.0 libcups2t64 libglib2.0-0t64 libglib2.0-bin libglib2.0-data
+2025-12-07T21:22:00.9627712Z   libssh-4
+2025-12-07T21:22:00.9840920Z 6 upgraded, 179 newly installed, 0 to remove and 47 not upgraded.
+2025-12-07T21:22:00.9841790Z Need to get 116 MB of archives.
+2025-12-07T21:22:00.9842507Z After this operation, 363 MB of additional disk space will be used.
+2025-12-07T21:22:00.9843293Z Get:1 file:/etc/apt/apt-mirrors.txt Mirrorlist [144 B]
+2025-12-07T21:22:01.0242672Z Get:2 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 fonts-ipafont-gothic all 00303-21ubuntu1 [3513 kB]
+2025-12-07T21:22:01.0864785Z Get:3 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libglib2.0-data all 2.80.0-6ubuntu3.5 [48.8 kB]
+2025-12-07T21:22:01.1084802Z Get:4 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libglib2.0-bin amd64 2.80.0-6ubuntu3.5 [97.9 kB]
+2025-12-07T21:22:01.1315151Z Get:5 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 gir1.2-glib-2.0 amd64 2.80.0-6ubuntu3.5 [183 kB]
+2025-12-07T21:22:01.1551300Z Get:6 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libglib2.0-0t64 amd64 2.80.0-6ubuntu3.5 [1544 kB]
+2025-12-07T21:22:01.1924924Z Get:7 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 fonts-freefont-ttf all 20211204+svn4273-2 [5641 kB]
+2025-12-07T21:22:01.2588918Z Get:8 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 fonts-tlwg-loma-otf all 1:0.7.3-1 [107 kB]
+2025-12-07T21:22:01.2812192Z Get:9 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 fonts-unifont all 1:15.1.01-1build1 [2993 kB]
+2025-12-07T21:22:01.3261131Z Get:10 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 fonts-wqy-zenhei all 0.9.45-8 [7472 kB]
+2025-12-07T21:22:01.4013778Z Get:11 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libproxy1v5 amd64 0.5.4-4build1 [26.5 kB]
+2025-12-07T21:22:01.4231255Z Get:12 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 glib-networking-common all 2.80.0-1build1 [6702 B]
+2025-12-07T21:22:01.4447884Z Get:13 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 glib-networking-services amd64 2.80.0-1build1 [12.8 kB]
+2025-12-07T21:22:01.4685108Z Get:14 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 session-migration amd64 0.3.9build1 [9034 B]
+2025-12-07T21:22:01.4902463Z Get:15 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 gsettings-desktop-schemas all 46.1-0ubuntu1 [35.6 kB]
+2025-12-07T21:22:01.5124411Z Get:16 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 glib-networking amd64 2.80.0-1build1 [64.1 kB]
+2025-12-07T21:22:01.5350507Z Get:17 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libva2 amd64 2.20.0-2build1 [66.2 kB]
+2025-12-07T21:22:01.5574121Z Get:18 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libva-drm2 amd64 2.20.0-2build1 [7124 B]
+2025-12-07T21:22:01.5789619Z Get:19 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libva-x11-2 amd64 2.20.0-2build1 [12.0 kB]
+2025-12-07T21:22:01.6414942Z Get:20 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libvdpau1 amd64 1.5-2build1 [27.8 kB]
+2025-12-07T21:22:01.6652571Z Get:21 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libvpl2 amd64 2023.3.0-1build1 [99.8 kB]
+2025-12-07T21:22:01.6900669Z Get:22 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 ocl-icd-libopencl1 amd64 2.3.2-1build1 [38.5 kB]
+2025-12-07T21:22:01.7117374Z Get:23 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libavutil58 amd64 7:6.1.1-3ubuntu5 [401 kB]
+2025-12-07T21:22:01.7433049Z Get:24 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libcodec2-1.2 amd64 1.2.0-2build1 [8998 kB]
+2025-12-07T21:22:01.8419999Z Get:25 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libdav1d7 amd64 1.4.1-1build1 [604 kB]
+2025-12-07T21:22:01.8688065Z Get:26 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libgsm1 amd64 1.0.22-1build1 [27.8 kB]
+2025-12-07T21:22:01.8909251Z Get:27 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libhwy1t64 amd64 1.0.7-8.1build1 [584 kB]
+2025-12-07T21:22:01.9192470Z Get:28 http://azure.archive.ubuntu.com/ubuntu noble-updates/universe amd64 libjxl0.7 amd64 0.7.0-10.2ubuntu6.1 [1001 kB]
+2025-12-07T21:22:01.9560481Z Get:29 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libmp3lame0 amd64 3.100-6build1 [142 kB]
+2025-12-07T21:22:01.9819438Z Get:30 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libopus0 amd64 1.4-1build1 [208 kB]
+2025-12-07T21:22:02.0070842Z Get:31 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 librav1e0 amd64 0.7.1-2 [1022 kB]
+2025-12-07T21:22:02.0400364Z Get:32 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 librsvg2-2 amd64 2.58.0+dfsg-1build1 [2135 kB]
+2025-12-07T21:22:02.0803183Z Get:33 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libshine3 amd64 3.1.1-2build1 [23.2 kB]
+2025-12-07T21:22:02.1053143Z Get:34 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libspeex1 amd64 1.2.1-2ubuntu2.24.04.1 [59.6 kB]
+2025-12-07T21:22:02.1286252Z Get:35 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libsvtav1enc1d1 amd64 1.7.0+dfsg-2build1 [2425 kB]
+2025-12-07T21:22:02.1768733Z Get:36 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libsoxr0 amd64 0.1.3-4build3 [80.0 kB]
+2025-12-07T21:22:02.1997246Z Get:37 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libswresample4 amd64 7:6.1.1-3ubuntu5 [63.8 kB]
+2025-12-07T21:22:02.2230248Z Get:38 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libtheora0 amd64 1.1.1+dfsg.1-16.1build3 [211 kB]
+2025-12-07T21:22:02.2899716Z Get:39 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libtwolame0 amd64 0.4.0-2build3 [52.3 kB]
+2025-12-07T21:22:02.3121105Z Get:40 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libvorbisenc2 amd64 1.3.7-1build3 [80.8 kB]
+2025-12-07T21:22:02.3356197Z Get:41 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libvpx9 amd64 1.14.0-1ubuntu2.2 [1143 kB]
+2025-12-07T21:22:02.3734652Z Get:42 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libx264-164 amd64 2:0.164.3108+git31e19f9-1 [604 kB]
+2025-12-07T21:22:02.4031601Z Get:43 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libx265-199 amd64 3.5-2build1 [1226 kB]
+2025-12-07T21:22:02.4397186Z Get:44 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libxvidcore4 amd64 2:1.3.7-1build1 [219 kB]
+2025-12-07T21:22:02.4632059Z Get:45 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libzvbi-common all 0.2.42-2 [42.4 kB]
+2025-12-07T21:22:02.4861936Z Get:46 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libzvbi0t64 amd64 0.2.42-2 [261 kB]
+2025-12-07T21:22:02.5110802Z Get:47 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libavcodec60 amd64 7:6.1.1-3ubuntu5 [5851 kB]
+2025-12-07T21:22:02.6079043Z Get:48 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libunibreak5 amd64 5.1-2build1 [25.0 kB]
+2025-12-07T21:22:02.6298833Z Get:49 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libass9 amd64 1:0.17.1-2build1 [104 kB]
+2025-12-07T21:22:02.6524769Z Get:50 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libudfread0 amd64 1.1.2-1build1 [19.0 kB]
+2025-12-07T21:22:02.6745889Z Get:51 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libbluray2 amd64 1:1.3.4-1build1 [159 kB]
+2025-12-07T21:22:02.6976310Z Get:52 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libchromaprint1 amd64 1.5.1-5 [30.5 kB]
+2025-12-07T21:22:02.7195331Z Get:53 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libgme0 amd64 0.6.3-7build1 [134 kB]
+2025-12-07T21:22:02.7429141Z Get:54 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libmpg123-0t64 amd64 1.32.5-1ubuntu1.1 [169 kB]
+2025-12-07T21:22:02.7655564Z Get:55 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libopenmpt0t64 amd64 0.7.3-1.1build3 [647 kB]
+2025-12-07T21:22:02.7976147Z Get:56 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libcjson1 amd64 1.7.17-1 [24.8 kB]
+2025-12-07T21:22:02.8198641Z Get:57 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libmbedcrypto7t64 amd64 2.28.8-1 [209 kB]
+2025-12-07T21:22:02.8872762Z Get:58 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 librist4 amd64 0.2.10+dfsg-2 [74.9 kB]
+2025-12-07T21:22:02.9195179Z Get:59 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libsrt1.5-gnutls amd64 1.5.3-1build2 [316 kB]
+2025-12-07T21:22:02.9457034Z Get:60 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libssh-gcrypt-4 amd64 0.10.6-2ubuntu0.2 [224 kB]
+2025-12-07T21:22:02.9922626Z Get:61 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libavformat60 amd64 7:6.1.1-3ubuntu5 [1153 kB]
+2025-12-07T21:22:03.0324806Z Get:62 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libbs2b0 amd64 3.1.0+dfsg-7build1 [10.6 kB]
+2025-12-07T21:22:03.0539369Z Get:63 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libflite1 amd64 2.2-6build3 [13.6 MB]
+2025-12-07T21:22:03.2508914Z Get:64 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libserd-0-0 amd64 0.32.2-1 [43.6 kB]
+2025-12-07T21:22:03.2725570Z Get:65 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libzix-0-0 amd64 0.4.2-2build1 [23.6 kB]
+2025-12-07T21:22:03.2942932Z Get:66 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libsord-0-0 amd64 0.16.16-2build1 [15.8 kB]
+2025-12-07T21:22:03.3161980Z Get:67 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libsratom-0-0 amd64 0.6.16-1build1 [17.3 kB]
+2025-12-07T21:22:03.3383860Z Get:68 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 liblilv-0-0 amd64 0.24.22-1build1 [41.0 kB]
+2025-12-07T21:22:03.3605860Z Get:69 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libmysofa1 amd64 1.3.2+dfsg-2ubuntu2 [1158 kB]
+2025-12-07T21:22:03.3974381Z Get:70 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libplacebo338 amd64 6.338.2-2build1 [2654 kB]
+2025-12-07T21:22:03.4515753Z Get:71 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libblas3 amd64 3.12.0-3build1.1 [238 kB]
+2025-12-07T21:22:03.4752568Z Get:72 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 liblapack3 amd64 3.12.0-3build1.1 [2646 kB]
+2025-12-07T21:22:03.5314812Z Get:73 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libasyncns0 amd64 0.8-6build4 [11.3 kB]
+2025-12-07T21:22:03.5531213Z Get:74 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libflac12t64 amd64 1.4.3+ds-2.1ubuntu2 [197 kB]
+2025-12-07T21:22:03.5777702Z Get:75 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libsndfile1 amd64 1.2.2-1ubuntu5.24.04.1 [209 kB]
+2025-12-07T21:22:03.6425904Z Get:76 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libpulse0 amd64 1:16.1+dfsg1-2ubuntu10.1 [292 kB]
+2025-12-07T21:22:03.6704671Z Get:77 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libsphinxbase3t64 amd64 0.8+5prealpha+1-17build2 [126 kB]
+2025-12-07T21:22:03.6941719Z Get:78 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libpocketsphinx3 amd64 0.8.0+real5prealpha+1-15ubuntu5 [133 kB]
+2025-12-07T21:22:03.7175062Z Get:79 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libpostproc57 amd64 7:6.1.1-3ubuntu5 [49.9 kB]
+2025-12-07T21:22:03.7398709Z Get:80 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libsamplerate0 amd64 0.2.2-4build1 [1344 kB]
+2025-12-07T21:22:03.7860524Z Get:81 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 librubberband2 amd64 3.3.0+dfsg-2build1 [130 kB]
+2025-12-07T21:22:03.8086205Z Get:82 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libswscale7 amd64 7:6.1.1-3ubuntu5 [193 kB]
+2025-12-07T21:22:03.8360268Z Get:83 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libvidstab1.1 amd64 1.1.0-2build1 [38.5 kB]
+2025-12-07T21:22:03.8585894Z Get:84 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libzimg2 amd64 3.0.5+ds1-1build1 [254 kB]
+2025-12-07T21:22:03.8829361Z Get:85 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libavfilter9 amd64 7:6.1.1-3ubuntu5 [4235 kB]
+2025-12-07T21:22:03.9529949Z Get:86 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 liborc-0.4-0t64 amd64 1:0.4.38-1ubuntu0.1 [207 kB]
+2025-12-07T21:22:03.9773051Z Get:87 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libgstreamer-plugins-base1.0-0 amd64 1.24.2-1ubuntu0.3 [862 kB]
+2025-12-07T21:22:04.0079794Z Get:88 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 gstreamer1.0-libav amd64 1.24.1-1build1 [103 kB]
+2025-12-07T21:22:04.0319402Z Get:89 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libcdparanoia0 amd64 3.10.2+debian-14build3 [48.5 kB]
+2025-12-07T21:22:04.0547459Z Get:90 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libvisual-0.4-0 amd64 0.4.2-2build1 [115 kB]
+2025-12-07T21:22:04.0784806Z Get:91 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 gstreamer1.0-plugins-base amd64 1.24.2-1ubuntu0.3 [721 kB]
+2025-12-07T21:22:04.1101119Z Get:92 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libaa1 amd64 1.4p5-51.1 [49.9 kB]
+2025-12-07T21:22:04.1328295Z Get:93 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libraw1394-11 amd64 2.1.2-2build3 [26.2 kB]
+2025-12-07T21:22:04.1552040Z Get:94 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libavc1394-0 amd64 0.5.4-5build3 [15.4 kB]
+2025-12-07T21:22:04.2187630Z Get:95 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libcaca0 amd64 0.99.beta20-4build2 [208 kB]
+2025-12-07T21:22:04.2422043Z Get:96 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libdv4t64 amd64 1.0.0-17.1build1 [63.2 kB]
+2025-12-07T21:22:04.2646738Z Get:97 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libgstreamer-plugins-good1.0-0 amd64 1.24.2-1ubuntu1.2 [33.0 kB]
+2025-12-07T21:22:04.2871302Z Get:98 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libiec61883-0 amd64 1.2.0-6build1 [24.5 kB]
+2025-12-07T21:22:04.3096433Z Get:99 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libshout3 amd64 2.4.6-1build2 [50.3 kB]
+2025-12-07T21:22:04.3321958Z Get:100 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libtag1v5-vanilla amd64 1.13.1-1build1 [326 kB]
+2025-12-07T21:22:04.3570655Z Get:101 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libtag1v5 amd64 1.13.1-1build1 [11.7 kB]
+2025-12-07T21:22:04.3793633Z Get:102 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libv4lconvert0t64 amd64 1.26.1-4build3 [87.6 kB]
+2025-12-07T21:22:04.4041128Z Get:103 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libv4l-0t64 amd64 1.26.1-4build3 [46.9 kB]
+2025-12-07T21:22:04.4289306Z Get:104 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libwavpack1 amd64 5.6.0-1build1 [84.6 kB]
+2025-12-07T21:22:04.4534259Z Get:105 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libsoup-3.0-common all 3.4.4-5ubuntu0.5 [11.3 kB]
+2025-12-07T21:22:04.4757455Z Get:106 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libsoup-3.0-0 amd64 3.4.4-5ubuntu0.5 [291 kB]
+2025-12-07T21:22:04.5019079Z Get:107 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 gstreamer1.0-plugins-good amd64 1.24.2-1ubuntu1.2 [2238 kB]
+2025-12-07T21:22:04.5518920Z Get:108 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libabsl20220623t64 amd64 20220623.1-3.1ubuntu3.2 [423 kB]
+2025-12-07T21:22:04.5786022Z Get:109 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libgav1-1 amd64 0.18.0-1build3 [357 kB]
+2025-12-07T21:22:04.6038591Z Get:110 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libyuv0 amd64 0.0~git202401110.af6ac82-1 [178 kB]
+2025-12-07T21:22:04.6282748Z Get:111 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libavif16 amd64 1.0.4-1ubuntu3 [91.2 kB]
+2025-12-07T21:22:04.6509180Z Get:112 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libavtp0 amd64 0.2.0-1build1 [6414 B]
+2025-12-07T21:22:04.6727593Z Get:113 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libcairo-script-interpreter2 amd64 1.18.0-3build1 [60.3 kB]
+2025-12-07T21:22:04.6950519Z Get:114 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libcups2t64 amd64 2.4.7-1.2ubuntu7.9 [273 kB]
+2025-12-07T21:22:04.7196712Z Get:115 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libdc1394-25 amd64 2.2.6-4build1 [90.1 kB]
+2025-12-07T21:22:04.7424409Z Get:116 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libdecor-0-0 amd64 0.2.2-1build2 [16.5 kB]
+2025-12-07T21:22:04.7647461Z Get:117 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libgles2 amd64 1.7.0-1build1 [17.1 kB]
+2025-12-07T21:22:04.7866130Z Get:118 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libdirectfb-1.7-7t64 amd64 1.7.7-11.1ubuntu2 [1035 kB]
+2025-12-07T21:22:04.8228651Z Get:119 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libdvdread8t64 amd64 6.1.3-1.1build1 [54.7 kB]
+2025-12-07T21:22:04.8868570Z Get:120 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libdvdnav4 amd64 6.1.1-3build1 [39.5 kB]
+2025-12-07T21:22:04.9526915Z Get:121 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libegl-mesa0 amd64 25.0.7-0ubuntu0.24.04.2 [124 kB]
+2025-12-07T21:22:04.9781245Z Get:122 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libevent-2.1-7t64 amd64 2.1.12-stable-9ubuntu2 [145 kB]
+2025-12-07T21:22:05.0012892Z Get:123 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libfaad2 amd64 2.11.1-1build1 [207 kB]
+2025-12-07T21:22:05.0249784Z Get:124 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libinstpatch-1.0-2 amd64 1.1.6-1build2 [251 kB]
+2025-12-07T21:22:05.0481656Z Get:125 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libjack-jackd2-0 amd64 1.9.21~dfsg-3ubuntu3 [289 kB]
+2025-12-07T21:22:05.0745096Z Get:126 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libwebrtc-audio-processing1 amd64 0.3.1-0ubuntu6 [290 kB]
+2025-12-07T21:22:05.0985784Z Get:127 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libspa-0.2-modules amd64 1.0.5-1ubuntu3.1 [626 kB]
+2025-12-07T21:22:05.1267246Z Get:128 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libpipewire-0.3-0t64 amd64 1.0.5-1ubuntu3.1 [252 kB]
+2025-12-07T21:22:05.1501316Z Get:129 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libsdl2-2.0-0 amd64 2.30.0+dfsg-1ubuntu3.1 [686 kB]
+2025-12-07T21:22:05.1878142Z Get:130 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 timgm6mb-soundfont all 1.3-5 [5427 kB]
+2025-12-07T21:22:05.2874024Z Get:131 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libfluidsynth3 amd64 2.3.4-1build3 [249 kB]
+2025-12-07T21:22:05.3115846Z Get:132 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libfreeaptx0 amd64 0.1.1-2build1 [13.5 kB]
+2025-12-07T21:22:05.3330175Z Get:133 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libgraphene-1.0-0 amd64 1.10.8-3build2 [46.2 kB]
+2025-12-07T21:22:05.3553309Z Get:134 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libgssdp-1.6-0 amd64 1.6.3-1build3 [40.4 kB]
+2025-12-07T21:22:05.3777245Z Get:135 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libegl1 amd64 1.7.0-1build1 [28.7 kB]
+2025-12-07T21:22:05.4000533Z Get:136 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libgstreamer-gl1.0-0 amd64 1.24.2-1ubuntu0.3 [214 kB]
+2025-12-07T21:22:05.4234970Z Get:137 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libgtk-4-common all 4.14.5+ds-0ubuntu0.7 [1496 kB]
+2025-12-07T21:22:05.4635131Z Get:138 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libgtk-4-1 amd64 4.14.5+ds-0ubuntu0.7 [3294 kB]
+2025-12-07T21:22:05.5672966Z Get:139 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libgupnp-1.6-0 amd64 1.6.6-1build3 [92.7 kB]
+2025-12-07T21:22:05.5897482Z Get:140 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libgupnp-igd-1.6-0 amd64 1.6.0-3build3 [16.5 kB]
+2025-12-07T21:22:05.6119014Z Get:141 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libharfbuzz-icu0 amd64 8.3.0-2build2 [13.3 kB]
+2025-12-07T21:22:05.6343619Z Get:142 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libhyphen0 amd64 2.8.8-7build3 [26.5 kB]
+2025-12-07T21:22:05.6562801Z Get:143 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libimath-3-1-29t64 amd64 3.1.9-3.1ubuntu2 [72.2 kB]
+2025-12-07T21:22:05.6787974Z Get:144 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 liblc3-1 amd64 1.0.4-3build1 [69.7 kB]
+2025-12-07T21:22:05.7058450Z Get:145 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libldacbt-enc2 amd64 2.0.2.3+git20200429+ed310a0-4ubuntu2 [27.1 kB]
+2025-12-07T21:22:05.7274679Z Get:146 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libraptor2-0 amd64 2.0.16-3ubuntu0.1 [165 kB]
+2025-12-07T21:22:05.7714205Z Get:147 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 liblrdf0 amd64 0.6.1-4build1 [18.5 kB]
+2025-12-07T21:22:05.8127924Z Get:148 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libltc11 amd64 1.3.2-1build1 [13.0 kB]
+2025-12-07T21:22:05.8394520Z Get:149 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libmanette-0.2-0 amd64 0.2.7-1build2 [30.6 kB]
+2025-12-07T21:22:05.8749368Z Get:150 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libmfx1 amd64 22.5.4-1 [3124 kB]
+2025-12-07T21:22:05.9265552Z Get:151 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libmjpegutils-2.1-0t64 amd64 1:2.1.0+debian-8.1build1 [25.5 kB]
+2025-12-07T21:22:05.9489147Z Get:152 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libmodplug1 amd64 1:0.8.9.0-3build1 [166 kB]
+2025-12-07T21:22:05.9722294Z Get:153 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libmpcdec6 amd64 2:0.1~r495-2build1 [32.7 kB]
+2025-12-07T21:22:05.9947894Z Get:154 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libmpeg2encpp-2.1-0t64 amd64 1:2.1.0+debian-8.1build1 [75.6 kB]
+2025-12-07T21:22:06.0178371Z Get:155 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libmplex2-2.1-0t64 amd64 1:2.1.0+debian-8.1build1 [46.1 kB]
+2025-12-07T21:22:06.0403106Z Get:156 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libneon27t64 amd64 0.33.0-1.1build3 [102 kB]
+2025-12-07T21:22:06.0682879Z Get:157 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libnice10 amd64 0.1.21-2build3 [157 kB]
+2025-12-07T21:22:06.1355482Z Get:158 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libopenal-data all 1:1.23.1-4build1 [161 kB]
+2025-12-07T21:22:06.1607724Z Get:159 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libopenexr-3-1-30 amd64 3.1.5-5.1build3 [1004 kB]
+2025-12-07T21:22:06.1988028Z Get:160 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libopenh264-7 amd64 2.4.1+dfsg-1 [409 kB]
+2025-12-07T21:22:06.2297161Z Get:161 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libopenni2-0 amd64 2.2.0.33+dfsg-18 [370 kB]
+2025-12-07T21:22:06.2555967Z Get:162 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libqrencode4 amd64 4.1.1-1build2 [25.0 kB]
+2025-12-07T21:22:06.2778892Z Get:163 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libsecret-common all 0.21.4-1build3 [4962 B]
+2025-12-07T21:22:06.2993089Z Get:164 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libsecret-1-0 amd64 0.21.4-1build3 [116 kB]
+2025-12-07T21:22:06.3217037Z Get:165 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libsndio7.0 amd64 1.9.0-0.3build3 [29.6 kB]
+2025-12-07T21:22:06.3439121Z Get:166 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libsoundtouch1 amd64 2.3.2+ds1-1build1 [60.5 kB]
+2025-12-07T21:22:06.3668035Z Get:167 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libspandsp2t64 amd64 0.0.6+dfsg-2.1build1 [311 kB]
+2025-12-07T21:22:06.3926995Z Get:168 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libsrtp2-1 amd64 2.5.0-3build1 [41.9 kB]
+2025-12-07T21:22:06.4158285Z Get:169 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libssh-4 amd64 0.10.6-2ubuntu0.2 [188 kB]
+2025-12-07T21:22:06.4400591Z Get:170 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libwildmidi2 amd64 0.4.3-1build3 [68.5 kB]
+2025-12-07T21:22:06.4624494Z Get:171 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libwoff1 amd64 1.0.2-2build1 [45.3 kB]
+2025-12-07T21:22:06.4904304Z Get:172 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libxcb-xkb1 amd64 1.15-1ubuntu2 [32.3 kB]
+2025-12-07T21:22:06.5129339Z Get:173 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libxkbcommon-x11-0 amd64 1.6.0-1build1 [14.5 kB]
+2025-12-07T21:22:06.5351859Z Get:174 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libzbar0t64 amd64 0.23.93-4build3 [123 kB]
+2025-12-07T21:22:06.5578910Z Get:175 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libzxing3 amd64 2.2.1-3 [583 kB]
+2025-12-07T21:22:06.6282696Z Get:176 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 xfonts-encodings all 1:1.0.5-0ubuntu2 [578 kB]
+2025-12-07T21:22:06.6552402Z Get:177 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 xfonts-utils amd64 1:7.7+6build3 [94.4 kB]
+2025-12-07T21:22:06.6775529Z Get:178 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 xfonts-cyrillic all 1:1.0.5+nmu1 [384 kB]
+2025-12-07T21:22:06.7028711Z Get:179 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 xfonts-scalable all 1:1.0.3-1.3 [304 kB]
+2025-12-07T21:22:06.7273779Z Get:180 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libgstreamer-plugins-bad1.0-0 amd64 1.24.2-1ubuntu4 [797 kB]
+2025-12-07T21:22:06.7572272Z Get:181 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libdca0 amd64 0.0.7-2build1 [93.8 kB]
+2025-12-07T21:22:06.7802283Z Get:182 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libopenal1 amd64 1:1.23.1-4build1 [540 kB]
+2025-12-07T21:22:06.8079865Z Get:183 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libsbc1 amd64 2.0-1build1 [33.9 kB]
+2025-12-07T21:22:06.8302091Z Get:184 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libvo-aacenc0 amd64 0.1.3-2build1 [67.8 kB]
+2025-12-07T21:22:06.8524817Z Get:185 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libvo-amrwbenc0 amd64 0.1.3-2build1 [76.7 kB]
+2025-12-07T21:22:06.8753958Z Get:186 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 gstreamer1.0-plugins-bad amd64 1.24.2-1ubuntu4 [3081 kB]
+2025-12-07T21:22:07.3560359Z Fetched 116 MB in 6s (19.6 MB/s)
+2025-12-07T21:22:07.3813486Z Selecting previously unselected package fonts-ipafont-gothic.
+2025-12-07T21:22:07.4085000Z (Reading database ... 
+2025-12-07T21:22:07.4085552Z (Reading database ... 5%
+2025-12-07T21:22:07.4086053Z (Reading database ... 10%
+2025-12-07T21:22:07.4086521Z (Reading database ... 15%
+2025-12-07T21:22:07.4086834Z (Reading database ... 20%
+2025-12-07T21:22:07.4087115Z (Reading database ... 25%
+2025-12-07T21:22:07.4087389Z (Reading database ... 30%
+2025-12-07T21:22:07.4087690Z (Reading database ... 35%
+2025-12-07T21:22:07.4087954Z (Reading database ... 40%
+2025-12-07T21:22:07.4088214Z (Reading database ... 45%
+2025-12-07T21:22:07.4088477Z (Reading database ... 50%
+2025-12-07T21:22:07.4188573Z (Reading database ... 55%
+2025-12-07T21:22:07.5651719Z (Reading database ... 60%
+2025-12-07T21:22:07.6778238Z (Reading database ... 65%
+2025-12-07T21:22:07.7274904Z (Reading database ... 70%
+2025-12-07T21:22:07.8290325Z (Reading database ... 75%
+2025-12-07T21:22:08.0032784Z (Reading database ... 80%
+2025-12-07T21:22:08.1647623Z (Reading database ... 85%
+2025-12-07T21:22:08.3470467Z (Reading database ... 90%
+2025-12-07T21:22:08.5188631Z (Reading database ... 95%
+2025-12-07T21:22:08.5189152Z (Reading database ... 100%
+2025-12-07T21:22:08.5189777Z (Reading database ... 217049 files and directories currently installed.)
+2025-12-07T21:22:08.5233004Z Preparing to unpack .../000-fonts-ipafont-gothic_00303-21ubuntu1_all.deb ...
+2025-12-07T21:22:08.5322344Z Unpacking fonts-ipafont-gothic (00303-21ubuntu1) ...
+2025-12-07T21:22:08.7736057Z Preparing to unpack .../001-libglib2.0-data_2.80.0-6ubuntu3.5_all.deb ...
+2025-12-07T21:22:08.7773606Z Unpacking libglib2.0-data (2.80.0-6ubuntu3.5) over (2.80.0-6ubuntu3.4) ...
+2025-12-07T21:22:08.8113497Z Preparing to unpack .../002-libglib2.0-bin_2.80.0-6ubuntu3.5_amd64.deb ...
+2025-12-07T21:22:08.8133414Z Unpacking libglib2.0-bin (2.80.0-6ubuntu3.5) over (2.80.0-6ubuntu3.4) ...
+2025-12-07T21:22:08.8628534Z Preparing to unpack .../003-gir1.2-glib-2.0_2.80.0-6ubuntu3.5_amd64.deb ...
+2025-12-07T21:22:08.8649282Z Unpacking gir1.2-glib-2.0:amd64 (2.80.0-6ubuntu3.5) over (2.80.0-6ubuntu3.4) ...
+2025-12-07T21:22:08.9048115Z Preparing to unpack .../004-libglib2.0-0t64_2.80.0-6ubuntu3.5_amd64.deb ...
+2025-12-07T21:22:08.9113322Z Unpacking libglib2.0-0t64:amd64 (2.80.0-6ubuntu3.5) over (2.80.0-6ubuntu3.4) ...
+2025-12-07T21:22:08.9523559Z Selecting previously unselected package fonts-freefont-ttf.
+2025-12-07T21:22:08.9660041Z Preparing to unpack .../005-fonts-freefont-ttf_20211204+svn4273-2_all.deb ...
+2025-12-07T21:22:08.9667707Z Unpacking fonts-freefont-ttf (20211204+svn4273-2) ...
+2025-12-07T21:22:09.0514853Z Selecting previously unselected package fonts-tlwg-loma-otf.
+2025-12-07T21:22:09.0649833Z Preparing to unpack .../006-fonts-tlwg-loma-otf_1%3a0.7.3-1_all.deb ...
+2025-12-07T21:22:09.0657362Z Unpacking fonts-tlwg-loma-otf (1:0.7.3-1) ...
+2025-12-07T21:22:09.0865286Z Selecting previously unselected package fonts-unifont.
+2025-12-07T21:22:09.0998241Z Preparing to unpack .../007-fonts-unifont_1%3a15.1.01-1build1_all.deb ...
+2025-12-07T21:22:09.1006740Z Unpacking fonts-unifont (1:15.1.01-1build1) ...
+2025-12-07T21:22:09.2192008Z Selecting previously unselected package fonts-wqy-zenhei.
+2025-12-07T21:22:09.2325354Z Preparing to unpack .../008-fonts-wqy-zenhei_0.9.45-8_all.deb ...
+2025-12-07T21:22:09.2432132Z Unpacking fonts-wqy-zenhei (0.9.45-8) ...
+2025-12-07T21:22:09.6955536Z Selecting previously unselected package libproxy1v5:amd64.
+2025-12-07T21:22:09.7087921Z Preparing to unpack .../009-libproxy1v5_0.5.4-4build1_amd64.deb ...
+2025-12-07T21:22:09.7096226Z Unpacking libproxy1v5:amd64 (0.5.4-4build1) ...
+2025-12-07T21:22:09.7294506Z Selecting previously unselected package glib-networking-common.
+2025-12-07T21:22:09.7427665Z Preparing to unpack .../010-glib-networking-common_2.80.0-1build1_all.deb ...
+2025-12-07T21:22:09.7435018Z Unpacking glib-networking-common (2.80.0-1build1) ...
+2025-12-07T21:22:09.7623370Z Selecting previously unselected package glib-networking-services.
+2025-12-07T21:22:09.7752632Z Preparing to unpack .../011-glib-networking-services_2.80.0-1build1_amd64.deb ...
+2025-12-07T21:22:09.7760391Z Unpacking glib-networking-services (2.80.0-1build1) ...
+2025-12-07T21:22:09.7968411Z Selecting previously unselected package session-migration.
+2025-12-07T21:22:09.8098921Z Preparing to unpack .../012-session-migration_0.3.9build1_amd64.deb ...
+2025-12-07T21:22:09.8108224Z Unpacking session-migration (0.3.9build1) ...
+2025-12-07T21:22:09.8326705Z Selecting previously unselected package gsettings-desktop-schemas.
+2025-12-07T21:22:09.8455405Z Preparing to unpack .../013-gsettings-desktop-schemas_46.1-0ubuntu1_all.deb ...
+2025-12-07T21:22:09.8465182Z Unpacking gsettings-desktop-schemas (46.1-0ubuntu1) ...
+2025-12-07T21:22:09.8725406Z Selecting previously unselected package glib-networking:amd64.
+2025-12-07T21:22:09.8855860Z Preparing to unpack .../014-glib-networking_2.80.0-1build1_amd64.deb ...
+2025-12-07T21:22:09.8863226Z Unpacking glib-networking:amd64 (2.80.0-1build1) ...
+2025-12-07T21:22:09.9071829Z Selecting previously unselected package libva2:amd64.
+2025-12-07T21:22:09.9202689Z Preparing to unpack .../015-libva2_2.20.0-2build1_amd64.deb ...
+2025-12-07T21:22:09.9210627Z Unpacking libva2:amd64 (2.20.0-2build1) ...
+2025-12-07T21:22:09.9463746Z Selecting previously unselected package libva-drm2:amd64.
+2025-12-07T21:22:09.9594049Z Preparing to unpack .../016-libva-drm2_2.20.0-2build1_amd64.deb ...
+2025-12-07T21:22:09.9602858Z Unpacking libva-drm2:amd64 (2.20.0-2build1) ...
+2025-12-07T21:22:09.9805004Z Selecting previously unselected package libva-x11-2:amd64.
+2025-12-07T21:22:09.9935515Z Preparing to unpack .../017-libva-x11-2_2.20.0-2build1_amd64.deb ...
+2025-12-07T21:22:09.9944269Z Unpacking libva-x11-2:amd64 (2.20.0-2build1) ...
+2025-12-07T21:22:10.0148090Z Selecting previously unselected package libvdpau1:amd64.
+2025-12-07T21:22:10.0277240Z Preparing to unpack .../018-libvdpau1_1.5-2build1_amd64.deb ...
+2025-12-07T21:22:10.0285644Z Unpacking libvdpau1:amd64 (1.5-2build1) ...
+2025-12-07T21:22:10.0511556Z Selecting previously unselected package libvpl2.
+2025-12-07T21:22:10.0644152Z Preparing to unpack .../019-libvpl2_2023.3.0-1build1_amd64.deb ...
+2025-12-07T21:22:10.0653510Z Unpacking libvpl2 (2023.3.0-1build1) ...
+2025-12-07T21:22:10.0879681Z Selecting previously unselected package ocl-icd-libopencl1:amd64.
+2025-12-07T21:22:10.1011745Z Preparing to unpack .../020-ocl-icd-libopencl1_2.3.2-1build1_amd64.deb ...
+2025-12-07T21:22:10.1021533Z Unpacking ocl-icd-libopencl1:amd64 (2.3.2-1build1) ...
+2025-12-07T21:22:10.1254683Z Selecting previously unselected package libavutil58:amd64.
+2025-12-07T21:22:10.1386722Z Preparing to unpack .../021-libavutil58_7%3a6.1.1-3ubuntu5_amd64.deb ...
+2025-12-07T21:22:10.1401825Z Unpacking libavutil58:amd64 (7:6.1.1-3ubuntu5) ...
+2025-12-07T21:22:10.1669303Z Selecting previously unselected package libcodec2-1.2:amd64.
+2025-12-07T21:22:10.1803365Z Preparing to unpack .../022-libcodec2-1.2_1.2.0-2build1_amd64.deb ...
+2025-12-07T21:22:10.1811820Z Unpacking libcodec2-1.2:amd64 (1.2.0-2build1) ...
+2025-12-07T21:22:10.2633202Z Selecting previously unselected package libdav1d7:amd64.
+2025-12-07T21:22:10.2766730Z Preparing to unpack .../023-libdav1d7_1.4.1-1build1_amd64.deb ...
+2025-12-07T21:22:10.2774970Z Unpacking libdav1d7:amd64 (1.4.1-1build1) ...
+2025-12-07T21:22:10.3068151Z Selecting previously unselected package libgsm1:amd64.
+2025-12-07T21:22:10.3200307Z Preparing to unpack .../024-libgsm1_1.0.22-1build1_amd64.deb ...
+2025-12-07T21:22:10.3209238Z Unpacking libgsm1:amd64 (1.0.22-1build1) ...
+2025-12-07T21:22:10.3418545Z Selecting previously unselected package libhwy1t64:amd64.
+2025-12-07T21:22:10.3551860Z Preparing to unpack .../025-libhwy1t64_1.0.7-8.1build1_amd64.deb ...
+2025-12-07T21:22:10.3559774Z Unpacking libhwy1t64:amd64 (1.0.7-8.1build1) ...
+2025-12-07T21:22:10.3896468Z Selecting previously unselected package libjxl0.7:amd64.
+2025-12-07T21:22:10.4029506Z Preparing to unpack .../026-libjxl0.7_0.7.0-10.2ubuntu6.1_amd64.deb ...
+2025-12-07T21:22:10.4037951Z Unpacking libjxl0.7:amd64 (0.7.0-10.2ubuntu6.1) ...
+2025-12-07T21:22:10.4396281Z Selecting previously unselected package libmp3lame0:amd64.
+2025-12-07T21:22:10.4529318Z Preparing to unpack .../027-libmp3lame0_3.100-6build1_amd64.deb ...
+2025-12-07T21:22:10.4536775Z Unpacking libmp3lame0:amd64 (3.100-6build1) ...
+2025-12-07T21:22:10.4765332Z Selecting previously unselected package libopus0:amd64.
+2025-12-07T21:22:10.4898272Z Preparing to unpack .../028-libopus0_1.4-1build1_amd64.deb ...
+2025-12-07T21:22:10.4906433Z Unpacking libopus0:amd64 (1.4-1build1) ...
+2025-12-07T21:22:10.5135872Z Selecting previously unselected package librav1e0:amd64.
+2025-12-07T21:22:10.5268962Z Preparing to unpack .../029-librav1e0_0.7.1-2_amd64.deb ...
+2025-12-07T21:22:10.5276252Z Unpacking librav1e0:amd64 (0.7.1-2) ...
+2025-12-07T21:22:10.5626133Z Selecting previously unselected package librsvg2-2:amd64.
+2025-12-07T21:22:10.5760057Z Preparing to unpack .../030-librsvg2-2_2.58.0+dfsg-1build1_amd64.deb ...
+2025-12-07T21:22:10.5769241Z Unpacking librsvg2-2:amd64 (2.58.0+dfsg-1build1) ...
+2025-12-07T21:22:10.6265694Z Selecting previously unselected package libshine3:amd64.
+2025-12-07T21:22:10.6398931Z Preparing to unpack .../031-libshine3_3.1.1-2build1_amd64.deb ...
+2025-12-07T21:22:10.6406871Z Unpacking libshine3:amd64 (3.1.1-2build1) ...
+2025-12-07T21:22:10.6607621Z Selecting previously unselected package libspeex1:amd64.
+2025-12-07T21:22:10.6739991Z Preparing to unpack .../032-libspeex1_1.2.1-2ubuntu2.24.04.1_amd64.deb ...
+2025-12-07T21:22:10.6748246Z Unpacking libspeex1:amd64 (1.2.1-2ubuntu2.24.04.1) ...
+2025-12-07T21:22:10.6958504Z Selecting previously unselected package libsvtav1enc1d1:amd64.
+2025-12-07T21:22:10.7089015Z Preparing to unpack .../033-libsvtav1enc1d1_1.7.0+dfsg-2build1_amd64.deb ...
+2025-12-07T21:22:10.7096521Z Unpacking libsvtav1enc1d1:amd64 (1.7.0+dfsg-2build1) ...
+2025-12-07T21:22:10.7593893Z Selecting previously unselected package libsoxr0:amd64.
+2025-12-07T21:22:10.7729151Z Preparing to unpack .../034-libsoxr0_0.1.3-4build3_amd64.deb ...
+2025-12-07T21:22:10.7736560Z Unpacking libsoxr0:amd64 (0.1.3-4build3) ...
+2025-12-07T21:22:10.7951019Z Selecting previously unselected package libswresample4:amd64.
+2025-12-07T21:22:10.8086259Z Preparing to unpack .../035-libswresample4_7%3a6.1.1-3ubuntu5_amd64.deb ...
+2025-12-07T21:22:10.8094624Z Unpacking libswresample4:amd64 (7:6.1.1-3ubuntu5) ...
+2025-12-07T21:22:10.8305901Z Selecting previously unselected package libtheora0:amd64.
+2025-12-07T21:22:10.8458250Z Preparing to unpack .../036-libtheora0_1.1.1+dfsg.1-16.1build3_amd64.deb ...
+2025-12-07T21:22:10.8468285Z Unpacking libtheora0:amd64 (1.1.1+dfsg.1-16.1build3) ...
+2025-12-07T21:22:10.8725215Z Selecting previously unselected package libtwolame0:amd64.
+2025-12-07T21:22:10.8858194Z Preparing to unpack .../037-libtwolame0_0.4.0-2build3_amd64.deb ...
+2025-12-07T21:22:10.8866250Z Unpacking libtwolame0:amd64 (0.4.0-2build3) ...
+2025-12-07T21:22:10.9072742Z Selecting previously unselected package libvorbisenc2:amd64.
+2025-12-07T21:22:10.9205096Z Preparing to unpack .../038-libvorbisenc2_1.3.7-1build3_amd64.deb ...
+2025-12-07T21:22:10.9214731Z Unpacking libvorbisenc2:amd64 (1.3.7-1build3) ...
+2025-12-07T21:22:10.9443148Z Selecting previously unselected package libvpx9:amd64.
+2025-12-07T21:22:10.9576793Z Preparing to unpack .../039-libvpx9_1.14.0-1ubuntu2.2_amd64.deb ...
+2025-12-07T21:22:10.9586189Z Unpacking libvpx9:amd64 (1.14.0-1ubuntu2.2) ...
+2025-12-07T21:22:10.9934182Z Selecting previously unselected package libx264-164:amd64.
+2025-12-07T21:22:11.0067307Z Preparing to unpack .../040-libx264-164_2%3a0.164.3108+git31e19f9-1_amd64.deb ...
+2025-12-07T21:22:11.0074757Z Unpacking libx264-164:amd64 (2:0.164.3108+git31e19f9-1) ...
+2025-12-07T21:22:11.0368208Z Selecting previously unselected package libx265-199:amd64.
+2025-12-07T21:22:11.0501118Z Preparing to unpack .../041-libx265-199_3.5-2build1_amd64.deb ...
+2025-12-07T21:22:11.0509825Z Unpacking libx265-199:amd64 (3.5-2build1) ...
+2025-12-07T21:22:11.1236391Z Selecting previously unselected package libxvidcore4:amd64.
+2025-12-07T21:22:11.1369526Z Preparing to unpack .../042-libxvidcore4_2%3a1.3.7-1build1_amd64.deb ...
+2025-12-07T21:22:11.1376796Z Unpacking libxvidcore4:amd64 (2:1.3.7-1build1) ...
+2025-12-07T21:22:11.1604212Z Selecting previously unselected package libzvbi-common.
+2025-12-07T21:22:11.1736964Z Preparing to unpack .../043-libzvbi-common_0.2.42-2_all.deb ...
+2025-12-07T21:22:11.1763666Z Unpacking libzvbi-common (0.2.42-2) ...
+2025-12-07T21:22:11.2034061Z Selecting previously unselected package libzvbi0t64:amd64.
+2025-12-07T21:22:11.2165609Z Preparing to unpack .../044-libzvbi0t64_0.2.42-2_amd64.deb ...
+2025-12-07T21:22:11.2173005Z Unpacking libzvbi0t64:amd64 (0.2.42-2) ...
+2025-12-07T21:22:11.2413077Z Selecting previously unselected package libavcodec60:amd64.
+2025-12-07T21:22:11.2546184Z Preparing to unpack .../045-libavcodec60_7%3a6.1.1-3ubuntu5_amd64.deb ...
+2025-12-07T21:22:11.2555146Z Unpacking libavcodec60:amd64 (7:6.1.1-3ubuntu5) ...
+2025-12-07T21:22:11.3444734Z Selecting previously unselected package libunibreak5:amd64.
+2025-12-07T21:22:11.3577904Z Preparing to unpack .../046-libunibreak5_5.1-2build1_amd64.deb ...
+2025-12-07T21:22:11.3585682Z Unpacking libunibreak5:amd64 (5.1-2build1) ...
+2025-12-07T21:22:11.3810241Z Selecting previously unselected package libass9:amd64.
+2025-12-07T21:22:11.3942969Z Preparing to unpack .../047-libass9_1%3a0.17.1-2build1_amd64.deb ...
+2025-12-07T21:22:11.3957209Z Unpacking libass9:amd64 (1:0.17.1-2build1) ...
+2025-12-07T21:22:11.4172586Z Selecting previously unselected package libudfread0:amd64.
+2025-12-07T21:22:11.4303578Z Preparing to unpack .../048-libudfread0_1.1.2-1build1_amd64.deb ...
+2025-12-07T21:22:11.4311823Z Unpacking libudfread0:amd64 (1.1.2-1build1) ...
+2025-12-07T21:22:11.4512804Z Selecting previously unselected package libbluray2:amd64.
+2025-12-07T21:22:11.4643871Z Preparing to unpack .../049-libbluray2_1%3a1.3.4-1build1_amd64.deb ...
+2025-12-07T21:22:11.4652094Z Unpacking libbluray2:amd64 (1:1.3.4-1build1) ...
+2025-12-07T21:22:11.4882134Z Selecting previously unselected package libchromaprint1:amd64.
+2025-12-07T21:22:11.5014731Z Preparing to unpack .../050-libchromaprint1_1.5.1-5_amd64.deb ...
+2025-12-07T21:22:11.5023094Z Unpacking libchromaprint1:amd64 (1.5.1-5) ...
+2025-12-07T21:22:11.5439098Z Selecting previously unselected package libgme0:amd64.
+2025-12-07T21:22:11.5572730Z Preparing to unpack .../051-libgme0_0.6.3-7build1_amd64.deb ...
+2025-12-07T21:22:11.5582136Z Unpacking libgme0:amd64 (0.6.3-7build1) ...
+2025-12-07T21:22:11.5805746Z Selecting previously unselected package libmpg123-0t64:amd64.
+2025-12-07T21:22:11.5939865Z Preparing to unpack .../052-libmpg123-0t64_1.32.5-1ubuntu1.1_amd64.deb ...
+2025-12-07T21:22:11.5947900Z Unpacking libmpg123-0t64:amd64 (1.32.5-1ubuntu1.1) ...
+2025-12-07T21:22:11.6201538Z Selecting previously unselected package libopenmpt0t64:amd64.
+2025-12-07T21:22:11.6334228Z Preparing to unpack .../053-libopenmpt0t64_0.7.3-1.1build3_amd64.deb ...
+2025-12-07T21:22:11.6343025Z Unpacking libopenmpt0t64:amd64 (0.7.3-1.1build3) ...
+2025-12-07T21:22:11.6614693Z Selecting previously unselected package libcjson1:amd64.
+2025-12-07T21:22:11.6746888Z Preparing to unpack .../054-libcjson1_1.7.17-1_amd64.deb ...
+2025-12-07T21:22:11.6754514Z Unpacking libcjson1:amd64 (1.7.17-1) ...
+2025-12-07T21:22:11.6960868Z Selecting previously unselected package libmbedcrypto7t64:amd64.
+2025-12-07T21:22:11.7092792Z Preparing to unpack .../055-libmbedcrypto7t64_2.28.8-1_amd64.deb ...
+2025-12-07T21:22:11.7100429Z Unpacking libmbedcrypto7t64:amd64 (2.28.8-1) ...
+2025-12-07T21:22:11.7360417Z Selecting previously unselected package librist4:amd64.
+2025-12-07T21:22:11.7491184Z Preparing to unpack .../056-librist4_0.2.10+dfsg-2_amd64.deb ...
+2025-12-07T21:22:11.7502120Z Unpacking librist4:amd64 (0.2.10+dfsg-2) ...
+2025-12-07T21:22:11.7705670Z Selecting previously unselected package libsrt1.5-gnutls:amd64.
+2025-12-07T21:22:11.7836471Z Preparing to unpack .../057-libsrt1.5-gnutls_1.5.3-1build2_amd64.deb ...
+2025-12-07T21:22:11.7844174Z Unpacking libsrt1.5-gnutls:amd64 (1.5.3-1build2) ...
+2025-12-07T21:22:11.8090319Z Selecting previously unselected package libssh-gcrypt-4:amd64.
+2025-12-07T21:22:11.8220471Z Preparing to unpack .../058-libssh-gcrypt-4_0.10.6-2ubuntu0.2_amd64.deb ...
+2025-12-07T21:22:11.8228086Z Unpacking libssh-gcrypt-4:amd64 (0.10.6-2ubuntu0.2) ...
+2025-12-07T21:22:11.8460871Z Selecting previously unselected package libavformat60:amd64.
+2025-12-07T21:22:11.8592558Z Preparing to unpack .../059-libavformat60_7%3a6.1.1-3ubuntu5_amd64.deb ...
+2025-12-07T21:22:11.8604372Z Unpacking libavformat60:amd64 (7:6.1.1-3ubuntu5) ...
+2025-12-07T21:22:11.8937736Z Selecting previously unselected package libbs2b0:amd64.
+2025-12-07T21:22:11.9071256Z Preparing to unpack .../060-libbs2b0_3.1.0+dfsg-7build1_amd64.deb ...
+2025-12-07T21:22:11.9079154Z Unpacking libbs2b0:amd64 (3.1.0+dfsg-7build1) ...
+2025-12-07T21:22:11.9304879Z Selecting previously unselected package libflite1:amd64.
+2025-12-07T21:22:11.9436276Z Preparing to unpack .../061-libflite1_2.2-6build3_amd64.deb ...
+2025-12-07T21:22:11.9443339Z Unpacking libflite1:amd64 (2.2-6build3) ...
+2025-12-07T21:22:12.0592625Z Selecting previously unselected package libserd-0-0:amd64.
+2025-12-07T21:22:12.0728643Z Preparing to unpack .../062-libserd-0-0_0.32.2-1_amd64.deb ...
+2025-12-07T21:22:12.0737824Z Unpacking libserd-0-0:amd64 (0.32.2-1) ...
+2025-12-07T21:22:12.0945942Z Selecting previously unselected package libzix-0-0:amd64.
+2025-12-07T21:22:12.1077580Z Preparing to unpack .../063-libzix-0-0_0.4.2-2build1_amd64.deb ...
+2025-12-07T21:22:12.1086008Z Unpacking libzix-0-0:amd64 (0.4.2-2build1) ...
+2025-12-07T21:22:12.1289600Z Selecting previously unselected package libsord-0-0:amd64.
+2025-12-07T21:22:12.1421620Z Preparing to unpack .../064-libsord-0-0_0.16.16-2build1_amd64.deb ...
+2025-12-07T21:22:12.1428740Z Unpacking libsord-0-0:amd64 (0.16.16-2build1) ...
+2025-12-07T21:22:12.1637374Z Selecting previously unselected package libsratom-0-0:amd64.
+2025-12-07T21:22:12.1768617Z Preparing to unpack .../065-libsratom-0-0_0.6.16-1build1_amd64.deb ...
+2025-12-07T21:22:12.1777750Z Unpacking libsratom-0-0:amd64 (0.6.16-1build1) ...
+2025-12-07T21:22:12.2036284Z Selecting previously unselected package liblilv-0-0:amd64.
+2025-12-07T21:22:12.2168377Z Preparing to unpack .../066-liblilv-0-0_0.24.22-1build1_amd64.deb ...
+2025-12-07T21:22:12.2175862Z Unpacking liblilv-0-0:amd64 (0.24.22-1build1) ...
+2025-12-07T21:22:12.2391760Z Selecting previously unselected package libmysofa1:amd64.
+2025-12-07T21:22:12.2523467Z Preparing to unpack .../067-libmysofa1_1.3.2+dfsg-2ubuntu2_amd64.deb ...
+2025-12-07T21:22:12.2531671Z Unpacking libmysofa1:amd64 (1.3.2+dfsg-2ubuntu2) ...
+2025-12-07T21:22:12.2845862Z Selecting previously unselected package libplacebo338:amd64.
+2025-12-07T21:22:12.2976794Z Preparing to unpack .../068-libplacebo338_6.338.2-2build1_amd64.deb ...
+2025-12-07T21:22:12.3006124Z Unpacking libplacebo338:amd64 (6.338.2-2build1) ...
+2025-12-07T21:22:12.3575274Z Selecting previously unselected package libblas3:amd64.
+2025-12-07T21:22:12.3709469Z Preparing to unpack .../069-libblas3_3.12.0-3build1.1_amd64.deb ...
+2025-12-07T21:22:12.3738526Z Unpacking libblas3:amd64 (3.12.0-3build1.1) ...
+2025-12-07T21:22:12.3980747Z Selecting previously unselected package liblapack3:amd64.
+2025-12-07T21:22:12.4114794Z Preparing to unpack .../070-liblapack3_3.12.0-3build1.1_amd64.deb ...
+2025-12-07T21:22:12.4145631Z Unpacking liblapack3:amd64 (3.12.0-3build1.1) ...
+2025-12-07T21:22:12.4645472Z Selecting previously unselected package libasyncns0:amd64.
+2025-12-07T21:22:12.4778324Z Preparing to unpack .../071-libasyncns0_0.8-6build4_amd64.deb ...
+2025-12-07T21:22:12.4788800Z Unpacking libasyncns0:amd64 (0.8-6build4) ...
+2025-12-07T21:22:12.5000601Z Selecting previously unselected package libflac12t64:amd64.
+2025-12-07T21:22:12.5133606Z Preparing to unpack .../072-libflac12t64_1.4.3+ds-2.1ubuntu2_amd64.deb ...
+2025-12-07T21:22:12.5141877Z Unpacking libflac12t64:amd64 (1.4.3+ds-2.1ubuntu2) ...
+2025-12-07T21:22:12.5408672Z Selecting previously unselected package libsndfile1:amd64.
+2025-12-07T21:22:12.5542545Z Preparing to unpack .../073-libsndfile1_1.2.2-1ubuntu5.24.04.1_amd64.deb ...
+2025-12-07T21:22:12.5550160Z Unpacking libsndfile1:amd64 (1.2.2-1ubuntu5.24.04.1) ...
+2025-12-07T21:22:12.5798432Z Selecting previously unselected package libpulse0:amd64.
+2025-12-07T21:22:12.5932643Z Preparing to unpack .../074-libpulse0_1%3a16.1+dfsg1-2ubuntu10.1_amd64.deb ...
+2025-12-07T21:22:12.5995225Z Unpacking libpulse0:amd64 (1:16.1+dfsg1-2ubuntu10.1) ...
+2025-12-07T21:22:12.6246447Z Selecting previously unselected package libsphinxbase3t64:amd64.
+2025-12-07T21:22:12.6379153Z Preparing to unpack .../075-libsphinxbase3t64_0.8+5prealpha+1-17build2_amd64.deb ...
+2025-12-07T21:22:12.6387410Z Unpacking libsphinxbase3t64:amd64 (0.8+5prealpha+1-17build2) ...
+2025-12-07T21:22:12.6642270Z Selecting previously unselected package libpocketsphinx3:amd64.
+2025-12-07T21:22:12.6774364Z Preparing to unpack .../076-libpocketsphinx3_0.8.0+real5prealpha+1-15ubuntu5_amd64.deb ...
+2025-12-07T21:22:12.6781567Z Unpacking libpocketsphinx3:amd64 (0.8.0+real5prealpha+1-15ubuntu5) ...
+2025-12-07T21:22:12.6998655Z Selecting previously unselected package libpostproc57:amd64.
+2025-12-07T21:22:12.7129611Z Preparing to unpack .../077-libpostproc57_7%3a6.1.1-3ubuntu5_amd64.deb ...
+2025-12-07T21:22:12.7139385Z Unpacking libpostproc57:amd64 (7:6.1.1-3ubuntu5) ...
+2025-12-07T21:22:12.7352512Z Selecting previously unselected package libsamplerate0:amd64.
+2025-12-07T21:22:12.7484291Z Preparing to unpack .../078-libsamplerate0_0.2.2-4build1_amd64.deb ...
+2025-12-07T21:22:12.7495645Z Unpacking libsamplerate0:amd64 (0.2.2-4build1) ...
+2025-12-07T21:22:12.7909776Z Selecting previously unselected package librubberband2:amd64.
+2025-12-07T21:22:12.8042910Z Preparing to unpack .../079-librubberband2_3.3.0+dfsg-2build1_amd64.deb ...
+2025-12-07T21:22:12.8051591Z Unpacking librubberband2:amd64 (3.3.0+dfsg-2build1) ...
+2025-12-07T21:22:12.8268587Z Selecting previously unselected package libswscale7:amd64.
+2025-12-07T21:22:12.8400423Z Preparing to unpack .../080-libswscale7_7%3a6.1.1-3ubuntu5_amd64.deb ...
+2025-12-07T21:22:12.8411726Z Unpacking libswscale7:amd64 (7:6.1.1-3ubuntu5) ...
+2025-12-07T21:22:12.8640192Z Selecting previously unselected package libvidstab1.1:amd64.
+2025-12-07T21:22:12.8772583Z Preparing to unpack .../081-libvidstab1.1_1.1.0-2build1_amd64.deb ...
+2025-12-07T21:22:12.8782208Z Unpacking libvidstab1.1:amd64 (1.1.0-2build1) ...
+2025-12-07T21:22:12.9006461Z Selecting previously unselected package libzimg2:amd64.
+2025-12-07T21:22:12.9138296Z Preparing to unpack .../082-libzimg2_3.0.5+ds1-1build1_amd64.deb ...
+2025-12-07T21:22:12.9148459Z Unpacking libzimg2:amd64 (3.0.5+ds1-1build1) ...
+2025-12-07T21:22:12.9385848Z Selecting previously unselected package libavfilter9:amd64.
+2025-12-07T21:22:12.9519709Z Preparing to unpack .../083-libavfilter9_7%3a6.1.1-3ubuntu5_amd64.deb ...
+2025-12-07T21:22:12.9530813Z Unpacking libavfilter9:amd64 (7:6.1.1-3ubuntu5) ...
+2025-12-07T21:22:13.0290971Z Selecting previously unselected package liborc-0.4-0t64:amd64.
+2025-12-07T21:22:13.0425932Z Preparing to unpack .../084-liborc-0.4-0t64_1%3a0.4.38-1ubuntu0.1_amd64.deb ...
+2025-12-07T21:22:13.0433849Z Unpacking liborc-0.4-0t64:amd64 (1:0.4.38-1ubuntu0.1) ...
+2025-12-07T21:22:13.0698468Z Selecting previously unselected package libgstreamer-plugins-base1.0-0:amd64.
+2025-12-07T21:22:13.0831932Z Preparing to unpack .../085-libgstreamer-plugins-base1.0-0_1.24.2-1ubuntu0.3_amd64.deb ...
+2025-12-07T21:22:13.0840887Z Unpacking libgstreamer-plugins-base1.0-0:amd64 (1.24.2-1ubuntu0.3) ...
+2025-12-07T21:22:13.1174194Z Selecting previously unselected package gstreamer1.0-libav:amd64.
+2025-12-07T21:22:13.1306989Z Preparing to unpack .../086-gstreamer1.0-libav_1.24.1-1build1_amd64.deb ...
+2025-12-07T21:22:13.1315978Z Unpacking gstreamer1.0-libav:amd64 (1.24.1-1build1) ...
+2025-12-07T21:22:13.1542720Z Selecting previously unselected package libcdparanoia0:amd64.
+2025-12-07T21:22:13.1674209Z Preparing to unpack .../087-libcdparanoia0_3.10.2+debian-14build3_amd64.deb ...
+2025-12-07T21:22:13.1684438Z Unpacking libcdparanoia0:amd64 (3.10.2+debian-14build3) ...
+2025-12-07T21:22:13.1899739Z Selecting previously unselected package libvisual-0.4-0:amd64.
+2025-12-07T21:22:13.2034627Z Preparing to unpack .../088-libvisual-0.4-0_0.4.2-2build1_amd64.deb ...
+2025-12-07T21:22:13.2042222Z Unpacking libvisual-0.4-0:amd64 (0.4.2-2build1) ...
+2025-12-07T21:22:13.2269994Z Selecting previously unselected package gstreamer1.0-plugins-base:amd64.
+2025-12-07T21:22:13.2401831Z Preparing to unpack .../089-gstreamer1.0-plugins-base_1.24.2-1ubuntu0.3_amd64.deb ...
+2025-12-07T21:22:13.2409788Z Unpacking gstreamer1.0-plugins-base:amd64 (1.24.2-1ubuntu0.3) ...
+2025-12-07T21:22:13.2744620Z Selecting previously unselected package libaa1:amd64.
+2025-12-07T21:22:13.2877310Z Preparing to unpack .../090-libaa1_1.4p5-51.1_amd64.deb ...
+2025-12-07T21:22:13.2887403Z Unpacking libaa1:amd64 (1.4p5-51.1) ...
+2025-12-07T21:22:13.3130259Z Selecting previously unselected package libraw1394-11:amd64.
+2025-12-07T21:22:13.3266573Z Preparing to unpack .../091-libraw1394-11_2.1.2-2build3_amd64.deb ...
+2025-12-07T21:22:13.3277387Z Unpacking libraw1394-11:amd64 (2.1.2-2build3) ...
+2025-12-07T21:22:13.3481550Z Selecting previously unselected package libavc1394-0:amd64.
+2025-12-07T21:22:13.3612930Z Preparing to unpack .../092-libavc1394-0_0.5.4-5build3_amd64.deb ...
+2025-12-07T21:22:13.3623531Z Unpacking libavc1394-0:amd64 (0.5.4-5build3) ...
+2025-12-07T21:22:13.3821331Z Selecting previously unselected package libcaca0:amd64.
+2025-12-07T21:22:13.3952173Z Preparing to unpack .../093-libcaca0_0.99.beta20-4build2_amd64.deb ...
+2025-12-07T21:22:13.3963106Z Unpacking libcaca0:amd64 (0.99.beta20-4build2) ...
+2025-12-07T21:22:13.4208829Z Selecting previously unselected package libdv4t64:amd64.
+2025-12-07T21:22:13.4339629Z Preparing to unpack .../094-libdv4t64_1.0.0-17.1build1_amd64.deb ...
+2025-12-07T21:22:13.4348655Z Unpacking libdv4t64:amd64 (1.0.0-17.1build1) ...
+2025-12-07T21:22:13.4566800Z Selecting previously unselected package libgstreamer-plugins-good1.0-0:amd64.
+2025-12-07T21:22:13.4697615Z Preparing to unpack .../095-libgstreamer-plugins-good1.0-0_1.24.2-1ubuntu1.2_amd64.deb ...
+2025-12-07T21:22:13.4710779Z Unpacking libgstreamer-plugins-good1.0-0:amd64 (1.24.2-1ubuntu1.2) ...
+2025-12-07T21:22:13.4923126Z Selecting previously unselected package libiec61883-0:amd64.
+2025-12-07T21:22:13.5053919Z Preparing to unpack .../096-libiec61883-0_1.2.0-6build1_amd64.deb ...
+2025-12-07T21:22:13.5064131Z Unpacking libiec61883-0:amd64 (1.2.0-6build1) ...
+2025-12-07T21:22:13.5270675Z Selecting previously unselected package libshout3:amd64.
+2025-12-07T21:22:13.5402201Z Preparing to unpack .../097-libshout3_2.4.6-1build2_amd64.deb ...
+2025-12-07T21:22:13.5412143Z Unpacking libshout3:amd64 (2.4.6-1build2) ...
+2025-12-07T21:22:13.5626451Z Selecting previously unselected package libtag1v5-vanilla:amd64.
+2025-12-07T21:22:13.5757129Z Preparing to unpack .../098-libtag1v5-vanilla_1.13.1-1build1_amd64.deb ...
+2025-12-07T21:22:13.5765205Z Unpacking libtag1v5-vanilla:amd64 (1.13.1-1build1) ...
+2025-12-07T21:22:13.6004431Z Selecting previously unselected package libtag1v5:amd64.
+2025-12-07T21:22:13.6136458Z Preparing to unpack .../099-libtag1v5_1.13.1-1build1_amd64.deb ...
+2025-12-07T21:22:13.6143585Z Unpacking libtag1v5:amd64 (1.13.1-1build1) ...
+2025-12-07T21:22:13.6350523Z Selecting previously unselected package libv4lconvert0t64:amd64.
+2025-12-07T21:22:13.6482018Z Preparing to unpack .../100-libv4lconvert0t64_1.26.1-4build3_amd64.deb ...
+2025-12-07T21:22:13.6490843Z Unpacking libv4lconvert0t64:amd64 (1.26.1-4build3) ...
+2025-12-07T21:22:13.6715074Z Selecting previously unselected package libv4l-0t64:amd64.
+2025-12-07T21:22:13.6845537Z Preparing to unpack .../101-libv4l-0t64_1.26.1-4build3_amd64.deb ...
+2025-12-07T21:22:13.6855405Z Unpacking libv4l-0t64:amd64 (1.26.1-4build3) ...
+2025-12-07T21:22:13.7085650Z Selecting previously unselected package libwavpack1:amd64.
+2025-12-07T21:22:13.7216402Z Preparing to unpack .../102-libwavpack1_5.6.0-1build1_amd64.deb ...
+2025-12-07T21:22:13.7225001Z Unpacking libwavpack1:amd64 (5.6.0-1build1) ...
+2025-12-07T21:22:13.7427254Z Selecting previously unselected package libsoup-3.0-common.
+2025-12-07T21:22:13.7559672Z Preparing to unpack .../103-libsoup-3.0-common_3.4.4-5ubuntu0.5_all.deb ...
+2025-12-07T21:22:13.7568203Z Unpacking libsoup-3.0-common (3.4.4-5ubuntu0.5) ...
+2025-12-07T21:22:13.7766784Z Selecting previously unselected package libsoup-3.0-0:amd64.
+2025-12-07T21:22:13.7897716Z Preparing to unpack .../104-libsoup-3.0-0_3.4.4-5ubuntu0.5_amd64.deb ...
+2025-12-07T21:22:13.7906673Z Unpacking libsoup-3.0-0:amd64 (3.4.4-5ubuntu0.5) ...
+2025-12-07T21:22:13.8137872Z Selecting previously unselected package gstreamer1.0-plugins-good:amd64.
+2025-12-07T21:22:13.8269921Z Preparing to unpack .../105-gstreamer1.0-plugins-good_1.24.2-1ubuntu1.2_amd64.deb ...
+2025-12-07T21:22:13.8278116Z Unpacking gstreamer1.0-plugins-good:amd64 (1.24.2-1ubuntu1.2) ...
+2025-12-07T21:22:13.8871245Z Selecting previously unselected package libabsl20220623t64:amd64.
+2025-12-07T21:22:13.9005165Z Preparing to unpack .../106-libabsl20220623t64_20220623.1-3.1ubuntu3.2_amd64.deb ...
+2025-12-07T21:22:13.9012626Z Unpacking libabsl20220623t64:amd64 (20220623.1-3.1ubuntu3.2) ...
+2025-12-07T21:22:13.9445442Z Selecting previously unselected package libgav1-1:amd64.
+2025-12-07T21:22:13.9582415Z Preparing to unpack .../107-libgav1-1_0.18.0-1build3_amd64.deb ...
+2025-12-07T21:22:13.9590913Z Unpacking libgav1-1:amd64 (0.18.0-1build3) ...
+2025-12-07T21:22:13.9832237Z Selecting previously unselected package libyuv0:amd64.
+2025-12-07T21:22:13.9968274Z Preparing to unpack .../108-libyuv0_0.0~git202401110.af6ac82-1_amd64.deb ...
+2025-12-07T21:22:13.9977764Z Unpacking libyuv0:amd64 (0.0~git202401110.af6ac82-1) ...
+2025-12-07T21:22:14.0205233Z Selecting previously unselected package libavif16:amd64.
+2025-12-07T21:22:14.0339884Z Preparing to unpack .../109-libavif16_1.0.4-1ubuntu3_amd64.deb ...
+2025-12-07T21:22:14.0348494Z Unpacking libavif16:amd64 (1.0.4-1ubuntu3) ...
+2025-12-07T21:22:14.0567716Z Selecting previously unselected package libavtp0:amd64.
+2025-12-07T21:22:14.0701287Z Preparing to unpack .../110-libavtp0_0.2.0-1build1_amd64.deb ...
+2025-12-07T21:22:14.0710446Z Unpacking libavtp0:amd64 (0.2.0-1build1) ...
+2025-12-07T21:22:14.0922208Z Selecting previously unselected package libcairo-script-interpreter2:amd64.
+2025-12-07T21:22:14.1056901Z Preparing to unpack .../111-libcairo-script-interpreter2_1.18.0-3build1_amd64.deb ...
+2025-12-07T21:22:14.1067791Z Unpacking libcairo-script-interpreter2:amd64 (1.18.0-3build1) ...
+2025-12-07T21:22:14.1413849Z Preparing to unpack .../112-libcups2t64_2.4.7-1.2ubuntu7.9_amd64.deb ...
+2025-12-07T21:22:14.1443316Z Unpacking libcups2t64:amd64 (2.4.7-1.2ubuntu7.9) over (2.4.7-1.2ubuntu7.4) ...
+2025-12-07T21:22:14.1710604Z Selecting previously unselected package libdc1394-25:amd64.
+2025-12-07T21:22:14.1845688Z Preparing to unpack .../113-libdc1394-25_2.2.6-4build1_amd64.deb ...
+2025-12-07T21:22:14.1853461Z Unpacking libdc1394-25:amd64 (2.2.6-4build1) ...
+2025-12-07T21:22:14.2083977Z Selecting previously unselected package libdecor-0-0:amd64.
+2025-12-07T21:22:14.2219607Z Preparing to unpack .../114-libdecor-0-0_0.2.2-1build2_amd64.deb ...
+2025-12-07T21:22:14.2229114Z Unpacking libdecor-0-0:amd64 (0.2.2-1build2) ...
+2025-12-07T21:22:14.2450936Z Selecting previously unselected package libgles2:amd64.
+2025-12-07T21:22:14.2585365Z Preparing to unpack .../115-libgles2_1.7.0-1build1_amd64.deb ...
+2025-12-07T21:22:14.2594930Z Unpacking libgles2:amd64 (1.7.0-1build1) ...
+2025-12-07T21:22:14.2809383Z Selecting previously unselected package libdirectfb-1.7-7t64:amd64.
+2025-12-07T21:22:14.2943914Z Preparing to unpack .../116-libdirectfb-1.7-7t64_1.7.7-11.1ubuntu2_amd64.deb ...
+2025-12-07T21:22:14.2952875Z Unpacking libdirectfb-1.7-7t64:amd64 (1.7.7-11.1ubuntu2) ...
+2025-12-07T21:22:14.3392630Z Selecting previously unselected package libdvdread8t64:amd64.
+2025-12-07T21:22:14.3526897Z Preparing to unpack .../117-libdvdread8t64_6.1.3-1.1build1_amd64.deb ...
+2025-12-07T21:22:14.3536266Z Unpacking libdvdread8t64:amd64 (6.1.3-1.1build1) ...
+2025-12-07T21:22:14.3757722Z Selecting previously unselected package libdvdnav4:amd64.
+2025-12-07T21:22:14.3891928Z Preparing to unpack .../118-libdvdnav4_6.1.1-3build1_amd64.deb ...
+2025-12-07T21:22:14.3900292Z Unpacking libdvdnav4:amd64 (6.1.1-3build1) ...
+2025-12-07T21:22:14.4126792Z Selecting previously unselected package libegl-mesa0:amd64.
+2025-12-07T21:22:14.4261816Z Preparing to unpack .../119-libegl-mesa0_25.0.7-0ubuntu0.24.04.2_amd64.deb ...
+2025-12-07T21:22:14.4270453Z Unpacking libegl-mesa0:amd64 (25.0.7-0ubuntu0.24.04.2) ...
+2025-12-07T21:22:14.4530668Z Selecting previously unselected package libevent-2.1-7t64:amd64.
+2025-12-07T21:22:14.4666127Z Preparing to unpack .../120-libevent-2.1-7t64_2.1.12-stable-9ubuntu2_amd64.deb ...
+2025-12-07T21:22:14.4674420Z Unpacking libevent-2.1-7t64:amd64 (2.1.12-stable-9ubuntu2) ...
+2025-12-07T21:22:14.4906304Z Selecting previously unselected package libfaad2:amd64.
+2025-12-07T21:22:14.5040524Z Preparing to unpack .../121-libfaad2_2.11.1-1build1_amd64.deb ...
+2025-12-07T21:22:14.5048315Z Unpacking libfaad2:amd64 (2.11.1-1build1) ...
+2025-12-07T21:22:14.5289930Z Selecting previously unselected package libinstpatch-1.0-2:amd64.
+2025-12-07T21:22:14.5424024Z Preparing to unpack .../122-libinstpatch-1.0-2_1.1.6-1build2_amd64.deb ...
+2025-12-07T21:22:14.5431655Z Unpacking libinstpatch-1.0-2:amd64 (1.1.6-1build2) ...
+2025-12-07T21:22:14.5673825Z Selecting previously unselected package libjack-jackd2-0:amd64.
+2025-12-07T21:22:14.5807904Z Preparing to unpack .../123-libjack-jackd2-0_1.9.21~dfsg-3ubuntu3_amd64.deb ...
+2025-12-07T21:22:14.5817986Z Unpacking libjack-jackd2-0:amd64 (1.9.21~dfsg-3ubuntu3) ...
+2025-12-07T21:22:14.6085345Z Selecting previously unselected package libwebrtc-audio-processing1:amd64.
+2025-12-07T21:22:14.6218984Z Preparing to unpack .../124-libwebrtc-audio-processing1_0.3.1-0ubuntu6_amd64.deb ...
+2025-12-07T21:22:14.6228147Z Unpacking libwebrtc-audio-processing1:amd64 (0.3.1-0ubuntu6) ...
+2025-12-07T21:22:14.6453251Z Selecting previously unselected package libspa-0.2-modules:amd64.
+2025-12-07T21:22:14.6587256Z Preparing to unpack .../125-libspa-0.2-modules_1.0.5-1ubuntu3.1_amd64.deb ...
+2025-12-07T21:22:14.6597208Z Unpacking libspa-0.2-modules:amd64 (1.0.5-1ubuntu3.1) ...
+2025-12-07T21:22:14.6934311Z Selecting previously unselected package libpipewire-0.3-0t64:amd64.
+2025-12-07T21:22:14.7068834Z Preparing to unpack .../126-libpipewire-0.3-0t64_1.0.5-1ubuntu3.1_amd64.deb ...
+2025-12-07T21:22:14.7081005Z Unpacking libpipewire-0.3-0t64:amd64 (1.0.5-1ubuntu3.1) ...
+2025-12-07T21:22:14.7334176Z Selecting previously unselected package libsdl2-2.0-0:amd64.
+2025-12-07T21:22:14.7467537Z Preparing to unpack .../127-libsdl2-2.0-0_2.30.0+dfsg-1ubuntu3.1_amd64.deb ...
+2025-12-07T21:22:14.7475361Z Unpacking libsdl2-2.0-0:amd64 (2.30.0+dfsg-1ubuntu3.1) ...
+2025-12-07T21:22:14.7785600Z Selecting previously unselected package timgm6mb-soundfont.
+2025-12-07T21:22:14.7920568Z Preparing to unpack .../128-timgm6mb-soundfont_1.3-5_all.deb ...
+2025-12-07T21:22:14.7929891Z Unpacking timgm6mb-soundfont (1.3-5) ...
+2025-12-07T21:22:15.1331713Z Selecting previously unselected package libfluidsynth3:amd64.
+2025-12-07T21:22:15.1467009Z Preparing to unpack .../129-libfluidsynth3_2.3.4-1build3_amd64.deb ...
+2025-12-07T21:22:15.1474645Z Unpacking libfluidsynth3:amd64 (2.3.4-1build3) ...
+2025-12-07T21:22:15.1725207Z Selecting previously unselected package libfreeaptx0:amd64.
+2025-12-07T21:22:15.1857842Z Preparing to unpack .../130-libfreeaptx0_0.1.1-2build1_amd64.deb ...
+2025-12-07T21:22:15.1866456Z Unpacking libfreeaptx0:amd64 (0.1.1-2build1) ...
+2025-12-07T21:22:15.2095193Z Selecting previously unselected package libgraphene-1.0-0:amd64.
+2025-12-07T21:22:15.2227267Z Preparing to unpack .../131-libgraphene-1.0-0_1.10.8-3build2_amd64.deb ...
+2025-12-07T21:22:15.2305738Z Unpacking libgraphene-1.0-0:amd64 (1.10.8-3build2) ...
+2025-12-07T21:22:15.2519800Z Selecting previously unselected package libgssdp-1.6-0:amd64.
+2025-12-07T21:22:15.2655012Z Preparing to unpack .../132-libgssdp-1.6-0_1.6.3-1build3_amd64.deb ...
+2025-12-07T21:22:15.2663581Z Unpacking libgssdp-1.6-0:amd64 (1.6.3-1build3) ...
+2025-12-07T21:22:15.2878454Z Selecting previously unselected package libegl1:amd64.
+2025-12-07T21:22:15.3009827Z Preparing to unpack .../133-libegl1_1.7.0-1build1_amd64.deb ...
+2025-12-07T21:22:15.3022232Z Unpacking libegl1:amd64 (1.7.0-1build1) ...
+2025-12-07T21:22:15.3238242Z Selecting previously unselected package libgstreamer-gl1.0-0:amd64.
+2025-12-07T21:22:15.3371792Z Preparing to unpack .../134-libgstreamer-gl1.0-0_1.24.2-1ubuntu0.3_amd64.deb ...
+2025-12-07T21:22:15.3381792Z Unpacking libgstreamer-gl1.0-0:amd64 (1.24.2-1ubuntu0.3) ...
+2025-12-07T21:22:15.3614301Z Selecting previously unselected package libgtk-4-common.
+2025-12-07T21:22:15.3749748Z Preparing to unpack .../135-libgtk-4-common_4.14.5+ds-0ubuntu0.7_all.deb ...
+2025-12-07T21:22:15.3760264Z Unpacking libgtk-4-common (4.14.5+ds-0ubuntu0.7) ...
+2025-12-07T21:22:15.4279097Z Selecting previously unselected package libgtk-4-1:amd64.
+2025-12-07T21:22:15.4412965Z Preparing to unpack .../136-libgtk-4-1_4.14.5+ds-0ubuntu0.7_amd64.deb ...
+2025-12-07T21:22:15.4422378Z Unpacking libgtk-4-1:amd64 (4.14.5+ds-0ubuntu0.7) ...
+2025-12-07T21:22:15.5134364Z Selecting previously unselected package libgupnp-1.6-0:amd64.
+2025-12-07T21:22:15.5268209Z Preparing to unpack .../137-libgupnp-1.6-0_1.6.6-1build3_amd64.deb ...
+2025-12-07T21:22:15.5276071Z Unpacking libgupnp-1.6-0:amd64 (1.6.6-1build3) ...
+2025-12-07T21:22:15.5504257Z Selecting previously unselected package libgupnp-igd-1.6-0:amd64.
+2025-12-07T21:22:15.5639849Z Preparing to unpack .../138-libgupnp-igd-1.6-0_1.6.0-3build3_amd64.deb ...
+2025-12-07T21:22:15.5649132Z Unpacking libgupnp-igd-1.6-0:amd64 (1.6.0-3build3) ...
+2025-12-07T21:22:15.5871110Z Selecting previously unselected package libharfbuzz-icu0:amd64.
+2025-12-07T21:22:15.5996081Z Preparing to unpack .../139-libharfbuzz-icu0_8.3.0-2build2_amd64.deb ...
+2025-12-07T21:22:15.6004300Z Unpacking libharfbuzz-icu0:amd64 (8.3.0-2build2) ...
+2025-12-07T21:22:15.6216767Z Selecting previously unselected package libhyphen0:amd64.
+2025-12-07T21:22:15.6349288Z Preparing to unpack .../140-libhyphen0_2.8.8-7build3_amd64.deb ...
+2025-12-07T21:22:15.6357998Z Unpacking libhyphen0:amd64 (2.8.8-7build3) ...
+2025-12-07T21:22:15.6570126Z Selecting previously unselected package libimath-3-1-29t64:amd64.
+2025-12-07T21:22:15.6703656Z Preparing to unpack .../141-libimath-3-1-29t64_3.1.9-3.1ubuntu2_amd64.deb ...
+2025-12-07T21:22:15.6713475Z Unpacking libimath-3-1-29t64:amd64 (3.1.9-3.1ubuntu2) ...
+2025-12-07T21:22:15.6940106Z Selecting previously unselected package liblc3-1:amd64.
+2025-12-07T21:22:15.7072352Z Preparing to unpack .../142-liblc3-1_1.0.4-3build1_amd64.deb ...
+2025-12-07T21:22:15.7081049Z Unpacking liblc3-1:amd64 (1.0.4-3build1) ...
+2025-12-07T21:22:15.7296446Z Selecting previously unselected package libldacbt-enc2:amd64.
+2025-12-07T21:22:15.7427362Z Preparing to unpack .../143-libldacbt-enc2_2.0.2.3+git20200429+ed310a0-4ubuntu2_amd64.deb ...
+2025-12-07T21:22:15.7436898Z Unpacking libldacbt-enc2:amd64 (2.0.2.3+git20200429+ed310a0-4ubuntu2) ...
+2025-12-07T21:22:15.7644682Z Selecting previously unselected package libraptor2-0:amd64.
+2025-12-07T21:22:15.7777668Z Preparing to unpack .../144-libraptor2-0_2.0.16-3ubuntu0.1_amd64.deb ...
+2025-12-07T21:22:15.7790786Z Unpacking libraptor2-0:amd64 (2.0.16-3ubuntu0.1) ...
+2025-12-07T21:22:15.8022763Z Selecting previously unselected package liblrdf0:amd64.
+2025-12-07T21:22:15.8155622Z Preparing to unpack .../145-liblrdf0_0.6.1-4build1_amd64.deb ...
+2025-12-07T21:22:15.8164638Z Unpacking liblrdf0:amd64 (0.6.1-4build1) ...
+2025-12-07T21:22:15.8385120Z Selecting previously unselected package libltc11:amd64.
+2025-12-07T21:22:15.8516225Z Preparing to unpack .../146-libltc11_1.3.2-1build1_amd64.deb ...
+2025-12-07T21:22:15.8524293Z Unpacking libltc11:amd64 (1.3.2-1build1) ...
+2025-12-07T21:22:15.8726619Z Selecting previously unselected package libmanette-0.2-0:amd64.
+2025-12-07T21:22:15.8857254Z Preparing to unpack .../147-libmanette-0.2-0_0.2.7-1build2_amd64.deb ...
+2025-12-07T21:22:15.8932193Z Unpacking libmanette-0.2-0:amd64 (0.2.7-1build2) ...
+2025-12-07T21:22:15.9145366Z Selecting previously unselected package libmfx1:amd64.
+2025-12-07T21:22:15.9276286Z Preparing to unpack .../148-libmfx1_22.5.4-1_amd64.deb ...
+2025-12-07T21:22:15.9284173Z Unpacking libmfx1:amd64 (22.5.4-1) ...
+2025-12-07T21:22:16.0270942Z Selecting previously unselected package libmjpegutils-2.1-0t64:amd64.
+2025-12-07T21:22:16.0405393Z Preparing to unpack .../149-libmjpegutils-2.1-0t64_1%3a2.1.0+debian-8.1build1_amd64.deb ...
+2025-12-07T21:22:16.0412993Z Unpacking libmjpegutils-2.1-0t64:amd64 (1:2.1.0+debian-8.1build1) ...
+2025-12-07T21:22:16.0639428Z Selecting previously unselected package libmodplug1:amd64.
+2025-12-07T21:22:16.0774834Z Preparing to unpack .../150-libmodplug1_1%3a0.8.9.0-3build1_amd64.deb ...
+2025-12-07T21:22:16.0784042Z Unpacking libmodplug1:amd64 (1:0.8.9.0-3build1) ...
+2025-12-07T21:22:16.1015275Z Selecting previously unselected package libmpcdec6:amd64.
+2025-12-07T21:22:16.1151643Z Preparing to unpack .../151-libmpcdec6_2%3a0.1~r495-2build1_amd64.deb ...
+2025-12-07T21:22:16.1163340Z Unpacking libmpcdec6:amd64 (2:0.1~r495-2build1) ...
+2025-12-07T21:22:16.1369720Z Selecting previously unselected package libmpeg2encpp-2.1-0t64:amd64.
+2025-12-07T21:22:16.1503578Z Preparing to unpack .../152-libmpeg2encpp-2.1-0t64_1%3a2.1.0+debian-8.1build1_amd64.deb ...
+2025-12-07T21:22:16.1512255Z Unpacking libmpeg2encpp-2.1-0t64:amd64 (1:2.1.0+debian-8.1build1) ...
+2025-12-07T21:22:16.1731028Z Selecting previously unselected package libmplex2-2.1-0t64:amd64.
+2025-12-07T21:22:16.1864751Z Preparing to unpack .../153-libmplex2-2.1-0t64_1%3a2.1.0+debian-8.1build1_amd64.deb ...
+2025-12-07T21:22:16.1876483Z Unpacking libmplex2-2.1-0t64:amd64 (1:2.1.0+debian-8.1build1) ...
+2025-12-07T21:22:16.2090868Z Selecting previously unselected package libneon27t64:amd64.
+2025-12-07T21:22:16.2225438Z Preparing to unpack .../154-libneon27t64_0.33.0-1.1build3_amd64.deb ...
+2025-12-07T21:22:16.2234564Z Unpacking libneon27t64:amd64 (0.33.0-1.1build3) ...
+2025-12-07T21:22:16.2463112Z Selecting previously unselected package libnice10:amd64.
+2025-12-07T21:22:16.2596723Z Preparing to unpack .../155-libnice10_0.1.21-2build3_amd64.deb ...
+2025-12-07T21:22:16.2604460Z Unpacking libnice10:amd64 (0.1.21-2build3) ...
+2025-12-07T21:22:16.2837474Z Selecting previously unselected package libopenal-data.
+2025-12-07T21:22:16.2973715Z Preparing to unpack .../156-libopenal-data_1%3a1.23.1-4build1_all.deb ...
+2025-12-07T21:22:16.2983558Z Unpacking libopenal-data (1:1.23.1-4build1) ...
+2025-12-07T21:22:16.3212946Z Selecting previously unselected package libopenexr-3-1-30:amd64.
+2025-12-07T21:22:16.3347205Z Preparing to unpack .../157-libopenexr-3-1-30_3.1.5-5.1build3_amd64.deb ...
+2025-12-07T21:22:16.3356563Z Unpacking libopenexr-3-1-30:amd64 (3.1.5-5.1build3) ...
+2025-12-07T21:22:16.3749413Z Selecting previously unselected package libopenh264-7:amd64.
+2025-12-07T21:22:16.3883064Z Preparing to unpack .../158-libopenh264-7_2.4.1+dfsg-1_amd64.deb ...
+2025-12-07T21:22:16.3890643Z Unpacking libopenh264-7:amd64 (2.4.1+dfsg-1) ...
+2025-12-07T21:22:16.4167665Z Selecting previously unselected package libopenni2-0:amd64.
+2025-12-07T21:22:16.4301779Z Preparing to unpack .../159-libopenni2-0_2.2.0.33+dfsg-18_amd64.deb ...
+2025-12-07T21:22:16.4332752Z Unpacking libopenni2-0:amd64 (2.2.0.33+dfsg-18) ...
+2025-12-07T21:22:16.4626927Z Selecting previously unselected package libqrencode4:amd64.
+2025-12-07T21:22:16.4761735Z Preparing to unpack .../160-libqrencode4_4.1.1-1build2_amd64.deb ...
+2025-12-07T21:22:16.4770901Z Unpacking libqrencode4:amd64 (4.1.1-1build2) ...
+2025-12-07T21:22:16.4971786Z Selecting previously unselected package libsecret-common.
+2025-12-07T21:22:16.5112654Z Preparing to unpack .../161-libsecret-common_0.21.4-1build3_all.deb ...
+2025-12-07T21:22:16.5238947Z Unpacking libsecret-common (0.21.4-1build3) ...
+2025-12-07T21:22:16.5447077Z Selecting previously unselected package libsecret-1-0:amd64.
+2025-12-07T21:22:16.5585698Z Preparing to unpack .../162-libsecret-1-0_0.21.4-1build3_amd64.deb ...
+2025-12-07T21:22:16.5596071Z Unpacking libsecret-1-0:amd64 (0.21.4-1build3) ...
+2025-12-07T21:22:16.5824936Z Selecting previously unselected package libsndio7.0:amd64.
+2025-12-07T21:22:16.5957020Z Preparing to unpack .../163-libsndio7.0_1.9.0-0.3build3_amd64.deb ...
+2025-12-07T21:22:16.5964396Z Unpacking libsndio7.0:amd64 (1.9.0-0.3build3) ...
+2025-12-07T21:22:16.6173574Z Selecting previously unselected package libsoundtouch1:amd64.
+2025-12-07T21:22:16.6305649Z Preparing to unpack .../164-libsoundtouch1_2.3.2+ds1-1build1_amd64.deb ...
+2025-12-07T21:22:16.6317357Z Unpacking libsoundtouch1:amd64 (2.3.2+ds1-1build1) ...
+2025-12-07T21:22:16.6537239Z Selecting previously unselected package libspandsp2t64:amd64.
+2025-12-07T21:22:16.6671094Z Preparing to unpack .../165-libspandsp2t64_0.0.6+dfsg-2.1build1_amd64.deb ...
+2025-12-07T21:22:16.6680006Z Unpacking libspandsp2t64:amd64 (0.0.6+dfsg-2.1build1) ...
+2025-12-07T21:22:16.6926912Z Selecting previously unselected package libsrtp2-1:amd64.
+2025-12-07T21:22:16.7059537Z Preparing to unpack .../166-libsrtp2-1_2.5.0-3build1_amd64.deb ...
+2025-12-07T21:22:16.7067236Z Unpacking libsrtp2-1:amd64 (2.5.0-3build1) ...
+2025-12-07T21:22:16.7416842Z Preparing to unpack .../167-libssh-4_0.10.6-2ubuntu0.2_amd64.deb ...
+2025-12-07T21:22:16.7451095Z Unpacking libssh-4:amd64 (0.10.6-2ubuntu0.2) over (0.10.6-2ubuntu0.1) ...
+2025-12-07T21:22:16.7713389Z Selecting previously unselected package libwildmidi2:amd64.
+2025-12-07T21:22:16.7847139Z Preparing to unpack .../168-libwildmidi2_0.4.3-1build3_amd64.deb ...
+2025-12-07T21:22:16.7855956Z Unpacking libwildmidi2:amd64 (0.4.3-1build3) ...
+2025-12-07T21:22:16.8071564Z Selecting previously unselected package libwoff1:amd64.
+2025-12-07T21:22:16.8201131Z Preparing to unpack .../169-libwoff1_1.0.2-2build1_amd64.deb ...
+2025-12-07T21:22:16.8212548Z Unpacking libwoff1:amd64 (1.0.2-2build1) ...
+2025-12-07T21:22:16.8424479Z Selecting previously unselected package libxcb-xkb1:amd64.
+2025-12-07T21:22:16.8555176Z Preparing to unpack .../170-libxcb-xkb1_1.15-1ubuntu2_amd64.deb ...
+2025-12-07T21:22:16.8568601Z Unpacking libxcb-xkb1:amd64 (1.15-1ubuntu2) ...
+2025-12-07T21:22:16.8784633Z Selecting previously unselected package libxkbcommon-x11-0:amd64.
+2025-12-07T21:22:16.8916478Z Preparing to unpack .../171-libxkbcommon-x11-0_1.6.0-1build1_amd64.deb ...
+2025-12-07T21:22:16.8928040Z Unpacking libxkbcommon-x11-0:amd64 (1.6.0-1build1) ...
+2025-12-07T21:22:16.9136438Z Selecting previously unselected package libzbar0t64:amd64.
+2025-12-07T21:22:16.9267472Z Preparing to unpack .../172-libzbar0t64_0.23.93-4build3_amd64.deb ...
+2025-12-07T21:22:16.9275573Z Unpacking libzbar0t64:amd64 (0.23.93-4build3) ...
+2025-12-07T21:22:16.9499790Z Selecting previously unselected package libzxing3:amd64.
+2025-12-07T21:22:16.9629739Z Preparing to unpack .../173-libzxing3_2.2.1-3_amd64.deb ...
+2025-12-07T21:22:16.9641569Z Unpacking libzxing3:amd64 (2.2.1-3) ...
+2025-12-07T21:22:16.9896203Z Selecting previously unselected package xfonts-encodings.
+2025-12-07T21:22:17.0027761Z Preparing to unpack .../174-xfonts-encodings_1%3a1.0.5-0ubuntu2_all.deb ...
+2025-12-07T21:22:17.0039688Z Unpacking xfonts-encodings (1:1.0.5-0ubuntu2) ...
+2025-12-07T21:22:17.0335708Z Selecting previously unselected package xfonts-utils.
+2025-12-07T21:22:17.0467259Z Preparing to unpack .../175-xfonts-utils_1%3a7.7+6build3_amd64.deb ...
+2025-12-07T21:22:17.0478281Z Unpacking xfonts-utils (1:7.7+6build3) ...
+2025-12-07T21:22:17.0835345Z Selecting previously unselected package xfonts-cyrillic.
+2025-12-07T21:22:17.0968241Z Preparing to unpack .../176-xfonts-cyrillic_1%3a1.0.5+nmu1_all.deb ...
+2025-12-07T21:22:17.0976576Z Unpacking xfonts-cyrillic (1:1.0.5+nmu1) ...
+2025-12-07T21:22:17.1328565Z Selecting previously unselected package xfonts-scalable.
+2025-12-07T21:22:17.1462446Z Preparing to unpack .../177-xfonts-scalable_1%3a1.0.3-1.3_all.deb ...
+2025-12-07T21:22:17.1472987Z Unpacking xfonts-scalable (1:1.0.3-1.3) ...
+2025-12-07T21:22:17.1730520Z Selecting previously unselected package libgstreamer-plugins-bad1.0-0:amd64.
+2025-12-07T21:22:17.1863898Z Preparing to unpack .../178-libgstreamer-plugins-bad1.0-0_1.24.2-1ubuntu4_amd64.deb ...
+2025-12-07T21:22:17.1873254Z Unpacking libgstreamer-plugins-bad1.0-0:amd64 (1.24.2-1ubuntu4) ...
+2025-12-07T21:22:17.2289350Z Selecting previously unselected package libdca0:amd64.
+2025-12-07T21:22:17.2422608Z Preparing to unpack .../179-libdca0_0.0.7-2build1_amd64.deb ...
+2025-12-07T21:22:17.2432598Z Unpacking libdca0:amd64 (0.0.7-2build1) ...
+2025-12-07T21:22:17.2652643Z Selecting previously unselected package libopenal1:amd64.
+2025-12-07T21:22:17.2785910Z Preparing to unpack .../180-libopenal1_1%3a1.23.1-4build1_amd64.deb ...
+2025-12-07T21:22:17.2795126Z Unpacking libopenal1:amd64 (1:1.23.1-4build1) ...
+2025-12-07T21:22:17.3064409Z Selecting previously unselected package libsbc1:amd64.
+2025-12-07T21:22:17.3197846Z Preparing to unpack .../181-libsbc1_2.0-1build1_amd64.deb ...
+2025-12-07T21:22:17.3205321Z Unpacking libsbc1:amd64 (2.0-1build1) ...
+2025-12-07T21:22:17.3453417Z Selecting previously unselected package libvo-aacenc0:amd64.
+2025-12-07T21:22:17.3587686Z Preparing to unpack .../182-libvo-aacenc0_0.1.3-2build1_amd64.deb ...
+2025-12-07T21:22:17.3597923Z Unpacking libvo-aacenc0:amd64 (0.1.3-2build1) ...
+2025-12-07T21:22:17.3814381Z Selecting previously unselected package libvo-amrwbenc0:amd64.
+2025-12-07T21:22:17.3947703Z Preparing to unpack .../183-libvo-amrwbenc0_0.1.3-2build1_amd64.deb ...
+2025-12-07T21:22:17.3956555Z Unpacking libvo-amrwbenc0:amd64 (0.1.3-2build1) ...
+2025-12-07T21:22:17.4164504Z Selecting previously unselected package gstreamer1.0-plugins-bad:amd64.
+2025-12-07T21:22:17.4297420Z Preparing to unpack .../184-gstreamer1.0-plugins-bad_1.24.2-1ubuntu4_amd64.deb ...
+2025-12-07T21:22:17.4305863Z Unpacking gstreamer1.0-plugins-bad:amd64 (1.24.2-1ubuntu4) ...
+2025-12-07T21:22:17.5908631Z Setting up libgme0:amd64 (0.6.3-7build1) ...
+2025-12-07T21:22:17.5934209Z Setting up libchromaprint1:amd64 (1.5.1-5) ...
+2025-12-07T21:22:17.5956706Z Setting up libssh-gcrypt-4:amd64 (0.10.6-2ubuntu0.2) ...
+2025-12-07T21:22:17.5977478Z Setting up libhwy1t64:amd64 (1.0.7-8.1build1) ...
+2025-12-07T21:22:17.5999441Z Setting up libcairo-script-interpreter2:amd64 (1.18.0-3build1) ...
+2025-12-07T21:22:17.6019775Z Setting up libfreeaptx0:amd64 (0.1.1-2build1) ...
+2025-12-07T21:22:17.6044109Z Setting up libdvdread8t64:amd64 (6.1.3-1.1build1) ...
+2025-12-07T21:22:17.6070306Z Setting up libudfread0:amd64 (1.1.2-1build1) ...
+2025-12-07T21:22:17.6095197Z Setting up libmodplug1:amd64 (1:0.8.9.0-3build1) ...
+2025-12-07T21:22:17.6118465Z Setting up libcdparanoia0:amd64 (3.10.2+debian-14build3) ...
+2025-12-07T21:22:17.6141808Z Setting up libvo-amrwbenc0:amd64 (0.1.3-2build1) ...
+2025-12-07T21:22:17.6162165Z Setting up libraw1394-11:amd64 (2.1.2-2build3) ...
+2025-12-07T21:22:17.6186122Z Setting up libsbc1:amd64 (2.0-1build1) ...
+2025-12-07T21:22:17.6207797Z Setting up libneon27t64:amd64 (0.33.0-1.1build3) ...
+2025-12-07T21:22:17.6228286Z Setting up libtag1v5-vanilla:amd64 (1.13.1-1build1) ...
+2025-12-07T21:22:17.6253383Z Setting up libharfbuzz-icu0:amd64 (8.3.0-2build2) ...
+2025-12-07T21:22:17.6273386Z Setting up libopenni2-0:amd64 (2.2.0.33+dfsg-18) ...
+2025-12-07T21:22:17.6434465Z Setting up libspeex1:amd64 (1.2.1-2ubuntu2.24.04.1) ...
+2025-12-07T21:22:17.6459621Z Setting up libshine3:amd64 (3.1.1-2build1) ...
+2025-12-07T21:22:17.6482128Z Setting up libcaca0:amd64 (0.99.beta20-4build2) ...
+2025-12-07T21:22:17.6502787Z Setting up libvpl2 (2023.3.0-1build1) ...
+2025-12-07T21:22:17.6525673Z Setting up libv4lconvert0t64:amd64 (1.26.1-4build3) ...
+2025-12-07T21:22:17.6545529Z Setting up libx264-164:amd64 (2:0.164.3108+git31e19f9-1) ...
+2025-12-07T21:22:17.6587287Z Setting up libtwolame0:amd64 (0.4.0-2build3) ...
+2025-12-07T21:22:17.6611207Z Setting up libmbedcrypto7t64:amd64 (2.28.8-1) ...
+2025-12-07T21:22:17.6634486Z Setting up libwoff1:amd64 (1.0.2-2build1) ...
+2025-12-07T21:22:17.6656922Z Setting up liblc3-1:amd64 (1.0.4-3build1) ...
+2025-12-07T21:22:17.6679376Z Setting up libqrencode4:amd64 (4.1.1-1build2) ...
+2025-12-07T21:22:17.6700019Z Setting up libhyphen0:amd64 (2.8.8-7build3) ...
+2025-12-07T21:22:17.6724879Z Setting up libgsm1:amd64 (1.0.22-1build1) ...
+2025-12-07T21:22:17.6749437Z Setting up libvisual-0.4-0:amd64 (0.4.2-2build1) ...
+2025-12-07T21:22:17.6769430Z Setting up libsoxr0:amd64 (0.1.3-4build3) ...
+2025-12-07T21:22:17.6790097Z Setting up libzix-0-0:amd64 (0.4.2-2build1) ...
+2025-12-07T21:22:17.6812653Z Setting up libcodec2-1.2:amd64 (1.2.0-2build1) ...
+2025-12-07T21:22:17.6835558Z Setting up libsrtp2-1:amd64 (2.5.0-3build1) ...
+2025-12-07T21:22:17.6857300Z Setting up libmysofa1:amd64 (1.3.2+dfsg-2ubuntu2) ...
+2025-12-07T21:22:17.6882664Z Setting up libraptor2-0:amd64 (2.0.16-3ubuntu0.1) ...
+2025-12-07T21:22:17.6903831Z Setting up libldacbt-enc2:amd64 (2.0.2.3+git20200429+ed310a0-4ubuntu2) ...
+2025-12-07T21:22:17.6926897Z Setting up fonts-wqy-zenhei (0.9.45-8) ...
+2025-12-07T21:22:17.7046186Z Setting up libwebrtc-audio-processing1:amd64 (0.3.1-0ubuntu6) ...
+2025-12-07T21:22:17.7069039Z Setting up fonts-freefont-ttf (20211204+svn4273-2) ...
+2025-12-07T21:22:17.7090504Z Setting up libevent-2.1-7t64:amd64 (2.1.12-stable-9ubuntu2) ...
+2025-12-07T21:22:17.7116283Z Setting up libsvtav1enc1d1:amd64 (1.7.0+dfsg-2build1) ...
+2025-12-07T21:22:17.7137843Z Setting up libsoup-3.0-common (3.4.4-5ubuntu0.5) ...
+2025-12-07T21:22:17.7159001Z Setting up libmpg123-0t64:amd64 (1.32.5-1ubuntu1.1) ...
+2025-12-07T21:22:17.7180348Z Setting up libcjson1:amd64 (1.7.17-1) ...
+2025-12-07T21:22:17.7206304Z Setting up libxvidcore4:amd64 (2:1.3.7-1build1) ...
+2025-12-07T21:22:17.7227568Z Setting up libmpcdec6:amd64 (2:0.1~r495-2build1) ...
+2025-12-07T21:22:17.7252192Z Setting up libmjpegutils-2.1-0t64:amd64 (1:2.1.0+debian-8.1build1) ...
+2025-12-07T21:22:17.7273170Z Setting up librav1e0:amd64 (0.7.1-2) ...
+2025-12-07T21:22:17.7297013Z Setting up liborc-0.4-0t64:amd64 (1:0.4.38-1ubuntu0.1) ...
+2025-12-07T21:22:17.7329867Z Setting up libxcb-xkb1:amd64 (1.15-1ubuntu2) ...
+2025-12-07T21:22:17.7352401Z Setting up libvo-aacenc0:amd64 (0.1.3-2build1) ...
+2025-12-07T21:22:17.7373057Z Setting up librist4:amd64 (0.2.10+dfsg-2) ...
+2025-12-07T21:22:17.7397603Z Setting up libglib2.0-0t64:amd64 (2.80.0-6ubuntu3.5) ...
+2025-12-07T21:22:17.7591021Z Setting up libblas3:amd64 (3.12.0-3build1.1) ...
+2025-12-07T21:22:17.7653687Z update-alternatives: using /usr/lib/x86_64-linux-gnu/blas/libblas.so.3 to provide /usr/lib/x86_64-linux-gnu/libblas.so.3 (libblas.so.3-x86_64-linux-gnu) in auto mode
+2025-12-07T21:22:17.7749477Z Setting up libegl-mesa0:amd64 (25.0.7-0ubuntu0.24.04.2) ...
+2025-12-07T21:22:17.7771984Z Setting up libsoundtouch1:amd64 (2.3.2+ds1-1build1) ...
+2025-12-07T21:22:17.7795049Z Setting up libglib2.0-data (2.80.0-6ubuntu3.5) ...
+2025-12-07T21:22:17.7815551Z Setting up libplacebo338:amd64 (6.338.2-2build1) ...
+2025-12-07T21:22:17.7844293Z Setting up libgles2:amd64 (1.7.0-1build1) ...
+2025-12-07T21:22:17.7874929Z Setting up fonts-tlwg-loma-otf (1:0.7.3-1) ...
+2025-12-07T21:22:17.7901700Z Setting up libva2:amd64 (2.20.0-2build1) ...
+2025-12-07T21:22:17.7927466Z Setting up libspa-0.2-modules:amd64 (1.0.5-1ubuntu3.1) ...
+2025-12-07T21:22:17.7954320Z Setting up libzxing3:amd64 (2.2.1-3) ...
+2025-12-07T21:22:17.7980819Z Setting up xfonts-encodings (1:1.0.5-0ubuntu2) ...
+2025-12-07T21:22:17.8005753Z Setting up libopus0:amd64 (1.4-1build1) ...
+2025-12-07T21:22:17.8029390Z Setting up libfaad2:amd64 (2.11.1-1build1) ...
+2025-12-07T21:22:17.8054372Z Setting up libxkbcommon-x11-0:amd64 (1.6.0-1build1) ...
+2025-12-07T21:22:17.8083919Z Setting up libdc1394-25:amd64 (2.2.6-4build1) ...
+2025-12-07T21:22:17.8106137Z Setting up libimath-3-1-29t64:amd64 (3.1.9-3.1ubuntu2) ...
+2025-12-07T21:22:17.8134459Z Setting up libunibreak5:amd64 (5.1-2build1) ...
+2025-12-07T21:22:17.8157478Z Setting up libdv4t64:amd64 (1.0.0-17.1build1) ...
+2025-12-07T21:22:17.8182937Z Setting up gir1.2-glib-2.0:amd64 (2.80.0-6ubuntu3.5) ...
+2025-12-07T21:22:17.8203348Z Setting up libjxl0.7:amd64 (0.7.0-10.2ubuntu6.1) ...
+2025-12-07T21:22:17.8226279Z Setting up libssh-4:amd64 (0.10.6-2ubuntu0.2) ...
+2025-12-07T21:22:17.8249111Z Setting up libopenh264-7:amd64 (2.4.1+dfsg-1) ...
+2025-12-07T21:22:17.8270351Z Setting up libltc11:amd64 (1.3.2-1build1) ...
+2025-12-07T21:22:17.8295732Z Setting up libx265-199:amd64 (3.5-2build1) ...
+2025-12-07T21:22:17.8318573Z Setting up libv4l-0t64:amd64 (1.26.1-4build3) ...
+2025-12-07T21:22:17.8342158Z Setting up libavtp0:amd64 (0.2.0-1build1) ...
+2025-12-07T21:22:17.8364681Z Setting up libsndio7.0:amd64 (1.9.0-0.3build3) ...
+2025-12-07T21:22:17.8386139Z Setting up libdirectfb-1.7-7t64:amd64 (1.7.7-11.1ubuntu2) ...
+2025-12-07T21:22:17.8527297Z Setting up libspandsp2t64:amd64 (0.0.6+dfsg-2.1build1) ...
+2025-12-07T21:22:17.8550656Z Setting up libvidstab1.1:amd64 (1.1.0-2build1) ...
+2025-12-07T21:22:17.8573059Z Setting up libvpx9:amd64 (1.14.0-1ubuntu2.2) ...
+2025-12-07T21:22:17.8596333Z Setting up libsrt1.5-gnutls:amd64 (1.5.3-1build2) ...
+2025-12-07T21:22:17.8618963Z Setting up libtag1v5:amd64 (1.13.1-1build1) ...
+2025-12-07T21:22:17.8639011Z Setting up libflite1:amd64 (2.2-6build3) ...
+2025-12-07T21:22:17.8660007Z Setting up libdav1d7:amd64 (1.4.1-1build1) ...
+2025-12-07T21:22:17.8682111Z Setting up libva-drm2:amd64 (2.20.0-2build1) ...
+2025-12-07T21:22:17.8703444Z Setting up fonts-ipafont-gothic (00303-21ubuntu1) ...
+2025-12-07T21:22:17.8771677Z update-alternatives: using /usr/share/fonts/opentype/ipafont-gothic/ipag.ttf to provide /usr/share/fonts/truetype/fonts-japanese-gothic.ttf (fonts-japanese-gothic.ttf) in auto mode
+2025-12-07T21:22:17.8791018Z Setting up ocl-icd-libopencl1:amd64 (2.3.2-1build1) ...
+2025-12-07T21:22:17.8810612Z Setting up libasyncns0:amd64 (0.8-6build4) ...
+2025-12-07T21:22:17.8835826Z Setting up libwildmidi2:amd64 (0.4.3-1build3) ...
+2025-12-07T21:22:17.8855554Z Setting up libvdpau1:amd64 (1.5-2build1) ...
+2025-12-07T21:22:17.8884534Z Setting up libwavpack1:amd64 (5.6.0-1build1) ...
+2025-12-07T21:22:17.8930557Z Setting up libbs2b0:amd64 (3.1.0+dfsg-7build1) ...
+2025-12-07T21:22:17.8953466Z Setting up libtheora0:amd64 (1.1.1+dfsg.1-16.1build3) ...
+2025-12-07T21:22:17.8981951Z Setting up libegl1:amd64 (1.7.0-1build1) ...
+2025-12-07T21:22:17.9004066Z Setting up libdecor-0-0:amd64 (0.2.2-1build2) ...
+2025-12-07T21:22:17.9027321Z Setting up libdca0:amd64 (0.0.7-2build1) ...
+2025-12-07T21:22:17.9053470Z Setting up libzimg2:amd64 (3.0.5+ds1-1build1) ...
+2025-12-07T21:22:17.9074860Z Setting up libopenal-data (1:1.23.1-4build1) ...
+2025-12-07T21:22:17.9103093Z Setting up libabsl20220623t64:amd64 (20220623.1-3.1ubuntu3.2) ...
+2025-12-07T21:22:17.9125004Z Setting up libflac12t64:amd64 (1.4.3+ds-2.1ubuntu2) ...
+2025-12-07T21:22:17.9148015Z Setting up libgtk-4-common (4.14.5+ds-0ubuntu0.7) ...
+2025-12-07T21:22:17.9171651Z Setting up libmpeg2encpp-2.1-0t64:amd64 (1:2.1.0+debian-8.1build1) ...
+2025-12-07T21:22:17.9192313Z Setting up glib-networking-common (2.80.0-1build1) ...
+2025-12-07T21:22:17.9213275Z Setting up libmfx1:amd64 (22.5.4-1) ...
+2025-12-07T21:22:17.9232991Z Setting up libbluray2:amd64 (1:1.3.4-1build1) ...
+2025-12-07T21:22:17.9252078Z Setting up libsamplerate0:amd64 (0.2.2-4build1) ...
+2025-12-07T21:22:17.9273058Z Setting up timgm6mb-soundfont (1.3-5) ...
+2025-12-07T21:22:17.9355610Z update-alternatives: using /usr/share/sounds/sf2/TimGM6mb.sf2 to provide /usr/share/sounds/sf2/default-GM.sf2 (default-GM.sf2) in auto mode
+2025-12-07T21:22:17.9398242Z update-alternatives: using /usr/share/sounds/sf2/TimGM6mb.sf2 to provide /usr/share/sounds/sf3/default-GM.sf3 (default-GM.sf3) in auto mode
+2025-12-07T21:22:17.9417179Z Setting up libva-x11-2:amd64 (2.20.0-2build1) ...
+2025-12-07T21:22:17.9439728Z Setting up libyuv0:amd64 (0.0~git202401110.af6ac82-1) ...
+2025-12-07T21:22:17.9460192Z Setting up libmplex2-2.1-0t64:amd64 (1:2.1.0+debian-8.1build1) ...
+2025-12-07T21:22:17.9481015Z Setting up libpipewire-0.3-0t64:amd64 (1.0.5-1ubuntu3.1) ...
+2025-12-07T21:22:17.9500733Z Setting up libcups2t64:amd64 (2.4.7-1.2ubuntu7.9) ...
+2025-12-07T21:22:17.9521726Z Setting up libopenmpt0t64:amd64 (0.7.3-1.1build3) ...
+2025-12-07T21:22:17.9546309Z Setting up libzvbi-common (0.2.42-2) ...
+2025-12-07T21:22:17.9564540Z Setting up libsecret-common (0.21.4-1build3) ...
+2025-12-07T21:22:17.9585180Z Setting up libmp3lame0:amd64 (3.100-6build1) ...
+2025-12-07T21:22:17.9606319Z Setting up libgraphene-1.0-0:amd64 (1.10.8-3build2) ...
+2025-12-07T21:22:17.9625520Z Setting up libvorbisenc2:amd64 (1.3.7-1build3) ...
+2025-12-07T21:22:17.9647547Z Setting up libdvdnav4:amd64 (6.1.1-3build1) ...
+2025-12-07T21:22:17.9667034Z Setting up fonts-unifont (1:15.1.01-1build1) ...
+2025-12-07T21:22:17.9689875Z Setting up libaa1:amd64 (1.4p5-51.1) ...
+2025-12-07T21:22:17.9711945Z Setting up libiec61883-0:amd64 (1.2.0-6build1) ...
+2025-12-07T21:22:17.9733760Z Setting up libserd-0-0:amd64 (0.32.2-1) ...
+2025-12-07T21:22:17.9754781Z Setting up libavc1394-0:amd64 (0.5.4-5build3) ...
+2025-12-07T21:22:17.9777445Z Setting up session-migration (0.3.9build1) ...
+2025-12-07T21:22:18.0938388Z Created symlink /etc/systemd/user/graphical-session-pre.target.wants/session-migration.service → /usr/lib/systemd/user/session-migration.service.
+2025-12-07T21:22:18.0939028Z 
+2025-12-07T21:22:18.0970851Z Setting up liblapack3:amd64 (3.12.0-3build1.1) ...
+2025-12-07T21:22:18.1029628Z update-alternatives: using /usr/lib/x86_64-linux-gnu/lapack/liblapack.so.3 to provide /usr/lib/x86_64-linux-gnu/liblapack.so.3 (liblapack.so.3-x86_64-linux-gnu) in auto mode
+2025-12-07T21:22:18.1046776Z Setting up libproxy1v5:amd64 (0.5.4-4build1) ...
+2025-12-07T21:22:18.1070152Z Setting up libzvbi0t64:amd64 (0.2.42-2) ...
+2025-12-07T21:22:18.1090282Z Setting up liblrdf0:amd64 (0.6.1-4build1) ...
+2025-12-07T21:22:18.1131971Z Setting up libmanette-0.2-0:amd64 (0.2.7-1build2) ...
+2025-12-07T21:22:18.1153490Z Setting up libglib2.0-bin (2.80.0-6ubuntu3.5) ...
+2025-12-07T21:22:18.1173797Z Setting up libzbar0t64:amd64 (0.23.93-4build3) ...
+2025-12-07T21:22:18.1198306Z Setting up libgstreamer-plugins-base1.0-0:amd64 (1.24.2-1ubuntu0.3) ...
+2025-12-07T21:22:18.1220309Z Setting up libavutil58:amd64 (7:6.1.1-3ubuntu5) ...
+2025-12-07T21:22:18.1243330Z Setting up libopenal1:amd64 (1:1.23.1-4build1) ...
+2025-12-07T21:22:18.1318495Z Setting up xfonts-utils (1:7.7+6build3) ...
+2025-12-07T21:22:18.1365428Z Setting up librsvg2-2:amd64 (2.58.0+dfsg-1build1) ...
+2025-12-07T21:22:18.1388892Z Setting up libsecret-1-0:amd64 (0.21.4-1build3) ...
+2025-12-07T21:22:18.1415881Z Setting up libgstreamer-plugins-good1.0-0:amd64 (1.24.2-1ubuntu1.2) ...
+2025-12-07T21:22:18.1438527Z Setting up libgstreamer-gl1.0-0:amd64 (1.24.2-1ubuntu0.3) ...
+2025-12-07T21:22:18.1462202Z Setting up gstreamer1.0-plugins-base:amd64 (1.24.2-1ubuntu0.3) ...
+2025-12-07T21:22:18.1488039Z Setting up libass9:amd64 (1:0.17.1-2build1) ...
+2025-12-07T21:22:18.1508066Z Setting up libswresample4:amd64 (7:6.1.1-3ubuntu5) ...
+2025-12-07T21:22:18.1532503Z Setting up libopenexr-3-1-30:amd64 (3.1.5-5.1build3) ...
+2025-12-07T21:22:18.1553171Z Setting up libshout3:amd64 (2.4.6-1build2) ...
+2025-12-07T21:22:18.1577831Z Setting up libgav1-1:amd64 (0.18.0-1build3) ...
+2025-12-07T21:22:18.1606328Z Setting up libavcodec60:amd64 (7:6.1.1-3ubuntu5) ...
+2025-12-07T21:22:18.1630070Z Setting up librubberband2:amd64 (3.3.0+dfsg-2build1) ...
+2025-12-07T21:22:18.1651505Z Setting up libjack-jackd2-0:amd64 (1.9.21~dfsg-3ubuntu3) ...
+2025-12-07T21:22:18.1672339Z Setting up libsord-0-0:amd64 (0.16.16-2build1) ...
+2025-12-07T21:22:18.1696946Z Setting up xfonts-cyrillic (1:1.0.5+nmu1) ...
+2025-12-07T21:22:18.2001564Z Setting up libpostproc57:amd64 (7:6.1.1-3ubuntu5) ...
+2025-12-07T21:22:18.2026209Z Setting up libsratom-0-0:amd64 (0.6.16-1build1) ...
+2025-12-07T21:22:18.2056159Z Setting up libgtk-4-1:amd64 (4.14.5+ds-0ubuntu0.7) ...
+2025-12-07T21:22:18.2638250Z Setting up libsndfile1:amd64 (1.2.2-1ubuntu5.24.04.1) ...
+2025-12-07T21:22:18.2661852Z Setting up liblilv-0-0:amd64 (0.24.22-1build1) ...
+2025-12-07T21:22:18.2690403Z Setting up libinstpatch-1.0-2:amd64 (1.1.6-1build2) ...
+2025-12-07T21:22:18.2716567Z Setting up xfonts-scalable (1:1.0.3-1.3) ...
+2025-12-07T21:22:18.3104425Z Setting up libswscale7:amd64 (7:6.1.1-3ubuntu5) ...
+2025-12-07T21:22:18.3126890Z Setting up gsettings-desktop-schemas (46.1-0ubuntu1) ...
+2025-12-07T21:22:18.3152213Z Setting up glib-networking-services (2.80.0-1build1) ...
+2025-12-07T21:22:18.3175058Z Setting up libavif16:amd64 (1.0.4-1ubuntu3) ...
+2025-12-07T21:22:18.3199770Z Setting up libpulse0:amd64 (1:16.1+dfsg1-2ubuntu10.1) ...
+2025-12-07T21:22:18.3273442Z Setting up libavformat60:amd64 (7:6.1.1-3ubuntu5) ...
+2025-12-07T21:22:18.3293285Z Setting up libsphinxbase3t64:amd64 (0.8+5prealpha+1-17build2) ...
+2025-12-07T21:22:18.3320818Z Setting up glib-networking:amd64 (2.80.0-1build1) ...
+2025-12-07T21:22:18.3342574Z Setting up libsdl2-2.0-0:amd64 (2.30.0+dfsg-1ubuntu3.1) ...
+2025-12-07T21:22:18.3363914Z Setting up libfluidsynth3:amd64 (2.3.4-1build3) ...
+2025-12-07T21:22:18.3396409Z Setting up libsoup-3.0-0:amd64 (3.4.4-5ubuntu0.5) ...
+2025-12-07T21:22:18.3417545Z Setting up libpocketsphinx3:amd64 (0.8.0+real5prealpha+1-15ubuntu5) ...
+2025-12-07T21:22:18.3440437Z Setting up libgssdp-1.6-0:amd64 (1.6.3-1build3) ...
+2025-12-07T21:22:18.3479864Z Setting up gstreamer1.0-plugins-good:amd64 (1.24.2-1ubuntu1.2) ...
+2025-12-07T21:22:18.3508244Z Setting up libgupnp-1.6-0:amd64 (1.6.6-1build3) ...
+2025-12-07T21:22:18.3535021Z Setting up libavfilter9:amd64 (7:6.1.1-3ubuntu5) ...
+2025-12-07T21:22:18.3560982Z Setting up libgupnp-igd-1.6-0:amd64 (1.6.0-3build3) ...
+2025-12-07T21:22:18.3585686Z Setting up gstreamer1.0-libav:amd64 (1.24.1-1build1) ...
+2025-12-07T21:22:18.3606400Z Setting up libnice10:amd64 (0.1.21-2build3) ...
+2025-12-07T21:22:18.3635144Z Setting up libgstreamer-plugins-bad1.0-0:amd64 (1.24.2-1ubuntu4) ...
+2025-12-07T21:22:18.3660484Z Setting up gstreamer1.0-plugins-bad:amd64 (1.24.2-1ubuntu4) ...
+2025-12-07T21:22:18.3689710Z Processing triggers for libc-bin (2.39-0ubuntu8.6) ...
+2025-12-07T21:22:18.5874800Z Processing triggers for man-db (2.12.0-4build2) ...
+2025-12-07T21:22:18.5903467Z Not building database; man-db/auto-update is not 'true'.
+2025-12-07T21:22:18.5915974Z Processing triggers for fontconfig (2.15.0-1.1ubuntu2) ...
+2025-12-07T21:22:19.2626222Z 
+2025-12-07T21:22:19.2626868Z Running kernel seems to be up-to-date.
+2025-12-07T21:22:19.2627287Z 
+2025-12-07T21:22:19.2627470Z Restarting services...
+2025-12-07T21:22:19.3056111Z  systemctl restart packagekit.service php8.3-fpm.service polkit.service udisks2.service
+2025-12-07T21:22:19.4243921Z 
+2025-12-07T21:22:19.4245854Z Service restarts being deferred:
+2025-12-07T21:22:19.4246785Z  systemctl restart ModemManager.service
+2025-12-07T21:22:19.4247715Z  systemctl restart networkd-dispatcher.service
+2025-12-07T21:22:19.4248135Z 
+2025-12-07T21:22:19.4248388Z No containers need to be restarted.
+2025-12-07T21:22:19.4248694Z 
+2025-12-07T21:22:19.4248984Z No user sessions are running outdated binaries.
+2025-12-07T21:22:19.4249327Z 
+2025-12-07T21:22:19.4249831Z No VM guests are running outdated hypervisor (qemu) binaries on this host.
+2025-12-07T21:22:20.3586391Z Downloading Chromium 141.0.7390.37 (playwright build v1194) from https://cdn.playwright.dev/dbazure/download/playwright/builds/chromium/1194/chromium-linux.zip
+2025-12-07T21:22:20.5244725Z |                                                                                |   0% of 173.9 MiB
+2025-12-07T21:22:20.7421769Z |■■■■■■■■                                                                        |  10% of 173.9 MiB
+2025-12-07T21:22:21.0479586Z |■■■■■■■■■■■■■■■■                                                                |  20% of 173.9 MiB
+2025-12-07T21:22:21.7176503Z |■■■■■■■■■■■■■■■■■■■■■■■■                                                        |  30% of 173.9 MiB
+2025-12-07T21:22:22.0019939Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■                                                |  40% of 173.9 MiB
+2025-12-07T21:22:22.5112791Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■                                        |  50% of 173.9 MiB
+2025-12-07T21:22:22.8271084Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■                                |  60% of 173.9 MiB
+2025-12-07T21:22:23.1143130Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■                        |  70% of 173.9 MiB
+2025-12-07T21:22:23.2399314Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■                |  80% of 173.9 MiB
+2025-12-07T21:22:23.3285883Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■        |  90% of 173.9 MiB
+2025-12-07T21:22:23.4523498Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■| 100% of 173.9 MiB
+2025-12-07T21:22:26.7494288Z Chromium 141.0.7390.37 (playwright build v1194) downloaded to /home/runner/.cache/ms-playwright/chromium-1194
+2025-12-07T21:22:26.7497973Z Downloading Chromium Headless Shell 141.0.7390.37 (playwright build v1194) from https://cdn.playwright.dev/dbazure/download/playwright/builds/chromium/1194/chromium-headless-shell-linux.zip
+2025-12-07T21:22:26.8759235Z |                                                                                |   0% of 104.3 MiB
+2025-12-07T21:22:26.9634455Z |■■■■■■■■                                                                        |  10% of 104.3 MiB
+2025-12-07T21:22:27.0223376Z |■■■■■■■■■■■■■■■■                                                                |  20% of 104.3 MiB
+2025-12-07T21:22:27.0778545Z |■■■■■■■■■■■■■■■■■■■■■■■■                                                        |  30% of 104.3 MiB
+2025-12-07T21:22:27.1305802Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■                                                |  40% of 104.3 MiB
+2025-12-07T21:22:27.1844442Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■                                        |  50% of 104.3 MiB
+2025-12-07T21:22:27.2285419Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■                                |  60% of 104.3 MiB
+2025-12-07T21:22:27.2693954Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■                        |  70% of 104.3 MiB
+2025-12-07T21:22:27.3383277Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■                |  80% of 104.3 MiB
+2025-12-07T21:22:27.4032847Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■        |  90% of 104.3 MiB
+2025-12-07T21:22:27.4551614Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■| 100% of 104.3 MiB
+2025-12-07T21:22:29.2104910Z Chromium Headless Shell 141.0.7390.37 (playwright build v1194) downloaded to /home/runner/.cache/ms-playwright/chromium_headless_shell-1194
+2025-12-07T21:22:29.2107940Z Downloading Firefox 142.0.1 (playwright build v1495) from https://cdn.playwright.dev/dbazure/download/playwright/builds/firefox/1495/firefox-ubuntu-24.04.zip
+2025-12-07T21:22:29.3453167Z |                                                                                |   0% of 96.7 MiB
+2025-12-07T21:22:29.4106437Z |■■■■■■■■                                                                        |  10% of 96.7 MiB
+2025-12-07T21:22:29.4701097Z |■■■■■■■■■■■■■■■■                                                                |  20% of 96.7 MiB
+2025-12-07T21:22:29.5158840Z |■■■■■■■■■■■■■■■■■■■■■■■■                                                        |  30% of 96.7 MiB
+2025-12-07T21:22:29.6159355Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■                                                |  40% of 96.7 MiB
+2025-12-07T21:22:29.6999495Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■                                        |  50% of 96.7 MiB
+2025-12-07T21:22:29.8035071Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■                                |  60% of 96.7 MiB
+2025-12-07T21:22:29.8727842Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■                        |  70% of 96.7 MiB
+2025-12-07T21:22:29.9398391Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■                |  80% of 96.7 MiB
+2025-12-07T21:22:30.1054682Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■        |  90% of 96.7 MiB
+2025-12-07T21:22:30.2411079Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■| 100% of 96.7 MiB
+2025-12-07T21:22:31.8557691Z Firefox 142.0.1 (playwright build v1495) downloaded to /home/runner/.cache/ms-playwright/firefox-1495
+2025-12-07T21:22:31.8560946Z Downloading Webkit 26.0 (playwright build v2215) from https://cdn.playwright.dev/dbazure/download/playwright/builds/webkit/2215/webkit-ubuntu-24.04.zip
+2025-12-07T21:22:31.9964527Z |                                                                                |   0% of 94.6 MiB
+2025-12-07T21:22:32.0649086Z |■■■■■■■■                                                                        |  10% of 94.6 MiB
+2025-12-07T21:22:32.1195923Z |■■■■■■■■■■■■■■■■                                                                |  20% of 94.6 MiB
+2025-12-07T21:22:32.1636477Z |■■■■■■■■■■■■■■■■■■■■■■■■                                                        |  30% of 94.6 MiB
+2025-12-07T21:22:32.2085426Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■                                                |  40% of 94.6 MiB
+2025-12-07T21:22:32.2696403Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■                                        |  50% of 94.6 MiB
+2025-12-07T21:22:32.3243165Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■                                |  60% of 94.6 MiB
+2025-12-07T21:22:32.3954304Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■                        |  70% of 94.6 MiB
+2025-12-07T21:22:32.4498515Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■                |  80% of 94.6 MiB
+2025-12-07T21:22:32.5035831Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■        |  90% of 94.6 MiB
+2025-12-07T21:22:32.5548042Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■| 100% of 94.6 MiB
+2025-12-07T21:22:34.1780430Z Webkit 26.0 (playwright build v2215) downloaded to /home/runner/.cache/ms-playwright/webkit-2215
+2025-12-07T21:22:34.1784425Z Downloading FFMPEG playwright build v1011 from https://cdn.playwright.dev/dbazure/download/playwright/builds/ffmpeg/1011/ffmpeg-linux.zip
+2025-12-07T21:22:34.3034669Z |                                                                                |   0% of 2.3 MiB
+2025-12-07T21:22:34.3090877Z |■■■■■■■■                                                                        |  10% of 2.3 MiB
+2025-12-07T21:22:34.3109263Z |■■■■■■■■■■■■■■■■                                                                |  20% of 2.3 MiB
+2025-12-07T21:22:34.3127758Z |■■■■■■■■■■■■■■■■■■■■■■■■                                                        |  30% of 2.3 MiB
+2025-12-07T21:22:34.3145556Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■                                                |  40% of 2.3 MiB
+2025-12-07T21:22:34.3156381Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■                                        |  50% of 2.3 MiB
+2025-12-07T21:22:34.3172685Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■                                |  60% of 2.3 MiB
+2025-12-07T21:22:34.3185859Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■                        |  70% of 2.3 MiB
+2025-12-07T21:22:34.3201899Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■                |  80% of 2.3 MiB
+2025-12-07T21:22:34.3215346Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■        |  90% of 2.3 MiB
+2025-12-07T21:22:34.3229058Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■| 100% of 2.3 MiB
+2025-12-07T21:22:34.3779707Z FFMPEG playwright build v1011 downloaded to /home/runner/.cache/ms-playwright/ffmpeg-1011
+2025-12-07T21:22:34.7532628Z ##[group]Run npx tsc --noEmit
+2025-12-07T21:22:34.7532941Z [36;1mnpx tsc --noEmit[0m
+2025-12-07T21:22:34.7565986Z shell: /usr/bin/bash -e {0}
+2025-12-07T21:22:34.7566293Z ##[endgroup]
+2025-12-07T21:22:36.2862814Z ##[group]Run npx playwright test --grep "@critical" --reporter=html
+2025-12-07T21:22:36.2863317Z [36;1mnpx playwright test --grep "@critical" --reporter=html[0m
+2025-12-07T21:22:36.2895379Z shell: /usr/bin/bash -e {0}
+2025-12-07T21:22:36.2895615Z env:
+2025-12-07T21:22:36.2895777Z   CI: true
+2025-12-07T21:22:36.2895942Z ##[endgroup]
+2025-12-07T21:22:39.5560706Z 
+2025-12-07T21:22:39.5561268Z Running 20 tests using 1 worker
+2025-12-07T21:22:44.8868137Z ····Course link href: /myFreecodecampLearning/pages/s100101-Certified-Full-Stack-Developer-Curriculum/Home-Certified-Full-Stack-Developer-Curriculum.html
+2025-12-07T21:22:44.9153328Z Navigation response status: [33m200[39m
+2025-12-07T21:22:44.9154648Z Navigation URL: http://localhost:4000/myFreecodecampLearning/pages/s100101-Certified-Full-Stack-Developer-Curriculum/Home-Certified-Full-Stack-Developer-Curriculum.html
+2025-12-07T21:22:51.5724764Z ·····Course link href: /myFreecodecampLearning/pages/s100101-Certified-Full-Stack-Developer-Curriculum/Home-Certified-Full-Stack-Developer-Curriculum.html
+2025-12-07T21:22:51.6332552Z Navigation response status: [33m200[39m
+2025-12-07T21:22:51.6335496Z Navigation URL: http://localhost:4000/myFreecodecampLearning/pages/s100101-Certified-Full-Stack-Developer-Curriculum/Home-Certified-Full-Stack-Developer-Curriculum.html
+2025-12-07T21:23:02.1457873Z ·····Course link href: /myFreecodecampLearning/pages/s100101-Certified-Full-Stack-Developer-Curriculum/Home-Certified-Full-Stack-Developer-Curriculum.html
+2025-12-07T21:23:02.1841078Z Navigation response status: [33m200[39m
+2025-12-07T21:23:02.1843080Z Navigation URL: http://localhost:4000/myFreecodecampLearning/pages/s100101-Certified-Full-Stack-Developer-Curriculum/Home-Certified-Full-Stack-Developer-Curriculum.html
+2025-12-07T21:23:22.4683093Z ·····Course link href: /myFreecodecampLearning/pages/s100101-Certified-Full-Stack-Developer-Curriculum/Home-Certified-Full-Stack-Developer-Curriculum.html
+2025-12-07T21:23:22.5171996Z Navigation response status: [33m200[39m
+2025-12-07T21:23:22.5174187Z Navigation URL: http://localhost:4000/myFreecodecampLearning/pages/s100101-Certified-Full-Stack-Developer-Curriculum/Home-Certified-Full-Stack-Developer-Curriculum.html
+2025-12-07T21:23:29.9858421Z ·
+2025-12-07T21:23:29.9862373Z   20 passed (52.5s)
+2025-12-07T21:23:30.0286871Z ##[group]Run actions/upload-artifact@v4
+2025-12-07T21:23:30.0287153Z with:
+2025-12-07T21:23:30.0287389Z   name: playwright-report-production-pre-deployment
+2025-12-07T21:23:30.0287706Z   path: playwright-report/
+2025-12-07T21:23:30.0287919Z   retention-days: 7
+2025-12-07T21:23:30.0288111Z   if-no-files-found: warn
+2025-12-07T21:23:30.0288317Z   compression-level: 6
+2025-12-07T21:23:30.0288509Z   overwrite: false
+2025-12-07T21:23:30.0288882Z   include-hidden-files: false
+2025-12-07T21:23:30.0289098Z ##[endgroup]
+2025-12-07T21:23:30.2419383Z With the provided path, there will be 1 file uploaded
+2025-12-07T21:23:30.2424697Z Artifact name is valid!
+2025-12-07T21:23:30.2425799Z Root directory input is valid!
+2025-12-07T21:23:30.3851612Z Beginning upload of artifact content to blob storage
+2025-12-07T21:23:30.5822578Z Uploaded bytes 203107
+2025-12-07T21:23:30.6157769Z Finished uploading artifact content to blob storage!
+2025-12-07T21:23:30.6161790Z SHA256 digest of uploaded artifact zip is dce8bae36e679c6dfcb25fa8dbb6efa5179249a6ab1d165095013288a719a43a
+2025-12-07T21:23:30.6163319Z Finalizing artifact upload
+2025-12-07T21:23:30.7012212Z Artifact playwright-report-production-pre-deployment.zip successfully finalized. Artifact ID 4791538740
+2025-12-07T21:23:30.7014335Z Artifact playwright-report-production-pre-deployment has been successfully uploaded! Final size is 203107 bytes. Artifact ID is 4791538740
+2025-12-07T21:23:30.7021153Z Artifact download URL: https://github.com/T193R-W00D5/myFreecodecampLearning/actions/runs/20010521046/artifacts/4791538740
+2025-12-07T21:23:30.7141231Z Post job cleanup.
+2025-12-07T21:23:30.8725918Z Cache hit occurred on the primary key node-cache-Linux-x64-npm-e3fade3f30968ac95fccac45edc85cd25eaa881f6a1cdb7268c834223e952c45, not saving cache.
+2025-12-07T21:23:30.8865257Z Post job cleanup.
+2025-12-07T21:23:30.9818685Z [command]/usr/bin/git version
+2025-12-07T21:23:30.9859964Z git version 2.52.0
+2025-12-07T21:23:30.9908990Z Temporarily overriding HOME='/home/runner/work/_temp/7e48972c-17de-4046-b20e-6906d9e64355' before making global git config changes
+2025-12-07T21:23:30.9910575Z Adding repository directory to the temporary git global config as a safe directory
+2025-12-07T21:23:30.9922765Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/myFreecodecampLearning/myFreecodecampLearning
+2025-12-07T21:23:30.9956740Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+2025-12-07T21:23:30.9989450Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+2025-12-07T21:23:31.0218470Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+2025-12-07T21:23:31.0238457Z http.https://github.com/.extraheader
+2025-12-07T21:23:31.0251233Z [command]/usr/bin/git config --local --unset-all http.https://github.com/.extraheader
+2025-12-07T21:23:31.0281847Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+2025-12-07T21:23:31.0498459Z [command]/usr/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+2025-12-07T21:23:31.0528910Z [command]/usr/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+2025-12-07T21:23:31.0846607Z Cleaning up orphan processes
+
+2025-12-07T21:23:37.0980159Z Current runner version: '2.329.0'
+2025-12-07T21:23:37.1006105Z ##[group]Runner Image Provisioner
+2025-12-07T21:23:37.1006939Z Hosted Compute Agent
+2025-12-07T21:23:37.1007486Z Version: 20251124.448
+2025-12-07T21:23:37.1008100Z Commit: fda5086b43ec66ade217e5fcd18146c879571177
+2025-12-07T21:23:37.1008807Z Build Date: 2025-11-24T21:16:26Z
+2025-12-07T21:23:37.1009392Z ##[endgroup]
+2025-12-07T21:23:37.1009990Z ##[group]Operating System
+2025-12-07T21:23:37.1010535Z Ubuntu
+2025-12-07T21:23:37.1011011Z 24.04.3
+2025-12-07T21:23:37.1011423Z LTS
+2025-12-07T21:23:37.1011937Z ##[endgroup]
+2025-12-07T21:23:37.1012433Z ##[group]Runner Image
+2025-12-07T21:23:37.1012957Z Image: ubuntu-24.04
+2025-12-07T21:23:37.1013530Z Version: 20251126.144.1
+2025-12-07T21:23:37.1014724Z Included Software: https://github.com/actions/runner-images/blob/ubuntu24/20251126.144/images/ubuntu/Ubuntu2404-Readme.md
+2025-12-07T21:23:37.1016357Z Image Release: https://github.com/actions/runner-images/releases/tag/ubuntu24%2F20251126.144
+2025-12-07T21:23:37.1017370Z ##[endgroup]
+2025-12-07T21:23:37.1019913Z ##[group]GITHUB_TOKEN Permissions
+2025-12-07T21:23:37.1022254Z Actions: write
+2025-12-07T21:23:37.1022846Z ArtifactMetadata: write
+2025-12-07T21:23:37.1023512Z Attestations: write
+2025-12-07T21:23:37.1024025Z Checks: write
+2025-12-07T21:23:37.1024758Z Contents: write
+2025-12-07T21:23:37.1025356Z Deployments: write
+2025-12-07T21:23:37.1025894Z Discussions: write
+2025-12-07T21:23:37.1026381Z Issues: write
+2025-12-07T21:23:37.1026897Z Metadata: read
+2025-12-07T21:23:37.1027394Z Models: read
+2025-12-07T21:23:37.1027867Z Packages: write
+2025-12-07T21:23:37.1028414Z Pages: write
+2025-12-07T21:23:37.1028941Z PullRequests: write
+2025-12-07T21:23:37.1029431Z RepositoryProjects: write
+2025-12-07T21:23:37.1030142Z SecurityEvents: write
+2025-12-07T21:23:37.1030631Z Statuses: write
+2025-12-07T21:23:37.1031124Z ##[endgroup]
+2025-12-07T21:23:37.1033152Z Secret source: Actions
+2025-12-07T21:23:37.1033832Z Prepare workflow directory
+2025-12-07T21:23:37.1349575Z Prepare all required actions
+2025-12-07T21:23:37.1388956Z Getting action download info
+2025-12-07T21:23:37.5163128Z Download action repository 'actions/checkout@v4' (SHA:34e114876b0b11c390a56381ad16ebd13914f8d5)
+2025-12-07T21:23:38.3077170Z Download action repository 'ruby/setup-ruby@v1' (SHA:d697be2f83c6234b20877c3b5eac7a7f342f0d0c)
+2025-12-07T21:23:38.7440209Z Download action repository 'peaceiris/actions-gh-pages@v4' (SHA:4f9cc6602d3f66b9c108549d475ec49e8ef4d45e)
+2025-12-07T21:23:39.3676385Z Complete job name: deploy-production
+2025-12-07T21:23:39.4482845Z ##[group]Run actions/checkout@v4
+2025-12-07T21:23:39.4484096Z with:
+2025-12-07T21:23:39.4485075Z   ref: main
+2025-12-07T21:23:39.4485905Z   repository: T193R-W00D5/myFreecodecampLearning
+2025-12-07T21:23:39.4487241Z   token: ***
+2025-12-07T21:23:39.4487912Z   ssh-strict: true
+2025-12-07T21:23:39.4488619Z   ssh-user: git
+2025-12-07T21:23:39.4489347Z   persist-credentials: true
+2025-12-07T21:23:39.4490169Z   clean: true
+2025-12-07T21:23:39.4490896Z   sparse-checkout-cone-mode: true
+2025-12-07T21:23:39.4491829Z   fetch-depth: 1
+2025-12-07T21:23:39.4492532Z   fetch-tags: false
+2025-12-07T21:23:39.4493262Z   show-progress: true
+2025-12-07T21:23:39.4493994Z   lfs: false
+2025-12-07T21:23:39.4494842Z   submodules: false
+2025-12-07T21:23:39.4495584Z   set-safe-directory: true
+2025-12-07T21:23:39.4496689Z ##[endgroup]
+2025-12-07T21:23:39.5557372Z Syncing repository: T193R-W00D5/myFreecodecampLearning
+2025-12-07T21:23:39.5559963Z ##[group]Getting Git version info
+2025-12-07T21:23:39.5561628Z Working directory is '/home/runner/work/myFreecodecampLearning/myFreecodecampLearning'
+2025-12-07T21:23:39.5564002Z [command]/usr/bin/git version
+2025-12-07T21:23:39.5630181Z git version 2.52.0
+2025-12-07T21:23:39.5656559Z ##[endgroup]
+2025-12-07T21:23:39.5671731Z Temporarily overriding HOME='/home/runner/work/_temp/9be84461-144a-435f-b5e5-7619ba620546' before making global git config changes
+2025-12-07T21:23:39.5674610Z Adding repository directory to the temporary git global config as a safe directory
+2025-12-07T21:23:39.5683578Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/myFreecodecampLearning/myFreecodecampLearning
+2025-12-07T21:23:39.5721182Z Deleting the contents of '/home/runner/work/myFreecodecampLearning/myFreecodecampLearning'
+2025-12-07T21:23:39.5724038Z ##[group]Initializing the repository
+2025-12-07T21:23:39.5728466Z [command]/usr/bin/git init /home/runner/work/myFreecodecampLearning/myFreecodecampLearning
+2025-12-07T21:23:39.5820000Z hint: Using 'master' as the name for the initial branch. This default branch name
+2025-12-07T21:23:39.5821785Z hint: will change to "main" in Git 3.0. To configure the initial branch name
+2025-12-07T21:23:39.5823767Z hint: to use in all of your new repositories, which will suppress this warning,
+2025-12-07T21:23:39.5826149Z hint: call:
+2025-12-07T21:23:39.5826984Z hint:
+2025-12-07T21:23:39.5827849Z hint: 	git config --global init.defaultBranch <name>
+2025-12-07T21:23:39.5829095Z hint:
+2025-12-07T21:23:39.5830241Z hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
+2025-12-07T21:23:39.5831992Z hint: 'development'. The just-created branch can be renamed via this command:
+2025-12-07T21:23:39.5833555Z hint:
+2025-12-07T21:23:39.5834800Z hint: 	git branch -m <name>
+2025-12-07T21:23:39.5835640Z hint:
+2025-12-07T21:23:39.5836760Z hint: Disable this message with "git config set advice.defaultBranchName false"
+2025-12-07T21:23:39.5839094Z Initialized empty Git repository in /home/runner/work/myFreecodecampLearning/myFreecodecampLearning/.git/
+2025-12-07T21:23:39.5842563Z [command]/usr/bin/git remote add origin https://github.com/T193R-W00D5/myFreecodecampLearning
+2025-12-07T21:23:39.5869487Z ##[endgroup]
+2025-12-07T21:23:39.5870869Z ##[group]Disabling automatic garbage collection
+2025-12-07T21:23:39.5872504Z [command]/usr/bin/git config --local gc.auto 0
+2025-12-07T21:23:39.5902746Z ##[endgroup]
+2025-12-07T21:23:39.5905024Z ##[group]Setting up auth
+2025-12-07T21:23:39.5910191Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+2025-12-07T21:23:39.5942894Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+2025-12-07T21:23:39.6270553Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+2025-12-07T21:23:39.6302414Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+2025-12-07T21:23:39.6515415Z [command]/usr/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+2025-12-07T21:23:39.6546095Z [command]/usr/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+2025-12-07T21:23:39.6772275Z [command]/usr/bin/git config --local http.https://github.com/.extraheader AUTHORIZATION: basic ***
+2025-12-07T21:23:39.6804803Z ##[endgroup]
+2025-12-07T21:23:39.6806996Z ##[group]Fetching the repository
+2025-12-07T21:23:39.6816116Z [command]/usr/bin/git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +refs/heads/main*:refs/remotes/origin/main* +refs/tags/main*:refs/tags/main*
+2025-12-07T21:23:40.2275112Z From https://github.com/T193R-W00D5/myFreecodecampLearning
+2025-12-07T21:23:40.2275708Z  * [new branch]      main       -> origin/main
+2025-12-07T21:23:40.2308190Z ##[endgroup]
+2025-12-07T21:23:40.2315908Z ##[group]Determining the checkout info
+2025-12-07T21:23:40.2316589Z [command]/usr/bin/git branch --list --remote origin/main
+2025-12-07T21:23:40.2339097Z   origin/main
+2025-12-07T21:23:40.2344781Z ##[endgroup]
+2025-12-07T21:23:40.2349141Z [command]/usr/bin/git sparse-checkout disable
+2025-12-07T21:23:40.2388625Z [command]/usr/bin/git config --local --unset-all extensions.worktreeConfig
+2025-12-07T21:23:40.2415075Z ##[group]Checking out the ref
+2025-12-07T21:23:40.2419408Z [command]/usr/bin/git checkout --progress --force -B main refs/remotes/origin/main
+2025-12-07T21:23:40.2772805Z Switched to a new branch 'main'
+2025-12-07T21:23:40.2776223Z branch 'main' set up to track 'origin/main'.
+2025-12-07T21:23:40.2783452Z ##[endgroup]
+2025-12-07T21:23:40.2819708Z [command]/usr/bin/git log -1 --format=%H
+2025-12-07T21:23:40.2842088Z 9d93fc766a566e22c60ab7248e1c0d43405514ba
+2025-12-07T21:23:40.3009599Z ##[group]Run echo "📦 PRODUCTION DEPLOYMENT" >> $GITHUB_STEP_SUMMARY
+2025-12-07T21:23:40.3010157Z [36;1mecho "📦 PRODUCTION DEPLOYMENT" >> $GITHUB_STEP_SUMMARY[0m
+2025-12-07T21:23:40.3010667Z [36;1mecho "**Commit being deployed:** $(git rev-parse HEAD)" >> $GITHUB_STEP_SUMMARY[0m
+2025-12-07T21:23:40.3011228Z [36;1mecho "**Commit details:** $(git log --oneline -n 1)" >> $GITHUB_STEP_SUMMARY[0m
+2025-12-07T21:23:40.3046124Z shell: /usr/bin/bash -e {0}
+2025-12-07T21:23:40.3046454Z ##[endgroup]
+2025-12-07T21:23:40.3212737Z ##[group]Run ruby/setup-ruby@v1
+2025-12-07T21:23:40.3213016Z with:
+2025-12-07T21:23:40.3213198Z   ruby-version: 3.3
+2025-12-07T21:23:40.3213400Z   bundler-cache: false
+2025-12-07T21:23:40.3213610Z ##[endgroup]
+2025-12-07T21:23:40.4989911Z ##[group]Modifying PATH
+2025-12-07T21:23:40.4994916Z Entries added to PATH to use selected Ruby:
+2025-12-07T21:23:40.4998650Z   /opt/hostedtoolcache/Ruby/3.3.10/x64/bin
+2025-12-07T21:23:40.5005921Z ##[endgroup]
+2025-12-07T21:23:40.5007030Z ##[group]Print Ruby version
+2025-12-07T21:23:40.5152683Z [command]/opt/hostedtoolcache/Ruby/3.3.10/x64/bin/ruby --version
+2025-12-07T21:23:40.7071416Z ruby 3.3.10 (2025-10-23 revision 343ea05002) [x86_64-linux]
+2025-12-07T21:23:40.7108317Z Took   0.21 seconds
+2025-12-07T21:23:40.7109394Z ##[endgroup]
+2025-12-07T21:23:40.7111444Z ##[group]Installing Bundler
+2025-12-07T21:23:40.7116268Z Using Bundler 2.7.2 from Gemfile.lock BUNDLED WITH 2.7.2
+2025-12-07T21:23:40.7120864Z [command]/opt/hostedtoolcache/Ruby/3.3.10/x64/bin/gem install bundler -v 2.7.2
+2025-12-07T21:23:42.1017790Z Successfully installed bundler-2.7.2
+2025-12-07T21:23:42.1018588Z 1 gem installed
+2025-12-07T21:23:42.1069881Z Took   1.40 seconds
+2025-12-07T21:23:42.1072024Z ##[endgroup]
+2025-12-07T21:23:42.1148783Z ##[group]Run rm -rf _site
+2025-12-07T21:23:42.1149081Z [36;1mrm -rf _site[0m
+2025-12-07T21:23:42.1149292Z [36;1mrm -rf .sass-cache[0m
+2025-12-07T21:23:42.1149609Z [36;1mecho "Cleaned existing build artifacts" >> $GITHUB_STEP_SUMMARY[0m
+2025-12-07T21:23:42.1183554Z shell: /usr/bin/bash -e {0}
+2025-12-07T21:23:42.1183811Z ##[endgroup]
+2025-12-07T21:23:42.1341541Z ##[group]Run bundle config set --local frozen false
+2025-12-07T21:23:42.1341933Z [36;1mbundle config set --local frozen false[0m
+2025-12-07T21:23:42.1342212Z [36;1mbundle install[0m
+2025-12-07T21:23:42.1342414Z [36;1m[0m
+2025-12-07T21:23:42.1342600Z [36;1m# Debug Jekyll environment[0m
+2025-12-07T21:23:42.1342969Z [36;1mecho "Jekyll version: $(bundle exec jekyll --version)" >> $GITHUB_STEP_SUMMARY[0m
+2025-12-07T21:23:42.1343421Z [36;1mecho "Ruby version: $(ruby --version)" >> $GITHUB_STEP_SUMMARY[0m
+2025-12-07T21:23:42.1343869Z [36;1mecho "Bundler version: $(bundle --version)" >> $GITHUB_STEP_SUMMARY[0m
+2025-12-07T21:23:42.1344468Z [36;1mecho "Current directory: $(pwd)" >> $GITHUB_STEP_SUMMARY[0m
+2025-12-07T21:23:42.1344975Z [36;1mecho "Config file exists: $(test -f _config.yml && echo 'YES' || echo 'NO')" >> $GITHUB_STEP_SUMMARY[0m
+2025-12-07T21:23:42.1345374Z [36;1m[0m
+2025-12-07T21:23:42.1345550Z [36;1m# Show config before build[0m
+2025-12-07T21:23:42.1345899Z [36;1mecho "Jekyll config baseurl before build:" >> $GITHUB_STEP_SUMMARY[0m
+2025-12-07T21:23:42.1346411Z [36;1mgrep "baseurl:" _config.yml >> $GITHUB_STEP_SUMMARY || echo "No baseurl in config" >> $GITHUB_STEP_SUMMARY[0m
+2025-12-07T21:23:42.1346821Z [36;1m[0m
+2025-12-07T21:23:42.1347050Z [36;1m# Build with production baseurl and verbose output[0m
+2025-12-07T21:23:42.1347456Z [36;1mecho "Starting Jekyll build with verbose output..." >> $GITHUB_STEP_SUMMARY[0m
+2025-12-07T21:23:42.1348132Z [36;1mbundle exec jekyll build --baseurl "/myFreecodecampLearning" --verbose --trace[0m
+2025-12-07T21:23:42.1348504Z [36;1m[0m
+2025-12-07T21:23:42.1348845Z [36;1mecho "Jekyll production build completed. Contents of _site:" >> $GITHUB_STEP_SUMMARY[0m
+2025-12-07T21:23:42.1349289Z [36;1mls -la _site/ >> $GITHUB_STEP_SUMMARY[0m
+2025-12-07T21:23:42.1349535Z [36;1m[0m
+2025-12-07T21:23:42.1349775Z [36;1mecho "Full generated index.html:" >> $GITHUB_STEP_SUMMARY[0m
+2025-12-07T21:23:42.1350115Z [36;1mcat _site/index.html >> $GITHUB_STEP_SUMMARY[0m
+2025-12-07T21:23:42.1350374Z [36;1m[0m
+2025-12-07T21:23:42.1350653Z [36;1mecho "Checking for Liquid syntax in generated files:" >> $GITHUB_STEP_SUMMARY[0m
+2025-12-07T21:23:42.1351202Z [36;1mgrep -n "{{" _site/index.html || echo "✅ No unprocessed Liquid syntax found" >> $GITHUB_STEP_SUMMARY[0m
+2025-12-07T21:23:42.1351591Z [36;1m[0m
+2025-12-07T21:23:42.1351833Z [36;1mecho "Checking navigation links:" >> $GITHUB_STEP_SUMMARY[0m
+2025-12-07T21:23:42.1352359Z [36;1mgrep -n "href.*pages" _site/index.html >> $GITHUB_STEP_SUMMARY || echo "No page links found" >> $GITHUB_STEP_SUMMARY[0m
+2025-12-07T21:23:42.1380832Z shell: /usr/bin/bash -e {0}
+2025-12-07T21:23:42.1381073Z ##[endgroup]
+2025-12-07T21:23:44.9040762Z Fetching gem metadata from https://rubygems.org/..........
+2025-12-07T21:23:44.9088431Z Fetching rake 13.3.1
+2025-12-07T21:23:45.0283899Z Installing rake 13.3.1
+2025-12-07T21:23:45.1190817Z Fetching public_suffix 7.0.0
+2025-12-07T21:23:45.1193742Z Fetching base64 0.3.0
+2025-12-07T21:23:45.1194477Z Fetching bigdecimal 3.3.1
+2025-12-07T21:23:45.1195121Z Fetching colorator 1.1.0
+2025-12-07T21:23:45.1441867Z Installing public_suffix 7.0.0
+2025-12-07T21:23:45.1499181Z Fetching concurrent-ruby 1.3.5
+2025-12-07T21:23:45.1572470Z Installing base64 0.3.0
+2025-12-07T21:23:45.1598412Z Fetching csv 3.3.5
+2025-12-07T21:23:45.1758369Z Installing bigdecimal 3.3.1 with native extensions
+2025-12-07T21:23:45.1916377Z Installing colorator 1.1.0
+2025-12-07T21:23:45.1961543Z Fetching eventmachine 1.2.7
+2025-12-07T21:23:45.2349444Z Installing concurrent-ruby 1.3.5
+2025-12-07T21:23:45.2467775Z Installing csv 3.3.5
+2025-12-07T21:23:45.3089167Z Fetching http_parser.rb 0.8.0
+2025-12-07T21:23:45.3121891Z Installing eventmachine 1.2.7 with native extensions
+2025-12-07T21:23:45.3490043Z Installing http_parser.rb 0.8.0 with native extensions
+2025-12-07T21:23:45.3747823Z Fetching ffi 1.17.2 (x86_64-linux-gnu)
+2025-12-07T21:23:45.4486657Z Installing ffi 1.17.2 (x86_64-linux-gnu)
+2025-12-07T21:23:45.5171602Z Fetching forwardable-extended 2.6.0
+2025-12-07T21:23:45.5384496Z Installing forwardable-extended 2.6.0
+2025-12-07T21:23:45.5422591Z Fetching rb-fsevent 0.11.2
+2025-12-07T21:23:45.5621569Z Installing rb-fsevent 0.11.2
+2025-12-07T21:23:45.5721160Z Fetching json 2.17.1
+2025-12-07T21:23:45.5913654Z Installing json 2.17.1 with native extensions
+2025-12-07T21:23:47.8946989Z Fetching liquid 4.0.4
+2025-12-07T21:23:47.9474043Z Installing liquid 4.0.4
+2025-12-07T21:23:47.9975082Z Fetching mercenary 0.4.0
+2025-12-07T21:23:48.0266937Z Installing mercenary 0.4.0
+2025-12-07T21:23:48.0521838Z Fetching rouge 4.6.1
+2025-12-07T21:23:48.1319115Z Installing rouge 4.6.1
+2025-12-07T21:23:48.2862889Z Fetching safe_yaml 1.0.5
+2025-12-07T21:23:48.3055180Z Installing safe_yaml 1.0.5
+2025-12-07T21:23:48.3185568Z Fetching unicode-display_width 2.6.0
+2025-12-07T21:23:48.3314133Z Installing unicode-display_width 2.6.0
+2025-12-07T21:23:48.3362486Z Fetching webrick 1.9.2
+2025-12-07T21:23:48.3540419Z Installing webrick 1.9.2
+2025-12-07T21:23:48.3772656Z Fetching addressable 2.8.8
+2025-12-07T21:23:48.3947321Z Installing addressable 2.8.8
+2025-12-07T21:23:48.4085104Z Fetching i18n 1.14.7
+2025-12-07T21:23:48.4236859Z Installing i18n 1.14.7
+2025-12-07T21:23:48.4393190Z Fetching rb-inotify 0.11.1
+2025-12-07T21:23:48.4535104Z Installing rb-inotify 0.11.1
+2025-12-07T21:23:48.4593613Z Fetching pathutil 0.16.2
+2025-12-07T21:23:48.4795159Z Installing pathutil 0.16.2
+2025-12-07T21:23:48.4811801Z Fetching kramdown 2.5.1
+2025-12-07T21:23:48.5054504Z Installing kramdown 2.5.1
+2025-12-07T21:23:48.6495689Z Fetching terminal-table 3.0.2
+2025-12-07T21:23:48.6653828Z Installing terminal-table 3.0.2
+2025-12-07T21:23:48.6752325Z Fetching listen 3.9.0
+2025-12-07T21:23:48.6893668Z Installing listen 3.9.0
+2025-12-07T21:23:48.7025005Z Fetching kramdown-parser-gfm 1.1.0
+2025-12-07T21:23:48.7172778Z Installing kramdown-parser-gfm 1.1.0
+2025-12-07T21:23:48.7289106Z Fetching jekyll-watch 2.2.1
+2025-12-07T21:23:48.7449595Z Installing jekyll-watch 2.2.1
+2025-12-07T21:23:55.8017035Z Fetching google-protobuf 4.33.1 (x86_64-linux-gnu)
+2025-12-07T21:23:55.9281647Z Installing google-protobuf 4.33.1 (x86_64-linux-gnu)
+2025-12-07T21:23:55.9834853Z Fetching sass-embedded 1.94.2 (x86_64-linux-gnu)
+2025-12-07T21:23:56.1180234Z Installing sass-embedded 1.94.2 (x86_64-linux-gnu)
+2025-12-07T21:23:56.2248573Z Fetching jekyll-sass-converter 3.1.0
+2025-12-07T21:23:56.2412635Z Installing jekyll-sass-converter 3.1.0
+2025-12-07T21:24:02.6295578Z Fetching em-websocket 0.5.3
+2025-12-07T21:24:02.6865165Z Installing em-websocket 0.5.3
+2025-12-07T21:24:02.6969311Z Fetching jekyll 4.4.1
+2025-12-07T21:24:02.7398103Z Installing jekyll 4.4.1
+2025-12-07T21:24:02.7656494Z Fetching jekyll-feed 0.17.0
+2025-12-07T21:24:02.7659830Z Fetching jekyll-seo-tag 2.8.0
+2025-12-07T21:24:02.7660270Z Fetching jekyll-sitemap 1.4.0
+2025-12-07T21:24:02.7894668Z Installing jekyll-feed 0.17.0
+2025-12-07T21:24:02.8111427Z Installing jekyll-seo-tag 2.8.0
+2025-12-07T21:24:02.8638367Z Installing jekyll-sitemap 1.4.0
+2025-12-07T21:24:02.8889928Z Bundle complete! 9 Gemfile dependencies, 38 gems now installed.
+2025-12-07T21:24:02.8890409Z Use `bundle info [gemname]` to see where a bundled gem is installed.
+2025-12-07T21:24:04.1986993Z   Logging at level: debug
+2025-12-07T21:24:04.1987282Z     Jekyll Version: 4.4.1
+2025-12-07T21:24:04.1994994Z Configuration file: /home/runner/work/myFreecodecampLearning/myFreecodecampLearning/_config.yml
+2025-12-07T21:24:04.2085095Z          Requiring: jekyll-feed
+2025-12-07T21:24:04.2085634Z          Requiring: jekyll-sitemap
+2025-12-07T21:24:04.2086178Z          Requiring: jekyll-seo-tag
+2025-12-07T21:24:04.2087226Z             Source: /home/runner/work/myFreecodecampLearning/myFreecodecampLearning
+2025-12-07T21:24:04.2088467Z        Destination: /home/runner/work/myFreecodecampLearning/myFreecodecampLearning/_site
+2025-12-07T21:24:04.2089523Z  Incremental build: disabled. Enable with --incremental
+2025-12-07T21:24:04.2090167Z       Generating... 
+2025-12-07T21:24:04.2100302Z            Reading: /_layouts/default.html
+2025-12-07T21:24:04.2117284Z        EntryFilter: excluded /jest.config.js
+2025-12-07T21:24:04.2117910Z        EntryFilter: excluded /.jekyll-cache
+2025-12-07T21:24:04.2118485Z        EntryFilter: excluded /playwright.config.ts
+2025-12-07T21:24:04.2119073Z        EntryFilter: excluded /Gemfile
+2025-12-07T21:24:04.2119610Z        EntryFilter: excluded /package-lock.json
+2025-12-07T21:24:04.2120177Z        EntryFilter: excluded /Gemfile.lock
+2025-12-07T21:24:04.2122971Z        EntryFilter: excluded /package.json
+2025-12-07T21:24:04.2126382Z        EntryFilter: excluded /__tests__
+2025-12-07T21:24:04.2156012Z            Reading: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100201-Lecture-Welcome-Message-from-Quincy-Larson.html
+2025-12-07T21:24:04.2165484Z            Reading: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Home-Basic-HTML.html
+2025-12-07T21:24:04.2167338Z            Reading: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100901-Lecture-HTML-Fundamentals.html
+2025-12-07T21:24:04.2169222Z            Reading: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100601-Lecture-Understanding-the-HTML-Boilerplate.html
+2025-12-07T21:24:04.2171210Z            Reading: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100101-Workshop-Build-a-Curriculum-Outline.html
+2025-12-07T21:24:04.2173142Z            Reading: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100401-Lecture-Understanding-HTML-Attributes.html
+2025-12-07T21:24:04.2183963Z            Reading: pages/s100101-Certified-Full-Stack-Developer-Curriculum/Home-Certified-Full-Stack-Developer-Curriculum.html
+2025-12-07T21:24:04.2185378Z            Reading: pages/interactive-features.html
+2025-12-07T21:24:04.2244004Z            Reading: index.html
+2025-12-07T21:24:04.2256097Z        Jekyll Feed: Generating feed for posts
+2025-12-07T21:24:04.2267350Z         Generating: JekyllFeed::Generator finished in 0.000520616 seconds.
+2025-12-07T21:24:04.2284527Z         Generating: Jekyll::JekyllSitemap finished in 0.002286075 seconds.
+2025-12-07T21:24:04.2285885Z          Rendering: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100101-Workshop-Build-a-Curriculum-Outline.html
+2025-12-07T21:24:04.2287872Z   Pre-Render Hooks: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100101-Workshop-Build-a-Curriculum-Outline.html
+2025-12-07T21:24:04.2289861Z   Rendering Liquid: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100101-Workshop-Build-a-Curriculum-Outline.html
+2025-12-07T21:24:04.2739469Z   Rendering Markup: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100101-Workshop-Build-a-Curriculum-Outline.html
+2025-12-07T21:24:04.2741465Z Post-Convert Hooks: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100101-Workshop-Build-a-Curriculum-Outline.html
+2025-12-07T21:24:04.2745365Z   Rendering Layout: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100101-Workshop-Build-a-Curriculum-Outline.html
+2025-12-07T21:24:04.2763577Z          Rendering: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100201-Lecture-Welcome-Message-from-Quincy-Larson.html
+2025-12-07T21:24:04.2765994Z   Pre-Render Hooks: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100201-Lecture-Welcome-Message-from-Quincy-Larson.html
+2025-12-07T21:24:04.2768181Z   Rendering Markup: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100201-Lecture-Welcome-Message-from-Quincy-Larson.html
+2025-12-07T21:24:04.2770700Z Post-Convert Hooks: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100201-Lecture-Welcome-Message-from-Quincy-Larson.html
+2025-12-07T21:24:04.2772908Z   Rendering Layout: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100201-Lecture-Welcome-Message-from-Quincy-Larson.html
+2025-12-07T21:24:04.2775203Z          Rendering: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100401-Lecture-Understanding-HTML-Attributes.html
+2025-12-07T21:24:04.2777226Z   Pre-Render Hooks: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100401-Lecture-Understanding-HTML-Attributes.html
+2025-12-07T21:24:04.2779310Z   Rendering Markup: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100401-Lecture-Understanding-HTML-Attributes.html
+2025-12-07T21:24:04.2781385Z Post-Convert Hooks: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100401-Lecture-Understanding-HTML-Attributes.html
+2025-12-07T21:24:04.2783462Z   Rendering Layout: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100401-Lecture-Understanding-HTML-Attributes.html
+2025-12-07T21:24:04.2785786Z          Rendering: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100601-Lecture-Understanding-the-HTML-Boilerplate.html
+2025-12-07T21:24:04.2787889Z   Pre-Render Hooks: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100601-Lecture-Understanding-the-HTML-Boilerplate.html
+2025-12-07T21:24:04.2790341Z   Rendering Markup: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100601-Lecture-Understanding-the-HTML-Boilerplate.html
+2025-12-07T21:24:04.2792531Z Post-Convert Hooks: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100601-Lecture-Understanding-the-HTML-Boilerplate.html
+2025-12-07T21:24:04.2794901Z   Rendering Layout: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100601-Lecture-Understanding-the-HTML-Boilerplate.html
+2025-12-07T21:24:04.2796937Z          Rendering: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100901-Lecture-HTML-Fundamentals.html
+2025-12-07T21:24:04.2798791Z   Pre-Render Hooks: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100901-Lecture-HTML-Fundamentals.html
+2025-12-07T21:24:04.2800678Z   Rendering Markup: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100901-Lecture-HTML-Fundamentals.html
+2025-12-07T21:24:04.2802579Z Post-Convert Hooks: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100901-Lecture-HTML-Fundamentals.html
+2025-12-07T21:24:04.2804624Z   Rendering Layout: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100901-Lecture-HTML-Fundamentals.html
+2025-12-07T21:24:04.2806252Z          Rendering: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Home-Basic-HTML.html
+2025-12-07T21:24:04.2807671Z   Pre-Render Hooks: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Home-Basic-HTML.html
+2025-12-07T21:24:04.2809095Z   Rendering Liquid: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Home-Basic-HTML.html
+2025-12-07T21:24:04.2810561Z   Rendering Markup: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Home-Basic-HTML.html
+2025-12-07T21:24:04.2812010Z Post-Convert Hooks: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Home-Basic-HTML.html
+2025-12-07T21:24:04.2813403Z   Rendering Layout: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Home-Basic-HTML.html
+2025-12-07T21:24:04.2815128Z          Rendering: pages/s100101-Certified-Full-Stack-Developer-Curriculum/Home-Certified-Full-Stack-Developer-Curriculum.html
+2025-12-07T21:24:04.2817025Z   Pre-Render Hooks: pages/s100101-Certified-Full-Stack-Developer-Curriculum/Home-Certified-Full-Stack-Developer-Curriculum.html
+2025-12-07T21:24:04.2818895Z   Rendering Liquid: pages/s100101-Certified-Full-Stack-Developer-Curriculum/Home-Certified-Full-Stack-Developer-Curriculum.html
+2025-12-07T21:24:04.2820643Z   Rendering Markup: pages/s100101-Certified-Full-Stack-Developer-Curriculum/Home-Certified-Full-Stack-Developer-Curriculum.html
+2025-12-07T21:24:04.2822367Z Post-Convert Hooks: pages/s100101-Certified-Full-Stack-Developer-Curriculum/Home-Certified-Full-Stack-Developer-Curriculum.html
+2025-12-07T21:24:04.2824089Z   Rendering Layout: pages/s100101-Certified-Full-Stack-Developer-Curriculum/Home-Certified-Full-Stack-Developer-Curriculum.html
+2025-12-07T21:24:04.2825410Z          Rendering: index.html
+2025-12-07T21:24:04.2825801Z   Pre-Render Hooks: index.html
+2025-12-07T21:24:04.2826194Z   Rendering Liquid: index.html
+2025-12-07T21:24:04.2826582Z   Rendering Markup: index.html
+2025-12-07T21:24:04.2826981Z Post-Convert Hooks: index.html
+2025-12-07T21:24:04.2827374Z   Rendering Layout: index.html
+2025-12-07T21:24:04.2827811Z          Rendering: pages/interactive-features.html
+2025-12-07T21:24:04.2828380Z   Pre-Render Hooks: pages/interactive-features.html
+2025-12-07T21:24:04.2828953Z   Rendering Liquid: pages/interactive-features.html
+2025-12-07T21:24:04.2829535Z   Rendering Markup: pages/interactive-features.html
+2025-12-07T21:24:04.2830110Z Post-Convert Hooks: pages/interactive-features.html
+2025-12-07T21:24:04.2830704Z   Rendering Layout: pages/interactive-features.html
+2025-12-07T21:24:04.2831503Z          Rendering: feed.xml
+2025-12-07T21:24:04.2831886Z   Pre-Render Hooks: feed.xml
+2025-12-07T21:24:04.2832263Z   Rendering Liquid: feed.xml
+2025-12-07T21:24:04.2953065Z   Rendering Markup: feed.xml
+2025-12-07T21:24:04.2953523Z Post-Convert Hooks: feed.xml
+2025-12-07T21:24:04.2953930Z   Rendering Layout: feed.xml
+2025-12-07T21:24:04.2954572Z          Rendering: sitemap.xml
+2025-12-07T21:24:04.2955011Z   Pre-Render Hooks: sitemap.xml
+2025-12-07T21:24:04.2955426Z   Rendering Liquid: sitemap.xml
+2025-12-07T21:24:04.3007226Z   Rendering Markup: sitemap.xml
+2025-12-07T21:24:04.3007689Z Post-Convert Hooks: sitemap.xml
+2025-12-07T21:24:04.3008118Z   Rendering Layout: sitemap.xml
+2025-12-07T21:24:04.3008523Z          Rendering: robots.txt
+2025-12-07T21:24:04.3008947Z   Pre-Render Hooks: robots.txt
+2025-12-07T21:24:04.3009357Z   Rendering Liquid: robots.txt
+2025-12-07T21:24:04.3011792Z   Rendering Markup: robots.txt
+2025-12-07T21:24:04.3012224Z Post-Convert Hooks: robots.txt
+2025-12-07T21:24:04.3012650Z   Rendering Layout: robots.txt
+2025-12-07T21:24:04.3036054Z            Writing: /home/runner/work/myFreecodecampLearning/myFreecodecampLearning/_site/pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100101-Workshop-Build-a-Curriculum-Outline.html
+2025-12-07T21:24:04.3039147Z            Writing: /home/runner/work/myFreecodecampLearning/myFreecodecampLearning/_site/pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100201-Lecture-Welcome-Message-from-Quincy-Larson.html
+2025-12-07T21:24:04.3042266Z            Writing: /home/runner/work/myFreecodecampLearning/myFreecodecampLearning/_site/pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100401-Lecture-Understanding-HTML-Attributes.html
+2025-12-07T21:24:04.3045515Z            Writing: /home/runner/work/myFreecodecampLearning/myFreecodecampLearning/_site/pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100601-Lecture-Understanding-the-HTML-Boilerplate.html
+2025-12-07T21:24:04.3048499Z            Writing: /home/runner/work/myFreecodecampLearning/myFreecodecampLearning/_site/pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100901-Lecture-HTML-Fundamentals.html
+2025-12-07T21:24:04.3051215Z            Writing: /home/runner/work/myFreecodecampLearning/myFreecodecampLearning/_site/pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Home-Basic-HTML.html
+2025-12-07T21:24:04.3053651Z            Writing: /home/runner/work/myFreecodecampLearning/myFreecodecampLearning/_site/pages/s100101-Certified-Full-Stack-Developer-Curriculum/Home-Certified-Full-Stack-Developer-Curriculum.html
+2025-12-07T21:24:04.3055644Z            Writing: /home/runner/work/myFreecodecampLearning/myFreecodecampLearning/_site/index.html
+2025-12-07T21:24:04.3056908Z            Writing: /home/runner/work/myFreecodecampLearning/myFreecodecampLearning/_site/pages/interactive-features.html
+2025-12-07T21:24:04.3058160Z            Writing: /home/runner/work/myFreecodecampLearning/myFreecodecampLearning/_site/feed.xml
+2025-12-07T21:24:04.3059239Z            Writing: /home/runner/work/myFreecodecampLearning/myFreecodecampLearning/_site/sitemap.xml
+2025-12-07T21:24:04.3060334Z            Writing: /home/runner/work/myFreecodecampLearning/myFreecodecampLearning/_site/robots.txt
+2025-12-07T21:24:04.3168350Z                     done in 0.108 seconds.
+2025-12-07T21:24:04.3168684Z  Auto-regeneration: disabled. Use --watch to enable.
+2025-12-07T21:24:04.3342264Z ##[group]Run touch _site/.nojekyll
+2025-12-07T21:24:04.3342556Z [36;1mtouch _site/.nojekyll[0m
+2025-12-07T21:24:04.3342966Z [36;1mecho "✅ Added .nojekyll file to prevent GitHub Pages Jekyll processing" >> $GITHUB_STEP_SUMMARY[0m
+2025-12-07T21:24:04.3374792Z shell: /usr/bin/bash -e {0}
+2025-12-07T21:24:04.3375020Z ##[endgroup]
+2025-12-07T21:24:04.3460137Z ##[group]Run echo "📋 DEPLOYMENT VERIFICATION" >> $GITHUB_STEP_SUMMARY
+2025-12-07T21:24:04.3460736Z [36;1mecho "📋 DEPLOYMENT VERIFICATION" >> $GITHUB_STEP_SUMMARY[0m
+2025-12-07T21:24:04.3461105Z [36;1mecho "Files to be deployed:" >> $GITHUB_STEP_SUMMARY[0m
+2025-12-07T21:24:04.3461491Z [36;1mfind _site -type f -name "*.html" | head -10 >> $GITHUB_STEP_SUMMARY[0m
+2025-12-07T21:24:04.3461823Z [36;1mecho "" >> $GITHUB_STEP_SUMMARY[0m
+2025-12-07T21:24:04.3462180Z [36;1mecho "Final check of index.html navigation links:" >> $GITHUB_STEP_SUMMARY[0m
+2025-12-07T21:24:04.3462805Z [36;1mgrep -n "href.*Certified.*Full.*Stack" _site/index.html >> $GITHUB_STEP_SUMMARY || echo "No navigation links found" >> $GITHUB_STEP_SUMMARY[0m
+2025-12-07T21:24:04.3492769Z shell: /usr/bin/bash -e {0}
+2025-12-07T21:24:04.3493004Z ##[endgroup]
+2025-12-07T21:24:04.3642905Z ##[group]Run peaceiris/actions-gh-pages@v4
+2025-12-07T21:24:04.3643196Z with:
+2025-12-07T21:24:04.3643619Z   github_token: ***
+2025-12-07T21:24:04.3643823Z   publish_dir: ./_site
+2025-12-07T21:24:04.3644027Z   enable_jekyll: false
+2025-12-07T21:24:04.3644224Z   force_orphan: true
+2025-12-07T21:24:04.3644674Z   disable_nojekyll: false
+2025-12-07T21:24:04.3644882Z   publish_branch: gh-pages
+2025-12-07T21:24:04.3645092Z   allow_empty_commit: false
+2025-12-07T21:24:04.3645284Z   keep_files: false
+2025-12-07T21:24:04.3645465Z   exclude_assets: .github
+2025-12-07T21:24:04.3645649Z ##[endgroup]
+2025-12-07T21:24:04.4249820Z [INFO] Usage https://github.com/peaceiris/actions-gh-pages#readme
+2025-12-07T21:24:04.4254470Z ##[group]Dump inputs
+2025-12-07T21:24:04.4254833Z [INFO] GithubToken: true
+2025-12-07T21:24:04.4255195Z [INFO] PublishBranch: gh-pages
+2025-12-07T21:24:04.4255563Z [INFO] PublishDir: ./_site
+2025-12-07T21:24:04.4255900Z [INFO] DestinationDir: 
+2025-12-07T21:24:04.4256311Z [INFO] ExternalRepository: 
+2025-12-07T21:24:04.4256548Z [INFO] AllowEmptyCommit: false
+2025-12-07T21:24:04.4256779Z [INFO] KeepFiles: false
+2025-12-07T21:24:04.4256973Z [INFO] ForceOrphan: true
+2025-12-07T21:24:04.4257176Z [INFO] UserName: 
+2025-12-07T21:24:04.4257472Z [INFO] UserEmail: 
+2025-12-07T21:24:04.4257769Z [INFO] CommitMessage: 
+2025-12-07T21:24:04.4258092Z [INFO] FullCommitMessage: 
+2025-12-07T21:24:04.4258413Z [INFO] TagName: 
+2025-12-07T21:24:04.4258672Z [INFO] TagMessage: 
+2025-12-07T21:24:04.4258909Z [INFO] EnableJekyll (DisableNoJekyll): false
+2025-12-07T21:24:04.4259319Z [INFO] CNAME: 
+2025-12-07T21:24:04.4259601Z [INFO] ExcludeAssets .github
+2025-12-07T21:24:04.4259837Z 
+2025-12-07T21:24:04.4260199Z ##[endgroup]
+2025-12-07T21:24:04.4260631Z ##[group]Setup auth token
+2025-12-07T21:24:04.4260969Z [INFO] setup GITHUB_TOKEN
+2025-12-07T21:24:04.4262000Z ##[endgroup]
+2025-12-07T21:24:04.4262308Z ##[group]Prepare publishing assets
+2025-12-07T21:24:04.4263773Z [INFO] ForceOrphan: true
+2025-12-07T21:24:04.4283195Z [INFO] chdir /home/runner/actions_github_pages_1765142644425
+2025-12-07T21:24:04.4311142Z [command]/usr/bin/git init
+2025-12-07T21:24:04.4361205Z hint: Using 'master' as the name for the initial branch. This default branch name
+2025-12-07T21:24:04.4361985Z hint: will change to "main" in Git 3.0. To configure the initial branch name
+2025-12-07T21:24:04.4362439Z hint: to use in all of your new repositories, which will suppress this warning,
+2025-12-07T21:24:04.4362769Z hint: call:
+2025-12-07T21:24:04.4362921Z hint:
+2025-12-07T21:24:04.4363134Z hint: 	git config --global init.defaultBranch <name>
+2025-12-07T21:24:04.4363385Z hint:
+2025-12-07T21:24:04.4363639Z hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
+2025-12-07T21:24:04.4364067Z hint: 'development'. The just-created branch can be renamed via this command:
+2025-12-07T21:24:04.4364605Z hint:
+2025-12-07T21:24:04.4364775Z hint: 	git branch -m <name>
+2025-12-07T21:24:04.4364967Z hint:
+2025-12-07T21:24:04.4365253Z hint: Disable this message with "git config set advice.defaultBranchName false"
+2025-12-07T21:24:04.4374830Z Initialized empty Git repository in /home/runner/actions_github_pages_1765142644425/.git/
+2025-12-07T21:24:04.4396240Z [command]/usr/bin/git checkout --orphan gh-pages
+2025-12-07T21:24:04.4417924Z Switched to a new branch 'gh-pages'
+2025-12-07T21:24:04.4423148Z [INFO] prepare publishing assets
+2025-12-07T21:24:04.4424194Z [INFO] copy /home/runner/work/myFreecodecampLearning/myFreecodecampLearning/_site to /home/runner/actions_github_pages_1765142644425
+2025-12-07T21:24:04.4700708Z [INFO] delete excluded assets
+2025-12-07T21:24:04.4731519Z rm: no paths given
+2025-12-07T21:24:04.4735597Z ##[endgroup]
+2025-12-07T21:24:04.4736145Z ##[group]Setup Git config
+2025-12-07T21:24:04.4750074Z [command]/usr/bin/git remote rm origin
+2025-12-07T21:24:04.4773313Z error: No such remote: 'origin'
+2025-12-07T21:24:04.4779554Z [INFO] The process '/usr/bin/git' failed with exit code 2
+2025-12-07T21:24:04.4793486Z [command]/usr/bin/git remote add origin ***github.com/T193R-W00D5/myFreecodecampLearning.git
+2025-12-07T21:24:04.4834527Z [command]/usr/bin/git add --all
+2025-12-07T21:24:04.6531389Z [command]/usr/bin/git config user.name T193R-W00D5
+2025-12-07T21:24:04.6577124Z [command]/usr/bin/git config user.email T193R-W00D5@users.noreply.github.com
+2025-12-07T21:24:04.6604903Z ##[endgroup]
+2025-12-07T21:24:04.6605281Z ##[group]Create a commit
+2025-12-07T21:24:04.6616384Z [command]/usr/bin/git commit -m deploy: 9d93fc766a566e22c60ab7248e1c0d43405514ba
+2025-12-07T21:24:04.6920643Z [gh-pages (root-commit) e8ba0c8] deploy: 9d93fc766a566e22c60ab7248e1c0d43405514ba
+2025-12-07T21:24:04.6921311Z  90 files changed, 32858 insertions(+)
+2025-12-07T21:24:04.6921729Z  create mode 100644 .nojekyll
+2025-12-07T21:24:04.6922010Z  create mode 100644 LICENSE
+2025-12-07T21:24:04.6922334Z  create mode 100644 ReadMe.md
+2025-12-07T21:24:04.6922715Z  create mode 100644 assets/audio/Duck.mp3
+2025-12-07T21:24:04.6923196Z  create mode 100644 assets/favicon/Wizard.ico
+2025-12-07T21:24:04.6923702Z  create mode 100644 assets/favicon/orange_inc_logo 00.jpg
+2025-12-07T21:24:04.6924480Z  create mode 100644 assets/favicon/orange_inc_logo 00.xcf
+2025-12-07T21:24:04.6925136Z  create mode 100644 assets/favicon/orange_inc_logo.ico
+2025-12-07T21:24:04.6925660Z  create mode 100644 assets/images/bg-techy-003.svg
+2025-12-07T21:24:04.6926064Z  create mode 100644 assets/images/eggs-whisk-flour-milk.jpg
+2025-12-07T21:24:04.6926445Z  create mode 100644 assets/images/kids-making-a-mud-pie - Copy.jpg
+2025-12-07T21:24:04.6927106Z  create mode 100644 assets/images/kids-making-a-mud-pie-400x267.avif
+2025-12-07T21:24:04.6927796Z  create mode 100644 assets/images/kids-making-a-mud-pie-400x267.jpg
+2025-12-07T21:24:04.6928412Z  create mode 100644 assets/images/kids-making-a-mud-pie-400x267.webp
+2025-12-07T21:24:04.6928920Z  create mode 100644 assets/images/kids-making-a-mud-pie.jpg
+2025-12-07T21:24:04.6929264Z  create mode 100644 assets/images/kids-making-a-mud-pie.xcf
+2025-12-07T21:24:04.6929717Z  create mode 100644 assets/images/triangle-icon.svg
+2025-12-07T21:24:04.6930042Z  create mode 100644 auto-staging-modern_yml_DELETE_ME.txt
+2025-12-07T21:24:04.6930334Z  create mode 100644 bin/jekyll
+2025-12-07T21:24:04.6930551Z  create mode 100644 bin/jekyll.cmd
+2025-12-07T21:24:04.6930794Z  create mode 100644 css/prism.css
+2025-12-07T21:24:04.6931032Z  create mode 100644 css/styles-center.css
+2025-12-07T21:24:04.6931305Z  create mode 100644 css/styles-freecodecamp.css
+2025-12-07T21:24:04.6931614Z  create mode 100644 css/styles-iframe-html-examples.css
+2025-12-07T21:24:04.6932012Z  create mode 100644 css/styles-left.css
+2025-12-07T21:24:04.6932259Z  create mode 100644 css/styles.css
+2025-12-07T21:24:04.6932741Z  create mode 100644 docs/Ai_chats/20251023a Volta setup and add project to new Github repo CoPilot .md
+2025-12-07T21:24:04.6933268Z  create mode 100644 docs/Ai_chats/20251025a Add Playwright tests and Git help.md
+2025-12-07T21:24:04.6933742Z  create mode 100644 docs/Ai_chats/20251026 Playwright Installation Success Summary.md
+2025-12-07T21:24:04.6934498Z  create mode 100644 docs/Ai_chats/20251105a Refactor project to use TypeScript.md
+2025-12-07T21:24:04.6935007Z  create mode 100644 docs/Ai_chats/20251108a CD and scheduled E2E tests.md
+2025-12-07T21:24:04.6935960Z  create mode 100644 docs/Ai_chats/20251113a playwright shared constants and test utilities functions .md
+2025-12-07T21:24:04.6936599Z  create mode 100644 docs/Ai_chats/20251115a express server, fixes Lighthouse performance, discuss React.md
+2025-12-07T21:24:04.6937357Z  create mode 100644 docs/Ai_chats/20251119a GitHub CoPilot - fix parallel worker tests using same port.md
+2025-12-07T21:24:04.6938055Z  create mode 100644 docs/Ai_chats/20251119a workflow defensive free port 3010 Github copilot.md
+2025-12-07T21:24:04.6938481Z  create mode 100644 docs/Ai_chats/VS Code help.md
+2025-12-07T21:24:04.6938756Z  create mode 100644 docs/Ai_chats/daemon.md
+2025-12-07T21:24:04.6939057Z  create mode 100644 docs/Ai_chats/toolchain Gai 20251024a .md
+2025-12-07T21:24:04.6939580Z  create mode 100644 docs/DEBUG_CONSOLE_GUIDE.md
+2025-12-07T21:24:04.6939896Z  create mode 100644 docs/DEPLOYMENT_GUIDE.md
+2025-12-07T21:24:04.6940285Z  create mode 100644 docs/PLAYWRIGHT_GUIDE.md
+2025-12-07T21:24:04.6940684Z  create mode 100644 docs/PROFESSIONAL_DEPLOYMENT_GUIDE.md
+2025-12-07T21:24:04.6940992Z  create mode 100644 docs/PR_changes.md
+2025-12-07T21:24:04.6941252Z  create mode 100644 docs/TESTING_BEST_PRACTICES.md
+2025-12-07T21:24:04.6941540Z  create mode 100644 docs/TWO_TRACK_STAGING_GUIDE.md
+2025-12-07T21:24:04.6941812Z  create mode 100644 docs/TYPESCRIPT_GUIDE.md
+2025-12-07T21:24:04.6942099Z  create mode 100644 docs/TYPESCRIPT_MIGRATION_COMMIT.md
+2025-12-07T21:24:04.6942372Z  create mode 100644 docs/ci.md
+2025-12-07T21:24:04.6942685Z  create mode 100644 docs/debug_dox/Deploy to Production 1 20251207_0349UTC.txt
+2025-12-07T21:24:04.6943112Z  create mode 100644 docs/debug_dox/Deploy to Production 2 20251207_2052UTC.txt
+2025-12-07T21:24:04.6943608Z  create mode 100644 docs/debug_dox/GitHub deploy.yml deploy no. 15 to production 20251207_1040.txt
+2025-12-07T21:24:04.6944066Z  create mode 100644 docs/git-workflow-branching-strategy.md
+2025-12-07T21:24:04.6944581Z  create mode 100644 feed.xml
+2025-12-07T21:24:04.6944871Z  create mode 100644 freecodecampOrg.code-workspace
+2025-12-07T21:24:04.6945139Z  create mode 100644 index.html
+2025-12-07T21:24:04.6945358Z  create mode 100644 pages/about.html
+2025-12-07T21:24:04.6945584Z  create mode 100644 pages/audio.html
+2025-12-07T21:24:04.6945821Z  create mode 100644 pages/cafe-menu.html
+2025-12-07T21:24:04.6946099Z  create mode 100644 pages/interactive-features.html
+2025-12-07T21:24:04.6946377Z  create mode 100644 pages/recipes.html
+2025-12-07T21:24:04.6946936Z  create mode 100644 pages/s100101-Certified-Full-Stack-Developer-Curriculum/Home-Certified-Full-Stack-Developer-Curriculum.html
+2025-12-07T21:24:04.6947858Z  create mode 100644 pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100101-10101-example-page-h1-h2-p.html
+2025-12-07T21:24:04.6948827Z  create mode 100644 pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100101-10201-example-page-final-page.html
+2025-12-07T21:24:04.6949829Z  create mode 100644 pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100101-Workshop-Build-a-Curriculum-Outline.html
+2025-12-07T21:24:04.6950895Z  create mode 100644 pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100201-Lecture-Welcome-Message-from-Quincy-Larson.html
+2025-12-07T21:24:04.6951957Z  create mode 100644 pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100401-Lecture-Understanding-HTML-Attributes.html
+2025-12-07T21:24:04.6953016Z  create mode 100644 pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100601-Lecture-Understanding-the-HTML-Boilerplate.html
+2025-12-07T21:24:04.6954031Z  create mode 100644 pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100901-Lecture-HTML-Fundamentals.html
+2025-12-07T21:24:04.6955153Z  create mode 100644 pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p700101-Review-Basic-HTML-Review.html
+2025-12-07T21:24:04.6956137Z  create mode 100644 pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Home-Basic-HTML.html
+2025-12-07T21:24:04.6956651Z  create mode 100644 pages/svg-heart-icon.html
+2025-12-07T21:24:04.6956910Z  create mode 100644 pages/videos.html
+2025-12-07T21:24:04.6973810Z  create mode 100644 robots.txt
+2025-12-07T21:24:04.6974180Z  create mode 100644 sitemap.xml
+2025-12-07T21:24:04.6974762Z  create mode 100644 src/components/Snackbar.js
+2025-12-07T21:24:04.6975050Z  create mode 100644 src/script.js
+2025-12-07T21:24:04.6975322Z  create mode 100644 src/scripts/consoleLogHandler.js
+2025-12-07T21:24:04.6975623Z  create mode 100644 src/scripts/css-loader.js
+2025-12-07T21:24:04.6976084Z  create mode 100644 src/scripts/debug-console.js
+2025-12-07T21:24:04.6976373Z  create mode 100644 src/scripts/prism.js
+2025-12-07T21:24:04.6976745Z  create mode 100644 src/scripts/sharedConstants-CFSD-basic-html-helper.js
+2025-12-07T21:24:04.6977152Z  create mode 100644 src/scripts/sharedConstants-__main.js
+2025-12-07T21:24:04.6977448Z  create mode 100644 test-staging.html
+2025-12-07T21:24:04.6977707Z  create mode 100644 tests/e2e/homepage.spec.ts
+2025-12-07T21:24:04.6978015Z  create mode 100644 tests/e2e/interactive-features.spec.ts
+2025-12-07T21:24:04.6978365Z  create mode 100644 tests/e2e/navigation/home-navigation.spec.ts
+2025-12-07T21:24:04.6978738Z  create mode 100644 tests/e2e/navigation/nav-CFSD-pages.spec.ts
+2025-12-07T21:24:04.6979061Z  create mode 100644 tests/fixtures/test-fixtures.ts
+2025-12-07T21:24:04.6979383Z  create mode 100644 tests/utils/helpers-page-navigation.ts
+2025-12-07T21:24:04.6979670Z  create mode 100644 tsconfig.json
+2025-12-07T21:24:04.6980084Z ##[endgroup]
+2025-12-07T21:24:04.6980416Z ##[group]Push the commit or tag
+2025-12-07T21:24:04.6980684Z [command]/usr/bin/git push origin --force gh-pages
+2025-12-07T21:24:05.9019487Z To https://github.com/T193R-W00D5/myFreecodecampLearning.git
+2025-12-07T21:24:05.9020200Z  + 523123e...e8ba0c8 gh-pages -> gh-pages (forced update)
+2025-12-07T21:24:05.9068343Z ##[endgroup]
+2025-12-07T21:24:05.9068671Z [INFO] Action successfully completed
+2025-12-07T21:24:05.9186142Z Post job cleanup.
+2025-12-07T21:24:06.0111335Z [command]/usr/bin/git version
+2025-12-07T21:24:06.0146050Z git version 2.52.0
+2025-12-07T21:24:06.0186638Z Temporarily overriding HOME='/home/runner/work/_temp/0962e424-e2b2-4e5c-8653-2a7dfe80e082' before making global git config changes
+2025-12-07T21:24:06.0187458Z Adding repository directory to the temporary git global config as a safe directory
+2025-12-07T21:24:06.0192007Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/myFreecodecampLearning/myFreecodecampLearning
+2025-12-07T21:24:06.0230997Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+2025-12-07T21:24:06.0262870Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+2025-12-07T21:24:06.0485433Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+2025-12-07T21:24:06.0505669Z http.https://github.com/.extraheader
+2025-12-07T21:24:06.0517486Z [command]/usr/bin/git config --local --unset-all http.https://github.com/.extraheader
+2025-12-07T21:24:06.0546501Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+2025-12-07T21:24:06.0761771Z [command]/usr/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+2025-12-07T21:24:06.0790941Z [command]/usr/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+2025-12-07T21:24:06.1110873Z Evaluate and set environment url
+2025-12-07T21:24:06.1113244Z Evaluated environment url: https://t193r-w00d5.github.io/myFreecodecampLearning
+2025-12-07T21:24:06.1114690Z Cleaning up orphan processes
+
+2025-12-07T21:24:11.9319415Z Current runner version: '2.329.0'
+2025-12-07T21:24:11.9343272Z ##[group]Runner Image Provisioner
+2025-12-07T21:24:11.9344118Z Hosted Compute Agent
+2025-12-07T21:24:11.9344636Z Version: 20251124.448
+2025-12-07T21:24:11.9345293Z Commit: fda5086b43ec66ade217e5fcd18146c879571177
+2025-12-07T21:24:11.9345975Z Build Date: 2025-11-24T21:16:26Z
+2025-12-07T21:24:11.9346570Z ##[endgroup]
+2025-12-07T21:24:11.9347085Z ##[group]Operating System
+2025-12-07T21:24:11.9347718Z Ubuntu
+2025-12-07T21:24:11.9348163Z 24.04.3
+2025-12-07T21:24:11.9348620Z LTS
+2025-12-07T21:24:11.9349140Z ##[endgroup]
+2025-12-07T21:24:11.9349657Z ##[group]Runner Image
+2025-12-07T21:24:11.9350230Z Image: ubuntu-24.04
+2025-12-07T21:24:11.9350777Z Version: 20251126.144.1
+2025-12-07T21:24:11.9351985Z Included Software: https://github.com/actions/runner-images/blob/ubuntu24/20251126.144/images/ubuntu/Ubuntu2404-Readme.md
+2025-12-07T21:24:11.9353567Z Image Release: https://github.com/actions/runner-images/releases/tag/ubuntu24%2F20251126.144
+2025-12-07T21:24:11.9354534Z ##[endgroup]
+2025-12-07T21:24:11.9357114Z ##[group]GITHUB_TOKEN Permissions
+2025-12-07T21:24:11.9359285Z Actions: write
+2025-12-07T21:24:11.9359828Z ArtifactMetadata: write
+2025-12-07T21:24:11.9360464Z Attestations: write
+2025-12-07T21:24:11.9360954Z Checks: write
+2025-12-07T21:24:11.9361629Z Contents: write
+2025-12-07T21:24:11.9362164Z Deployments: write
+2025-12-07T21:24:11.9362740Z Discussions: write
+2025-12-07T21:24:11.9363209Z Issues: write
+2025-12-07T21:24:11.9363730Z Metadata: read
+2025-12-07T21:24:11.9364242Z Models: read
+2025-12-07T21:24:11.9364690Z Packages: write
+2025-12-07T21:24:11.9365218Z Pages: write
+2025-12-07T21:24:11.9365716Z PullRequests: write
+2025-12-07T21:24:11.9366252Z RepositoryProjects: write
+2025-12-07T21:24:11.9366845Z SecurityEvents: write
+2025-12-07T21:24:11.9367453Z Statuses: write
+2025-12-07T21:24:11.9367954Z ##[endgroup]
+2025-12-07T21:24:11.9370229Z Secret source: Actions
+2025-12-07T21:24:11.9371321Z Prepare workflow directory
+2025-12-07T21:24:11.9691035Z Prepare all required actions
+2025-12-07T21:24:11.9790456Z Complete job name: deployment-success
+2025-12-07T21:24:12.0514620Z ##[group]Run echo "## 🚀 Production Deployment Successful!" >> $GITHUB_STEP_SUMMARY
+2025-12-07T21:24:12.0515884Z [36;1mecho "## 🚀 Production Deployment Successful!" >> $GITHUB_STEP_SUMMARY[0m
+2025-12-07T21:24:12.0516695Z [36;1mecho "" >> $GITHUB_STEP_SUMMARY[0m
+2025-12-07T21:24:12.0517440Z [36;1mecho "**Environment:** Production" >> $GITHUB_STEP_SUMMARY[0m
+2025-12-07T21:24:12.0518429Z [36;1mecho "**Commit:** 9d93fc766a566e22c60ab7248e1c0d43405514ba" >> $GITHUB_STEP_SUMMARY[0m
+2025-12-07T21:24:12.0519479Z [36;1mecho "**Deployed by:** T193R-W00D5" >> $GITHUB_STEP_SUMMARY[0m
+2025-12-07T21:24:12.0520216Z [36;1mecho "" >> $GITHUB_STEP_SUMMARY[0m
+2025-12-07T21:24:12.0521144Z [36;1mecho "**Live URL:** https://t193r-w00d5.github.io/myFreecodecampLearning" >> $GITHUB_STEP_SUMMARY[0m
+2025-12-07T21:24:12.0522488Z [36;1mecho "" >> $GITHUB_STEP_SUMMARY[0m
+2025-12-07T21:24:12.0523417Z [36;1mecho "Please allow 5-10 minutes for GitHub Pages to update." >> $GITHUB_STEP_SUMMARY[0m
+2025-12-07T21:24:12.0935758Z shell: /usr/bin/bash -e {0}
+2025-12-07T21:24:12.0936856Z ##[endgroup]
+2025-12-07T21:24:12.1265984Z Cleaning up orphan processes


### PR DESCRIPTION
Previous fix with disable_nojekyll: false didn't work - GitHub Pages still double-processes Jekyll despite .nojekyll file.

NEW APPROACH: Use GitHub's official actions/deploy-pages@v4 instead of peaceiris/actions-gh-pages. This should give us better control over Jekyll processing.

Changes:
- Replace peaceiris action with upload-pages-artifact + deploy-pages
- Add required pages: write and id-token: write permissions
- Change environment to github-pages with dynamic URL
- Keep all Jekyll build logic exactly the same