### PR TITLE
modified to use GitHub's native deployment actions, not peaceiris

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -94,9 +94,14 @@ jobs:
       needs.pre-deployment-tests.result == 'success'
     needs: pre-deployment-tests
     runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
     environment: 
       name: staging
-      url: https://t193r-w00d5.github.io/myFreecodecampLearning/staging
+      url: ${{ steps.deployment.outputs.page_url }}
+    outputs:
+      page_url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Checkout specific commit for staging
         uses: actions/checkout@v4
@@ -141,20 +146,27 @@ jobs:
           echo "Checking CSS link paths:" >> $GITHUB_STEP_SUMMARY
           grep -n "css" _site/index.html >> $GITHUB_STEP_SUMMARY || echo "No CSS links found" >> $GITHUB_STEP_SUMMARY
 
-      - name: Add .nojekyll file
+      - name: Create staging subdirectory structure
         run: |
-          touch _site/.nojekyll
-          echo "✅ Added .nojekyll file to prevent GitHub Pages Jekyll processing" >> $GITHUB_STEP_SUMMARY
+          mkdir -p _site_staging/myFreecodecampLearning/staging
+          cp -r _site/* _site_staging/myFreecodecampLearning/staging/
+          echo "Created staging directory structure" >> $GITHUB_STEP_SUMMARY
+          echo "Contents of staging directory:" >> $GITHUB_STEP_SUMMARY
+          ls -la _site_staging/myFreecodecampLearning/staging/ >> $GITHUB_STEP_SUMMARY
+
+      - name: Add .nojekyll file to staging
+        run: |
+          touch _site_staging/.nojekyll
+          echo "✅ Added .nojekyll file to staging deployment" >> $GITHUB_STEP_SUMMARY
+
+      - name: Upload staging site artifacts
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./_site_staging
 
       - name: Deploy to GitHub Pages (staging)
-        uses: peaceiris/actions-gh-pages@v4
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./_site
-          destination_dir: staging
-          enable_jekyll: false
-          force_orphan: false  # Don't orphan staging, append to gh-pages
-          disable_nojekyll: false  # Ensure .nojekyll file is created
+        id: deployment
+        uses: actions/deploy-pages@v4
 
   # Deployment success notification
   deployment-success:
@@ -170,6 +182,6 @@ jobs:
           echo "**Commit:** ${{ github.sha }}" >> $GITHUB_STEP_SUMMARY
           echo "**Deployed by:** ${{ github.actor }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Staging URL:** https://t193r-w00d5.github.io/myFreecodecampLearning/staging" >> $GITHUB_STEP_SUMMARY
+          echo "**Staging URL:** ${{ needs.deploy-staging.outputs.page_url }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "Please allow 5-10 minutes for GitHub Pages to update." >> $GITHUB_STEP_SUMMARY

--- a/docs/debug_dox/Deploy to Staging 2 20251209_1350UTC.txt
+++ b/docs/debug_dox/Deploy to Staging 2 20251209_1350UTC.txt
@@ -1,0 +1,2227 @@
+# logs for pre-deployment-tests job
+2025-12-09T11:10:39.4823220Z Current runner version: '2.329.0'
+2025-12-09T11:10:39.4846661Z ##[group]Runner Image Provisioner
+2025-12-09T11:10:39.4847431Z Hosted Compute Agent
+2025-12-09T11:10:39.4847957Z Version: 20251124.448
+2025-12-09T11:10:39.4848630Z Commit: fda5086b43ec66ade217e5fcd18146c879571177
+2025-12-09T11:10:39.4849321Z Build Date: 2025-11-24T21:16:26Z
+2025-12-09T11:10:39.4849907Z ##[endgroup]
+2025-12-09T11:10:39.4850506Z ##[group]Operating System
+2025-12-09T11:10:39.4851076Z Ubuntu
+2025-12-09T11:10:39.4851526Z 24.04.3
+2025-12-09T11:10:39.4852050Z LTS
+2025-12-09T11:10:39.4852512Z ##[endgroup]
+2025-12-09T11:10:39.4853022Z ##[group]Runner Image
+2025-12-09T11:10:39.4853560Z Image: ubuntu-24.04
+2025-12-09T11:10:39.4854346Z Version: 20251126.144.1
+2025-12-09T11:10:39.4855369Z Included Software: https://github.com/actions/runner-images/blob/ubuntu24/20251126.144/images/ubuntu/Ubuntu2404-Readme.md
+2025-12-09T11:10:39.4856927Z Image Release: https://github.com/actions/runner-images/releases/tag/ubuntu24%2F20251126.144
+2025-12-09T11:10:39.4857890Z ##[endgroup]
+2025-12-09T11:10:39.4860469Z ##[group]GITHUB_TOKEN Permissions
+2025-12-09T11:10:39.4862379Z Actions: write
+2025-12-09T11:10:39.4863024Z ArtifactMetadata: write
+2025-12-09T11:10:39.4863560Z Attestations: write
+2025-12-09T11:10:39.4864260Z Checks: write
+2025-12-09T11:10:39.4864847Z Contents: write
+2025-12-09T11:10:39.4865337Z Deployments: write
+2025-12-09T11:10:39.4865858Z Discussions: write
+2025-12-09T11:10:39.4866312Z Issues: write
+2025-12-09T11:10:39.4866882Z Metadata: read
+2025-12-09T11:10:39.4867346Z Models: read
+2025-12-09T11:10:39.4867860Z Packages: write
+2025-12-09T11:10:39.4868404Z Pages: write
+2025-12-09T11:10:39.4868919Z PullRequests: write
+2025-12-09T11:10:39.4869426Z RepositoryProjects: write
+2025-12-09T11:10:39.4870146Z SecurityEvents: write
+2025-12-09T11:10:39.4870689Z Statuses: write
+2025-12-09T11:10:39.4871189Z ##[endgroup]
+2025-12-09T11:10:39.4873458Z Secret source: Actions
+2025-12-09T11:10:39.4874693Z Prepare workflow directory
+2025-12-09T11:10:39.5180621Z Prepare all required actions
+2025-12-09T11:10:39.5217706Z Getting action download info
+2025-12-09T11:10:40.0470976Z Download action repository 'actions/checkout@v4' (SHA:34e114876b0b11c390a56381ad16ebd13914f8d5)
+2025-12-09T11:10:40.5737899Z Download action repository 'actions/setup-node@v4' (SHA:49933ea5288caeca8642d1e84afbd3f7d6820020)
+2025-12-09T11:10:40.6949161Z Download action repository 'ruby/setup-ruby@v1' (SHA:d697be2f83c6234b20877c3b5eac7a7f342f0d0c)
+2025-12-09T11:10:41.1921248Z Download action repository 'actions/upload-artifact@v4' (SHA:ea165f8d65b6e75b540449e92b4886f43607fa02)
+2025-12-09T11:10:41.4059871Z Complete job name: pre-deployment-tests
+2025-12-09T11:10:41.4903322Z ##[group]Run actions/checkout@v4
+2025-12-09T11:10:41.4904911Z with:
+2025-12-09T11:10:41.4905618Z   ref: main
+2025-12-09T11:10:41.4906476Z   repository: T193R-W00D5/myFreecodecampLearning
+2025-12-09T11:10:41.4907844Z   token: ***
+2025-12-09T11:10:41.4908583Z   ssh-strict: true
+2025-12-09T11:10:41.4909342Z   ssh-user: git
+2025-12-09T11:10:41.4910144Z   persist-credentials: true
+2025-12-09T11:10:41.4911019Z   clean: true
+2025-12-09T11:10:41.4911798Z   sparse-checkout-cone-mode: true
+2025-12-09T11:10:41.4912751Z   fetch-depth: 1
+2025-12-09T11:10:41.4913506Z   fetch-tags: false
+2025-12-09T11:10:41.4914449Z   show-progress: true
+2025-12-09T11:10:41.4915259Z   lfs: false
+2025-12-09T11:10:41.4915982Z   submodules: false
+2025-12-09T11:10:41.4916763Z   set-safe-directory: true
+2025-12-09T11:10:41.4917883Z ##[endgroup]
+2025-12-09T11:10:41.6036532Z Syncing repository: T193R-W00D5/myFreecodecampLearning
+2025-12-09T11:10:41.6040892Z ##[group]Getting Git version info
+2025-12-09T11:10:41.6044820Z Working directory is '/home/runner/work/myFreecodecampLearning/myFreecodecampLearning'
+2025-12-09T11:10:41.6048203Z [command]/usr/bin/git version
+2025-12-09T11:10:41.6118015Z git version 2.52.0
+2025-12-09T11:10:41.6143584Z ##[endgroup]
+2025-12-09T11:10:41.6157169Z Temporarily overriding HOME='/home/runner/work/_temp/ac54eb4f-8521-4e0e-bd29-cc6d7f89901f' before making global git config changes
+2025-12-09T11:10:41.6160290Z Adding repository directory to the temporary git global config as a safe directory
+2025-12-09T11:10:41.6169620Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/myFreecodecampLearning/myFreecodecampLearning
+2025-12-09T11:10:41.6206666Z Deleting the contents of '/home/runner/work/myFreecodecampLearning/myFreecodecampLearning'
+2025-12-09T11:10:41.6209359Z ##[group]Initializing the repository
+2025-12-09T11:10:41.6213500Z [command]/usr/bin/git init /home/runner/work/myFreecodecampLearning/myFreecodecampLearning
+2025-12-09T11:10:41.6319032Z hint: Using 'master' as the name for the initial branch. This default branch name
+2025-12-09T11:10:41.6321237Z hint: will change to "main" in Git 3.0. To configure the initial branch name
+2025-12-09T11:10:41.6323624Z hint: to use in all of your new repositories, which will suppress this warning,
+2025-12-09T11:10:41.6326029Z hint: call:
+2025-12-09T11:10:41.6327452Z hint:
+2025-12-09T11:10:41.6329241Z hint: 	git config --global init.defaultBranch <name>
+2025-12-09T11:10:41.6331349Z hint:
+2025-12-09T11:10:41.6333206Z hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
+2025-12-09T11:10:41.6336622Z hint: 'development'. The just-created branch can be renamed via this command:
+2025-12-09T11:10:41.6339200Z hint:
+2025-12-09T11:10:41.6340471Z hint: 	git branch -m <name>
+2025-12-09T11:10:41.6341882Z hint:
+2025-12-09T11:10:41.6344234Z hint: Disable this message with "git config set advice.defaultBranchName false"
+2025-12-09T11:10:41.6346662Z Initialized empty Git repository in /home/runner/work/myFreecodecampLearning/myFreecodecampLearning/.git/
+2025-12-09T11:10:41.6351430Z [command]/usr/bin/git remote add origin https://github.com/T193R-W00D5/myFreecodecampLearning
+2025-12-09T11:10:41.6373504Z ##[endgroup]
+2025-12-09T11:10:41.6376254Z ##[group]Disabling automatic garbage collection
+2025-12-09T11:10:41.6378520Z [command]/usr/bin/git config --local gc.auto 0
+2025-12-09T11:10:41.6407525Z ##[endgroup]
+2025-12-09T11:10:41.6409847Z ##[group]Setting up auth
+2025-12-09T11:10:41.6414852Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+2025-12-09T11:10:41.6447566Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+2025-12-09T11:10:41.6780835Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+2025-12-09T11:10:41.6811514Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+2025-12-09T11:10:41.7023156Z [command]/usr/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+2025-12-09T11:10:41.7052466Z [command]/usr/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+2025-12-09T11:10:41.7275513Z [command]/usr/bin/git config --local http.https://github.com/.extraheader AUTHORIZATION: basic ***
+2025-12-09T11:10:41.7308603Z ##[endgroup]
+2025-12-09T11:10:41.7309920Z ##[group]Fetching the repository
+2025-12-09T11:10:41.7317538Z [command]/usr/bin/git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +refs/heads/main*:refs/remotes/origin/main* +refs/tags/main*:refs/tags/main*
+2025-12-09T11:10:42.4427288Z From https://github.com/T193R-W00D5/myFreecodecampLearning
+2025-12-09T11:10:42.4429174Z  * [new branch]      main       -> origin/main
+2025-12-09T11:10:42.4459747Z ##[endgroup]
+2025-12-09T11:10:42.4460274Z ##[group]Determining the checkout info
+2025-12-09T11:10:42.4466879Z [command]/usr/bin/git branch --list --remote origin/main
+2025-12-09T11:10:42.4489464Z   origin/main
+2025-12-09T11:10:42.4494847Z ##[endgroup]
+2025-12-09T11:10:42.4499508Z [command]/usr/bin/git sparse-checkout disable
+2025-12-09T11:10:42.4539674Z [command]/usr/bin/git config --local --unset-all extensions.worktreeConfig
+2025-12-09T11:10:42.4565934Z ##[group]Checking out the ref
+2025-12-09T11:10:42.4569539Z [command]/usr/bin/git checkout --progress --force -B main refs/remotes/origin/main
+2025-12-09T11:10:42.4919880Z Switched to a new branch 'main'
+2025-12-09T11:10:42.4923260Z branch 'main' set up to track 'origin/main'.
+2025-12-09T11:10:42.4931112Z ##[endgroup]
+2025-12-09T11:10:42.4966505Z [command]/usr/bin/git log -1 --format=%H
+2025-12-09T11:10:42.4987751Z d1c48a37612e974c398263097bde7994acc3f9b6
+2025-12-09T11:10:42.5179681Z ##[group]Run echo "🧪 STAGING DEPLOYMENT INFORMATION" >> $GITHUB_STEP_SUMMARY
+2025-12-09T11:10:42.5180377Z [36;1mecho "🧪 STAGING DEPLOYMENT INFORMATION" >> $GITHUB_STEP_SUMMARY[0m
+2025-12-09T11:10:42.5180911Z [36;1mecho "**Environment:** Staging" >> $GITHUB_STEP_SUMMARY[0m
+2025-12-09T11:10:42.5181372Z [36;1mecho "**Branch:** main" >> $GITHUB_STEP_SUMMARY[0m
+2025-12-09T11:10:42.5181855Z [36;1mecho "**Commit:** $(git rev-parse HEAD)" >> $GITHUB_STEP_SUMMARY[0m
+2025-12-09T11:10:42.5182433Z [36;1mecho "**Commit Message:** $(git log --oneline -n 1)" >> $GITHUB_STEP_SUMMARY[0m
+2025-12-09T11:10:42.5182970Z [36;1mecho "**Triggered by:** T193R-W00D5" >> $GITHUB_STEP_SUMMARY[0m
+2025-12-09T11:10:42.5183440Z [36;1mecho "**Timestamp:** $(date)" >> $GITHUB_STEP_SUMMARY[0m
+2025-12-09T11:10:42.5220692Z shell: /usr/bin/bash -e {0}
+2025-12-09T11:10:42.5221034Z ##[endgroup]
+2025-12-09T11:10:42.5429888Z ##[group]Run actions/setup-node@v4
+2025-12-09T11:10:42.5430234Z with:
+2025-12-09T11:10:42.5430477Z   node-version: 22
+2025-12-09T11:10:42.5430720Z   cache: npm
+2025-12-09T11:10:42.5430962Z   always-auth: false
+2025-12-09T11:10:42.5431224Z   check-latest: false
+2025-12-09T11:10:42.5431625Z   token: ***
+2025-12-09T11:10:42.5431865Z ##[endgroup]
+2025-12-09T11:10:42.7412314Z Found in cache @ /opt/hostedtoolcache/node/22.21.1/x64
+2025-12-09T11:10:42.7418693Z ##[group]Environment details
+2025-12-09T11:10:45.1555049Z node: v22.21.1
+2025-12-09T11:10:45.1555738Z npm: 10.9.4
+2025-12-09T11:10:45.1556242Z yarn: 1.22.22
+2025-12-09T11:10:45.1557344Z ##[endgroup]
+2025-12-09T11:10:45.1576669Z [command]/opt/hostedtoolcache/node/22.21.1/x64/bin/npm config get cache
+2025-12-09T11:10:45.4044543Z /home/runner/.npm
+2025-12-09T11:10:45.7770230Z Cache hit for: node-cache-Linux-x64-npm-e3fade3f30968ac95fccac45edc85cd25eaa881f6a1cdb7268c834223e952c45
+2025-12-09T11:10:47.0881039Z Received 4194304 of 20062804 (20.9%), 4.0 MBs/sec
+2025-12-09T11:10:47.3006020Z Received 20062804 of 20062804 (100.0%), 15.8 MBs/sec
+2025-12-09T11:10:47.3006753Z Cache Size: ~19 MB (20062804 B)
+2025-12-09T11:10:47.3044894Z [command]/usr/bin/tar -xf /home/runner/work/_temp/99a9d7c0-4f58-4d2e-bd39-49918141dc36/cache.tzst -P -C /home/runner/work/myFreecodecampLearning/myFreecodecampLearning --use-compress-program unzstd
+2025-12-09T11:10:47.4037638Z Cache restored successfully
+2025-12-09T11:10:47.4080668Z Cache restored from key: node-cache-Linux-x64-npm-e3fade3f30968ac95fccac45edc85cd25eaa881f6a1cdb7268c834223e952c45
+2025-12-09T11:10:47.4228771Z ##[group]Run ruby/setup-ruby@v1
+2025-12-09T11:10:47.4229047Z with:
+2025-12-09T11:10:47.4229256Z   ruby-version: 3.3
+2025-12-09T11:10:47.4229462Z   bundler-cache: false
+2025-12-09T11:10:47.4229662Z ##[endgroup]
+2025-12-09T11:10:47.5933233Z ##[group]Modifying PATH
+2025-12-09T11:10:47.5948122Z Entries added to PATH to use selected Ruby:
+2025-12-09T11:10:47.5948848Z   /opt/hostedtoolcache/Ruby/3.3.10/x64/bin
+2025-12-09T11:10:47.5951763Z ##[endgroup]
+2025-12-09T11:10:47.5952678Z ##[group]Print Ruby version
+2025-12-09T11:10:47.6065505Z [command]/opt/hostedtoolcache/Ruby/3.3.10/x64/bin/ruby --version
+2025-12-09T11:10:47.8534797Z ruby 3.3.10 (2025-10-23 revision 343ea05002) [x86_64-linux]
+2025-12-09T11:10:47.8568607Z Took   0.26 seconds
+2025-12-09T11:10:47.8569333Z ##[endgroup]
+2025-12-09T11:10:47.8571268Z ##[group]Installing Bundler
+2025-12-09T11:10:47.8576857Z Using Bundler 2.7.2 from Gemfile.lock BUNDLED WITH 2.7.2
+2025-12-09T11:10:47.8581254Z [command]/opt/hostedtoolcache/Ruby/3.3.10/x64/bin/gem install bundler -v 2.7.2
+2025-12-09T11:10:49.2095306Z Successfully installed bundler-2.7.2
+2025-12-09T11:10:49.2095940Z 1 gem installed
+2025-12-09T11:10:49.2148502Z Took   1.36 seconds
+2025-12-09T11:10:49.2150917Z ##[endgroup]
+2025-12-09T11:10:49.2228467Z ##[group]Run npm ci
+2025-12-09T11:10:49.2228716Z [36;1mnpm ci[0m
+2025-12-09T11:10:49.2268166Z shell: /usr/bin/bash -e {0}
+2025-12-09T11:10:49.2268411Z ##[endgroup]
+2025-12-09T11:10:50.8310939Z npm warn EBADENGINE Unsupported engine {
+2025-12-09T11:10:50.8311905Z npm warn EBADENGINE   package: 'freecodecamporg-website-copies@1.0.0',
+2025-12-09T11:10:50.8312775Z npm warn EBADENGINE   required: { node: '>=18 <=22.21.0' },
+2025-12-09T11:10:50.8313855Z npm warn EBADENGINE   current: { node: 'v22.21.1', npm: '10.9.4' }
+2025-12-09T11:10:50.8314456Z npm warn EBADENGINE }
+2025-12-09T11:10:51.9790773Z npm warn deprecated inflight@1.0.6: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
+2025-12-09T11:10:52.1763418Z npm warn deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported
+2025-12-09T11:10:53.1032395Z 
+2025-12-09T11:10:53.1033342Z added 557 packages, and audited 558 packages in 4s
+2025-12-09T11:10:53.1034091Z 
+2025-12-09T11:10:53.1034455Z 68 packages are looking for funding
+2025-12-09T11:10:53.1035514Z   run `npm fund` for details
+2025-12-09T11:10:53.1060558Z 
+2025-12-09T11:10:53.1060885Z 1 moderate severity vulnerability
+2025-12-09T11:10:53.1061205Z 
+2025-12-09T11:10:53.1061405Z To address all issues, run:
+2025-12-09T11:10:53.1061823Z   npm audit fix
+2025-12-09T11:10:53.1062034Z 
+2025-12-09T11:10:53.1062223Z Run `npm audit` for details.
+2025-12-09T11:10:53.1681823Z ##[group]Run bundle config set --local frozen false
+2025-12-09T11:10:53.1682205Z [36;1mbundle config set --local frozen false[0m
+2025-12-09T11:10:53.1682478Z [36;1mbundle install[0m
+2025-12-09T11:10:53.1715067Z shell: /usr/bin/bash -e {0}
+2025-12-09T11:10:53.1715303Z ##[endgroup]
+2025-12-09T11:10:55.0744595Z Fetching gem metadata from https://rubygems.org/..........
+2025-12-09T11:10:55.0793556Z Fetching rake 13.3.1
+2025-12-09T11:10:55.1487131Z Installing rake 13.3.1
+2025-12-09T11:10:55.1634728Z Fetching public_suffix 7.0.0
+2025-12-09T11:10:55.1637645Z Fetching base64 0.3.0
+2025-12-09T11:10:55.1638190Z Fetching bigdecimal 3.3.1
+2025-12-09T11:10:55.1638616Z Fetching colorator 1.1.0
+2025-12-09T11:10:55.1724166Z Installing base64 0.3.0
+2025-12-09T11:10:55.1741532Z Installing public_suffix 7.0.0
+2025-12-09T11:10:55.1829012Z Fetching concurrent-ruby 1.3.5
+2025-12-09T11:10:55.1852950Z Installing colorator 1.1.0
+2025-12-09T11:10:55.1877918Z Installing bigdecimal 3.3.1 with native extensions
+2025-12-09T11:10:55.1959580Z Fetching csv 3.3.5
+2025-12-09T11:10:55.2045941Z Fetching eventmachine 1.2.7
+2025-12-09T11:10:55.2127189Z Installing csv 3.3.5
+2025-12-09T11:10:55.2379524Z Installing concurrent-ruby 1.3.5
+2025-12-09T11:10:55.2498907Z Installing eventmachine 1.2.7 with native extensions
+2025-12-09T11:10:55.2904694Z Fetching http_parser.rb 0.8.0
+2025-12-09T11:10:55.3246017Z Installing http_parser.rb 0.8.0 with native extensions
+2025-12-09T11:10:55.4209232Z Fetching ffi 1.17.2 (x86_64-linux-gnu)
+2025-12-09T11:10:55.4605272Z Installing ffi 1.17.2 (x86_64-linux-gnu)
+2025-12-09T11:10:55.5284841Z Fetching forwardable-extended 2.6.0
+2025-12-09T11:10:55.5340874Z Installing forwardable-extended 2.6.0
+2025-12-09T11:10:55.5374643Z Fetching rb-fsevent 0.11.2
+2025-12-09T11:10:55.5462918Z Installing rb-fsevent 0.11.2
+2025-12-09T11:10:55.5614859Z Fetching json 2.17.1
+2025-12-09T11:10:55.5686693Z Installing json 2.17.1 with native extensions
+2025-12-09T11:10:58.1268192Z Fetching liquid 4.0.4
+2025-12-09T11:10:58.1577467Z Installing liquid 4.0.4
+2025-12-09T11:10:58.1978312Z Fetching mercenary 0.4.0
+2025-12-09T11:10:58.2108095Z Installing mercenary 0.4.0
+2025-12-09T11:10:58.2346396Z Fetching rouge 4.6.1
+2025-12-09T11:10:58.2836722Z Installing rouge 4.6.1
+2025-12-09T11:10:58.4806861Z Fetching safe_yaml 1.0.5
+2025-12-09T11:10:58.4879863Z Installing safe_yaml 1.0.5
+2025-12-09T11:10:58.5060766Z Fetching unicode-display_width 2.6.0
+2025-12-09T11:10:58.5135063Z Installing unicode-display_width 2.6.0
+2025-12-09T11:10:58.5169223Z Fetching webrick 1.9.2
+2025-12-09T11:10:58.5247319Z Installing webrick 1.9.2
+2025-12-09T11:10:58.5483544Z Fetching addressable 2.8.8
+2025-12-09T11:10:58.5624796Z Installing addressable 2.8.8
+2025-12-09T11:10:58.5759694Z Fetching i18n 1.14.7
+2025-12-09T11:10:58.5834937Z Installing i18n 1.14.7
+2025-12-09T11:10:58.6014556Z Fetching rb-inotify 0.11.1
+2025-12-09T11:10:58.6076387Z Installing rb-inotify 0.11.1
+2025-12-09T11:10:58.6154214Z Fetching pathutil 0.16.2
+2025-12-09T11:10:58.6244558Z Installing pathutil 0.16.2
+2025-12-09T11:10:58.6261893Z Fetching kramdown 2.5.1
+2025-12-09T11:10:58.6456701Z Installing kramdown 2.5.1
+2025-12-09T11:10:58.7932554Z Fetching terminal-table 3.0.2
+2025-12-09T11:10:58.8011148Z Installing terminal-table 3.0.2
+2025-12-09T11:10:58.8098436Z Fetching listen 3.9.0
+2025-12-09T11:10:58.8184582Z Installing listen 3.9.0
+2025-12-09T11:10:58.8271919Z Fetching kramdown-parser-gfm 1.1.0
+2025-12-09T11:10:58.8325516Z Installing kramdown-parser-gfm 1.1.0
+2025-12-09T11:10:58.8440369Z Fetching jekyll-watch 2.2.1
+2025-12-09T11:10:58.8499474Z Installing jekyll-watch 2.2.1
+2025-12-09T11:11:05.7002155Z Fetching google-protobuf 4.33.1 (x86_64-linux-gnu)
+2025-12-09T11:11:05.7369154Z Installing google-protobuf 4.33.1 (x86_64-linux-gnu)
+2025-12-09T11:11:05.7946466Z Fetching sass-embedded 1.94.2 (x86_64-linux-gnu)
+2025-12-09T11:11:05.9013071Z Installing sass-embedded 1.94.2 (x86_64-linux-gnu)
+2025-12-09T11:11:06.0064381Z Fetching jekyll-sass-converter 3.1.0
+2025-12-09T11:11:06.0105102Z Installing jekyll-sass-converter 3.1.0
+2025-12-09T11:11:12.8013262Z Fetching em-websocket 0.5.3
+2025-12-09T11:11:12.8117788Z Installing em-websocket 0.5.3
+2025-12-09T11:11:12.8219293Z Fetching jekyll 4.4.1
+2025-12-09T11:11:12.8344840Z Installing jekyll 4.4.1
+2025-12-09T11:11:12.8599355Z Fetching jekyll-feed 0.17.0
+2025-12-09T11:11:12.8602224Z Fetching jekyll-seo-tag 2.8.0
+2025-12-09T11:11:12.8602939Z Fetching jekyll-sitemap 1.4.0
+2025-12-09T11:11:12.8656782Z Installing jekyll-feed 0.17.0
+2025-12-09T11:11:12.8734169Z Installing jekyll-seo-tag 2.8.0
+2025-12-09T11:11:12.8893181Z Installing jekyll-sitemap 1.4.0
+2025-12-09T11:11:12.9157967Z Bundle complete! 9 Gemfile dependencies, 38 gems now installed.
+2025-12-09T11:11:12.9158791Z Use `bundle info [gemname]` to see where a bundled gem is installed.
+2025-12-09T11:11:12.9676019Z ##[group]Run npx playwright install --with-deps
+2025-12-09T11:11:12.9676390Z [36;1mnpx playwright install --with-deps[0m
+2025-12-09T11:11:12.9708639Z shell: /usr/bin/bash -e {0}
+2025-12-09T11:11:12.9708892Z ##[endgroup]
+2025-12-09T11:11:13.8090280Z Installing dependencies...
+2025-12-09T11:11:13.8182700Z Switching to root user to install dependencies...
+2025-12-09T11:11:13.8928003Z Get:1 file:/etc/apt/apt-mirrors.txt Mirrorlist [144 B]
+2025-12-09T11:11:13.9259889Z Hit:2 http://azure.archive.ubuntu.com/ubuntu noble InRelease
+2025-12-09T11:11:13.9261255Z Get:6 https://packages.microsoft.com/repos/azure-cli noble InRelease [3564 B]
+2025-12-09T11:11:13.9275936Z Get:3 http://azure.archive.ubuntu.com/ubuntu noble-updates InRelease [126 kB]
+2025-12-09T11:11:13.9286813Z Get:7 https://packages.microsoft.com/ubuntu/24.04/prod noble InRelease [3600 B]
+2025-12-09T11:11:13.9336598Z Get:4 http://azure.archive.ubuntu.com/ubuntu noble-backports InRelease [126 kB]
+2025-12-09T11:11:13.9354195Z Get:5 http://azure.archive.ubuntu.com/ubuntu noble-security InRelease [126 kB]
+2025-12-09T11:11:14.0536340Z Get:8 https://packages.microsoft.com/repos/azure-cli noble/main amd64 Packages [1822 B]
+2025-12-09T11:11:14.0954702Z Get:9 https://packages.microsoft.com/ubuntu/24.04/prod noble/main arm64 Packages [56.6 kB]
+2025-12-09T11:11:14.1000207Z Get:10 https://packages.microsoft.com/ubuntu/24.04/prod noble/main armhf Packages [11.3 kB]
+2025-12-09T11:11:14.1035923Z Get:11 https://packages.microsoft.com/ubuntu/24.04/prod noble/main amd64 Packages [74.6 kB]
+2025-12-09T11:11:14.1427090Z Get:12 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 Packages [1627 kB]
+2025-12-09T11:11:14.1526246Z Get:13 http://azure.archive.ubuntu.com/ubuntu noble-updates/main Translation-en [305 kB]
+2025-12-09T11:11:14.1583932Z Get:14 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 Components [175 kB]
+2025-12-09T11:11:14.1607778Z Get:15 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 c-n-f Metadata [15.7 kB]
+2025-12-09T11:11:14.1622715Z Get:16 http://azure.archive.ubuntu.com/ubuntu noble-updates/universe amd64 Packages [1501 kB]
+2025-12-09T11:11:14.1712881Z Get:17 http://azure.archive.ubuntu.com/ubuntu noble-updates/universe Translation-en [304 kB]
+2025-12-09T11:11:14.1744010Z Get:18 http://azure.archive.ubuntu.com/ubuntu noble-updates/universe amd64 Components [378 kB]
+2025-12-09T11:11:14.1780335Z Get:19 http://azure.archive.ubuntu.com/ubuntu noble-updates/universe amd64 c-n-f Metadata [31.4 kB]
+2025-12-09T11:11:14.1792027Z Get:20 http://azure.archive.ubuntu.com/ubuntu noble-updates/restricted amd64 Packages [2309 kB]
+2025-12-09T11:11:14.1931272Z Get:21 http://azure.archive.ubuntu.com/ubuntu noble-updates/restricted Translation-en [526 kB]
+2025-12-09T11:11:14.2400802Z Get:22 http://azure.archive.ubuntu.com/ubuntu noble-updates/restricted amd64 Components [212 B]
+2025-12-09T11:11:14.2419830Z Get:23 http://azure.archive.ubuntu.com/ubuntu noble-updates/multiverse amd64 Components [940 B]
+2025-12-09T11:11:14.2431657Z Get:24 http://azure.archive.ubuntu.com/ubuntu noble-backports/main amd64 Components [7140 B]
+2025-12-09T11:11:14.2441956Z Get:25 http://azure.archive.ubuntu.com/ubuntu noble-backports/universe amd64 Packages [29.2 kB]
+2025-12-09T11:11:14.2458385Z Get:26 http://azure.archive.ubuntu.com/ubuntu noble-backports/universe Translation-en [17.6 kB]
+2025-12-09T11:11:14.2505844Z Get:27 http://azure.archive.ubuntu.com/ubuntu noble-backports/universe amd64 Components [11.0 kB]
+2025-12-09T11:11:14.2507198Z Get:28 http://azure.archive.ubuntu.com/ubuntu noble-backports/restricted amd64 Components [212 B]
+2025-12-09T11:11:14.2508590Z Get:29 http://azure.archive.ubuntu.com/ubuntu noble-backports/multiverse amd64 Components [212 B]
+2025-12-09T11:11:14.2526323Z Get:30 http://azure.archive.ubuntu.com/ubuntu noble-security/main amd64 Packages [1350 kB]
+2025-12-09T11:11:14.2601551Z Get:31 http://azure.archive.ubuntu.com/ubuntu noble-security/main Translation-en [221 kB]
+2025-12-09T11:11:14.2628316Z Get:32 http://azure.archive.ubuntu.com/ubuntu noble-security/main amd64 Components [21.5 kB]
+2025-12-09T11:11:14.2640487Z Get:33 http://azure.archive.ubuntu.com/ubuntu noble-security/main amd64 c-n-f Metadata [9448 B]
+2025-12-09T11:11:14.2659746Z Get:34 http://azure.archive.ubuntu.com/ubuntu noble-security/universe amd64 Packages [915 kB]
+2025-12-09T11:11:14.2709502Z Get:35 http://azure.archive.ubuntu.com/ubuntu noble-security/universe Translation-en [206 kB]
+2025-12-09T11:11:14.3161578Z Get:36 http://azure.archive.ubuntu.com/ubuntu noble-security/universe amd64 Components [71.4 kB]
+2025-12-09T11:11:14.3177979Z Get:37 http://azure.archive.ubuntu.com/ubuntu noble-security/universe amd64 c-n-f Metadata [19.4 kB]
+2025-12-09T11:11:14.3190108Z Get:38 http://azure.archive.ubuntu.com/ubuntu noble-security/restricted amd64 Packages [2205 kB]
+2025-12-09T11:11:14.3325087Z Get:39 http://azure.archive.ubuntu.com/ubuntu noble-security/restricted Translation-en [503 kB]
+2025-12-09T11:11:14.3358524Z Get:40 http://azure.archive.ubuntu.com/ubuntu noble-security/restricted amd64 Components [212 B]
+2025-12-09T11:11:14.3371278Z Get:41 http://azure.archive.ubuntu.com/ubuntu noble-security/multiverse amd64 Components [212 B]
+2025-12-09T11:11:22.9781689Z Fetched 13.3 MB in 2s (8517 kB/s)
+2025-12-09T11:11:23.7541603Z Reading package lists...
+2025-12-09T11:11:23.7800967Z Reading package lists...
+2025-12-09T11:11:23.9529553Z Building dependency tree...
+2025-12-09T11:11:23.9537214Z Reading state information...
+2025-12-09T11:11:23.9705638Z libasound2t64 is already the newest version (1.2.11-1ubuntu0.1).
+2025-12-09T11:11:23.9706351Z libasound2t64 set to manually installed.
+2025-12-09T11:11:23.9707073Z libatk-bridge2.0-0t64 is already the newest version (2.52.0-1build1).
+2025-12-09T11:11:23.9707814Z libatk-bridge2.0-0t64 set to manually installed.
+2025-12-09T11:11:23.9708530Z libatk1.0-0t64 is already the newest version (2.52.0-1build1).
+2025-12-09T11:11:23.9709161Z libatk1.0-0t64 set to manually installed.
+2025-12-09T11:11:23.9709875Z libatspi2.0-0t64 is already the newest version (2.52.0-1build1).
+2025-12-09T11:11:23.9710536Z libatspi2.0-0t64 set to manually installed.
+2025-12-09T11:11:23.9711177Z libcairo2 is already the newest version (1.18.0-3build1).
+2025-12-09T11:11:23.9711767Z libcairo2 set to manually installed.
+2025-12-09T11:11:23.9712417Z libdbus-1-3 is already the newest version (1.14.10-4ubuntu4.1).
+2025-12-09T11:11:23.9713041Z libdbus-1-3 set to manually installed.
+2025-12-09T11:11:23.9713963Z libdrm2 is already the newest version (2.4.122-1~ubuntu0.24.04.2).
+2025-12-09T11:11:23.9714614Z libdrm2 set to manually installed.
+2025-12-09T11:11:23.9715256Z libgbm1 is already the newest version (25.0.7-0ubuntu0.24.04.2).
+2025-12-09T11:11:23.9715863Z libgbm1 set to manually installed.
+2025-12-09T11:11:23.9716483Z libnspr4 is already the newest version (2:4.35-1.1build1).
+2025-12-09T11:11:23.9717084Z libnspr4 set to manually installed.
+2025-12-09T11:11:23.9717676Z libnss3 is already the newest version (2:3.98-1build1).
+2025-12-09T11:11:23.9718248Z libnss3 set to manually installed.
+2025-12-09T11:11:23.9718899Z libpango-1.0-0 is already the newest version (1.52.1+ds-1build1).
+2025-12-09T11:11:23.9719551Z libpango-1.0-0 set to manually installed.
+2025-12-09T11:11:23.9720182Z libx11-6 is already the newest version (2:1.8.7-1build1).
+2025-12-09T11:11:23.9720754Z libx11-6 set to manually installed.
+2025-12-09T11:11:23.9721322Z libxcb1 is already the newest version (1.15-1ubuntu2).
+2025-12-09T11:11:23.9721882Z libxcb1 set to manually installed.
+2025-12-09T11:11:23.9722547Z libxcomposite1 is already the newest version (1:0.4.5-1build3).
+2025-12-09T11:11:23.9723208Z libxcomposite1 set to manually installed.
+2025-12-09T11:11:23.9724070Z libxdamage1 is already the newest version (1:1.1.6-1build1).
+2025-12-09T11:11:23.9724697Z libxdamage1 set to manually installed.
+2025-12-09T11:11:23.9725322Z libxext6 is already the newest version (2:1.3.4-1build2).
+2025-12-09T11:11:23.9725913Z libxext6 set to manually installed.
+2025-12-09T11:11:23.9726896Z libxfixes3 is already the newest version (1:6.0.0-2build1).
+2025-12-09T11:11:23.9727543Z libxfixes3 set to manually installed.
+2025-12-09T11:11:23.9728204Z libxkbcommon0 is already the newest version (1.6.0-1build1).
+2025-12-09T11:11:23.9728854Z libxkbcommon0 set to manually installed.
+2025-12-09T11:11:23.9729513Z libxrandr2 is already the newest version (2:1.5.2-2build1).
+2025-12-09T11:11:23.9730123Z libxrandr2 set to manually installed.
+2025-12-09T11:11:23.9730814Z libcairo-gobject2 is already the newest version (1.18.0-3build1).
+2025-12-09T11:11:23.9731522Z libcairo-gobject2 set to manually installed.
+2025-12-09T11:11:23.9732248Z libfontconfig1 is already the newest version (2.15.0-1.1ubuntu2).
+2025-12-09T11:11:23.9732917Z libfontconfig1 set to manually installed.
+2025-12-09T11:11:23.9733632Z libfreetype6 is already the newest version (2.13.2+dfsg-1build3).
+2025-12-09T11:11:23.9734478Z libfreetype6 set to manually installed.
+2025-12-09T11:11:23.9735251Z libgdk-pixbuf-2.0-0 is already the newest version (2.42.10+dfsg-3ubuntu3.2).
+2025-12-09T11:11:23.9736021Z libgdk-pixbuf-2.0-0 set to manually installed.
+2025-12-09T11:11:23.9736747Z libgtk-3-0t64 is already the newest version (3.24.41-4ubuntu1.3).
+2025-12-09T11:11:23.9737399Z libgtk-3-0t64 set to manually installed.
+2025-12-09T11:11:23.9738129Z libpangocairo-1.0-0 is already the newest version (1.52.1+ds-1build1).
+2025-12-09T11:11:23.9738863Z libpangocairo-1.0-0 set to manually installed.
+2025-12-09T11:11:23.9739544Z libx11-xcb1 is already the newest version (2:1.8.7-1build1).
+2025-12-09T11:11:23.9740366Z libx11-xcb1 set to manually installed.
+2025-12-09T11:11:23.9740998Z libxcb-shm0 is already the newest version (1.15-1ubuntu2).
+2025-12-09T11:11:23.9741606Z libxcb-shm0 set to manually installed.
+2025-12-09T11:11:23.9742260Z libxcursor1 is already the newest version (1:1.2.1-1build1).
+2025-12-09T11:11:23.9742888Z libxcursor1 set to manually installed.
+2025-12-09T11:11:23.9743501Z libxi6 is already the newest version (2:1.8.1-1build1).
+2025-12-09T11:11:23.9744231Z libxi6 set to manually installed.
+2025-12-09T11:11:23.9744880Z libxrender1 is already the newest version (1:0.9.10-1.1build1).
+2025-12-09T11:11:23.9745531Z libxrender1 set to manually installed.
+2025-12-09T11:11:23.9746167Z libicu74 is already the newest version (74.2-1ubuntu3.1).
+2025-12-09T11:11:23.9746940Z libatomic1 is already the newest version (14.2.0-4ubuntu2~24.04).
+2025-12-09T11:11:23.9747558Z libatomic1 set to manually installed.
+2025-12-09T11:11:23.9748212Z libenchant-2-2 is already the newest version (2.3.3-2build2).
+2025-12-09T11:11:23.9748819Z libenchant-2-2 set to manually installed.
+2025-12-09T11:11:23.9749373Z libepoxy0 is already the newest version (1.5.10-1build1).
+2025-12-09T11:11:23.9749909Z libepoxy0 set to manually installed.
+2025-12-09T11:11:23.9750550Z libgstreamer1.0-0 is already the newest version (1.24.2-1ubuntu0.1).
+2025-12-09T11:11:23.9751227Z libgstreamer1.0-0 set to manually installed.
+2025-12-09T11:11:23.9751814Z libharfbuzz0b is already the newest version (8.3.0-2build2).
+2025-12-09T11:11:23.9752378Z libharfbuzz0b set to manually installed.
+2025-12-09T11:11:23.9752964Z libjpeg-turbo8 is already the newest version (2.1.5-2ubuntu2).
+2025-12-09T11:11:23.9753506Z libjpeg-turbo8 set to manually installed.
+2025-12-09T11:11:23.9754244Z liblcms2-2 is already the newest version (2.14-2build1).
+2025-12-09T11:11:23.9754745Z liblcms2-2 set to manually installed.
+2025-12-09T11:11:23.9755291Z libpng16-16t64 is already the newest version (1.6.43-5build1).
+2025-12-09T11:11:23.9755852Z libpng16-16t64 set to manually installed.
+2025-12-09T11:11:23.9756471Z libwayland-client0 is already the newest version (1.22.0-2.1build1).
+2025-12-09T11:11:23.9757200Z libwayland-client0 set to manually installed.
+2025-12-09T11:11:24.1206394Z libwayland-egl1 is already the newest version (1.22.0-2.1build1).
+2025-12-09T11:11:24.1207160Z libwayland-egl1 set to manually installed.
+2025-12-09T11:11:24.1207918Z libwayland-server0 is already the newest version (1.22.0-2.1build1).
+2025-12-09T11:11:24.1209172Z libwayland-server0 set to manually installed.
+2025-12-09T11:11:24.1209895Z libwebp7 is already the newest version (1.3.2-0.4build3).
+2025-12-09T11:11:24.1210506Z libwebp7 set to manually installed.
+2025-12-09T11:11:24.1211272Z libwebpdemux2 is already the newest version (1.3.2-0.4build3).
+2025-12-09T11:11:24.1211942Z libwebpdemux2 set to manually installed.
+2025-12-09T11:11:24.1212652Z libxml2 is already the newest version (2.9.14+dfsg-1.3ubuntu3.6).
+2025-12-09T11:11:24.1213292Z libxml2 set to manually installed.
+2025-12-09T11:11:24.1214249Z libxslt1.1 is already the newest version (1.1.39-0exp1ubuntu0.24.04.2).
+2025-12-09T11:11:24.1214919Z libxslt1.1 set to manually installed.
+2025-12-09T11:11:24.1215556Z xvfb is already the newest version (2:21.1.12-1ubuntu1.5).
+2025-12-09T11:11:24.1216420Z fonts-noto-color-emoji is already the newest version (2.047-0ubuntu0.24.04.1).
+2025-12-09T11:11:24.1217269Z fonts-liberation is already the newest version (1:2.1.5-3).
+2025-12-09T11:11:24.1217964Z fonts-liberation set to manually installed.
+2025-12-09T11:11:24.1218701Z The following additional packages will be installed:
+2025-12-09T11:11:24.1219379Z   gir1.2-glib-2.0 glib-networking glib-networking-common
+2025-12-09T11:11:24.1220308Z   glib-networking-services gsettings-desktop-schemas libaa1 libabsl20220623t64
+2025-12-09T11:11:24.1221276Z   libass9 libasyncns0 libavc1394-0 libavcodec60 libavfilter9 libavformat60
+2025-12-09T11:11:24.1222063Z   libavtp0 libavutil58 libblas3 libbluray2 libbs2b0 libcaca0
+2025-12-09T11:11:24.1223117Z   libcairo-script-interpreter2 libcdparanoia0 libchromaprint1 libcjson1
+2025-12-09T11:11:24.1224067Z   libcodec2-1.2 libdav1d7 libdc1394-25 libdca0 libdecor-0-0
+2025-12-09T11:11:24.1224517Z   libdirectfb-1.7-7t64 libdv4t64 libdvdnav4 libdvdread8t64 libegl-mesa0
+2025-12-09T11:11:24.1225080Z   libegl1 libfaad2 libflac12t64 libfluidsynth3 libfreeaptx0 libgav1-1
+2025-12-09T11:11:24.1225553Z   libglib2.0-bin libglib2.0-data libgme0 libgraphene-1.0-0 libgsm1
+2025-12-09T11:11:24.1226269Z   libgssdp-1.6-0 libgstreamer-plugins-good1.0-0 libgtk-4-common libgupnp-1.6-0
+2025-12-09T11:11:24.1226780Z   libgupnp-igd-1.6-0 libhwy1t64 libiec61883-0 libimath-3-1-29t64
+2025-12-09T11:11:24.1227231Z   libinstpatch-1.0-2 libjack-jackd2-0 libjxl0.7 liblapack3 liblc3-1
+2025-12-09T11:11:24.1227711Z   libldacbt-enc2 liblilv-0-0 liblrdf0 libltc11 libmbedcrypto7t64 libmfx1
+2025-12-09T11:11:24.1228669Z   libmjpegutils-2.1-0t64 libmodplug1 libmp3lame0 libmpcdec6
+2025-12-09T11:11:24.1229136Z   libmpeg2encpp-2.1-0t64 libmpg123-0t64 libmplex2-2.1-0t64 libmysofa1
+2025-12-09T11:11:24.1229648Z   libneon27t64 libnice10 libopenal-data libopenal1 libopenexr-3-1-30
+2025-12-09T11:11:24.1230096Z   libopenh264-7 libopenmpt0t64 libopenni2-0 liborc-0.4-0t64
+2025-12-09T11:11:24.1230538Z   libpipewire-0.3-0t64 libplacebo338 libpocketsphinx3 libpostproc57
+2025-12-09T11:11:24.1231034Z   libproxy1v5 libpulse0 libqrencode4 libraptor2-0 librav1e0 libraw1394-11
+2025-12-09T11:11:24.1231891Z   librist4 librsvg2-2 librubberband2 libsamplerate0 libsbc1 libsdl2-2.0-0
+2025-12-09T11:11:24.1232789Z   libsecret-common libserd-0-0 libshine3 libshout3 libsndfile1 libsndio7.0
+2025-12-09T11:11:24.1233834Z   libsord-0-0 libsoundtouch1 libsoup-3.0-0 libsoup-3.0-common libsoxr0
+2025-12-09T11:11:24.1234515Z   libspa-0.2-modules libspandsp2t64 libspeex1 libsphinxbase3t64 libsratom-0-0
+2025-12-09T11:11:24.1235025Z   libsrt1.5-gnutls libsrtp2-1 libssh-4 libssh-gcrypt-4 libsvtav1enc1d1
+2025-12-09T11:11:24.1235502Z   libswresample4 libswscale7 libtag1v5 libtag1v5-vanilla libtheora0
+2025-12-09T11:11:24.1235972Z   libtwolame0 libudfread0 libunibreak5 libv4l-0t64 libv4lconvert0t64
+2025-12-09T11:11:24.1236637Z   libva-drm2 libva-x11-2 libva2 libvdpau1 libvidstab1.1 libvisual-0.4-0
+2025-12-09T11:11:24.1237496Z   libvo-aacenc0 libvo-amrwbenc0 libvorbisenc2 libvpl2 libwavpack1
+2025-12-09T11:11:24.1238307Z   libwebrtc-audio-processing1 libwildmidi2 libx265-199 libxcb-xkb1
+2025-12-09T11:11:24.1238803Z   libxkbcommon-x11-0 libxvidcore4 libyuv0 libzbar0t64 libzimg2 libzix-0-0
+2025-12-09T11:11:24.1239489Z   libzvbi-common libzvbi0t64 libzxing3 ocl-icd-libopencl1 session-migration
+2025-12-09T11:11:24.1239958Z   timgm6mb-soundfont xfonts-encodings xfonts-utils
+2025-12-09T11:11:24.1240263Z Suggested packages:
+2025-12-09T11:11:24.1240622Z   frei0r-plugins gvfs libcuda1 libnvcuvid1 libnvidia-encode1 libbluray-bdj
+2025-12-09T11:11:24.1241415Z   cups-common libdirectfb-extra libdv-bin oss-compat libdvdcss2
+2025-12-09T11:11:24.1242319Z   low-memory-monitor libvisual-0.4-plugins jackd2 liblrdf0-dev libportaudio2
+2025-12-09T11:11:24.1243286Z   opus-tools pipewire pulseaudio raptor2-utils libraw1394-doc librsvg2-bin
+2025-12-09T11:11:24.1244378Z   serdi sndiod sordi speex libwildmidi-config opencl-icd fluid-soundfont-gm
+2025-12-09T11:11:24.1245068Z Recommended packages:
+2025-12-09T11:11:24.1245618Z   fonts-ipafont-mincho fonts-tlwg-loma gstreamer1.0-x libaacs0
+2025-12-09T11:11:24.1246440Z   default-libdecor-0-plugin-1 | libdecor-0-plugin-1 gstreamer1.0-gl
+2025-12-09T11:11:24.1247369Z   libgtk-4-bin librsvg2-common libgtk-4-media-gstreamer libpipewire-0.3-common
+2025-12-09T11:11:24.1248328Z   pocketsphinx-en-us va-driver-all | va-driver vdpau-driver-all | vdpau-driver
+2025-12-09T11:11:24.1275372Z   libmagickcore-6.q16-7-extra
+2025-12-09T11:11:24.2003022Z The following NEW packages will be installed:
+2025-12-09T11:11:24.2004107Z   fonts-freefont-ttf fonts-ipafont-gothic fonts-tlwg-loma-otf fonts-unifont
+2025-12-09T11:11:24.2004996Z   fonts-wqy-zenhei glib-networking glib-networking-common
+2025-12-09T11:11:24.2006264Z   glib-networking-services gsettings-desktop-schemas gstreamer1.0-libav
+2025-12-09T11:11:24.2007312Z   gstreamer1.0-plugins-bad gstreamer1.0-plugins-base gstreamer1.0-plugins-good
+2025-12-09T11:11:24.2008339Z   libaa1 libabsl20220623t64 libass9 libasyncns0 libavc1394-0 libavcodec60
+2025-12-09T11:11:24.2009252Z   libavfilter9 libavformat60 libavif16 libavtp0 libavutil58 libblas3
+2025-12-09T11:11:24.2010168Z   libbluray2 libbs2b0 libcaca0 libcairo-script-interpreter2 libcdparanoia0
+2025-12-09T11:11:24.2011173Z   libchromaprint1 libcjson1 libcodec2-1.2 libdav1d7 libdc1394-25 libdca0
+2025-12-09T11:11:24.2012090Z   libdecor-0-0 libdirectfb-1.7-7t64 libdv4t64 libdvdnav4 libdvdread8t64
+2025-12-09T11:11:24.2012988Z   libegl-mesa0 libegl1 libevent-2.1-7t64 libfaad2 libflac12t64 libflite1
+2025-12-09T11:11:24.2014085Z   libfluidsynth3 libfreeaptx0 libgav1-1 libgles2 libgme0 libgraphene-1.0-0
+2025-12-09T11:11:24.2015008Z   libgsm1 libgssdp-1.6-0 libgstreamer-gl1.0-0 libgstreamer-plugins-bad1.0-0
+2025-12-09T11:11:24.2015944Z   libgstreamer-plugins-base1.0-0 libgstreamer-plugins-good1.0-0 libgtk-4-1
+2025-12-09T11:11:24.2016873Z   libgtk-4-common libgupnp-1.6-0 libgupnp-igd-1.6-0 libharfbuzz-icu0
+2025-12-09T11:11:24.2017790Z   libhwy1t64 libhyphen0 libiec61883-0 libimath-3-1-29t64 libinstpatch-1.0-2
+2025-12-09T11:11:24.2018672Z   libjack-jackd2-0 libjxl0.7 liblapack3 liblc3-1 libldacbt-enc2 liblilv-0-0
+2025-12-09T11:11:24.2019484Z   liblrdf0 libltc11 libmanette-0.2-0 libmbedcrypto7t64 libmfx1
+2025-12-09T11:11:24.2020209Z   libmjpegutils-2.1-0t64 libmodplug1 libmp3lame0 libmpcdec6
+2025-12-09T11:11:24.2020978Z   libmpeg2encpp-2.1-0t64 libmpg123-0t64 libmplex2-2.1-0t64 libmysofa1
+2025-12-09T11:11:24.2021783Z   libneon27t64 libnice10 libopenal-data libopenal1 libopenexr-3-1-30
+2025-12-09T11:11:24.2022656Z   libopenh264-7 libopenmpt0t64 libopenni2-0 libopus0 liborc-0.4-0t64
+2025-12-09T11:11:24.2023510Z   libpipewire-0.3-0t64 libplacebo338 libpocketsphinx3 libpostproc57
+2025-12-09T11:11:24.2024506Z   libproxy1v5 libpulse0 libqrencode4 libraptor2-0 librav1e0 libraw1394-11
+2025-12-09T11:11:24.2025450Z   librist4 librsvg2-2 librubberband2 libsamplerate0 libsbc1 libsdl2-2.0-0
+2025-12-09T11:11:24.2026311Z   libsecret-1-0 libsecret-common libserd-0-0 libshine3 libshout3 libsndfile1
+2025-12-09T11:11:24.2027160Z   libsndio7.0 libsord-0-0 libsoundtouch1 libsoup-3.0-0 libsoup-3.0-common
+2025-12-09T11:11:24.2028009Z   libsoxr0 libspa-0.2-modules libspandsp2t64 libspeex1 libsphinxbase3t64
+2025-12-09T11:11:24.2029075Z   libsratom-0-0 libsrt1.5-gnutls libsrtp2-1 libssh-gcrypt-4 libsvtav1enc1d1
+2025-12-09T11:11:24.2029922Z   libswresample4 libswscale7 libtag1v5 libtag1v5-vanilla libtheora0
+2025-12-09T11:11:24.2030805Z   libtwolame0 libudfread0 libunibreak5 libv4l-0t64 libv4lconvert0t64
+2025-12-09T11:11:24.2031635Z   libva-drm2 libva-x11-2 libva2 libvdpau1 libvidstab1.1 libvisual-0.4-0
+2025-12-09T11:11:24.2032535Z   libvo-aacenc0 libvo-amrwbenc0 libvorbisenc2 libvpl2 libvpx9 libwavpack1
+2025-12-09T11:11:24.2033398Z   libwebrtc-audio-processing1 libwildmidi2 libwoff1 libx264-164 libx265-199
+2025-12-09T11:11:24.2034446Z   libxcb-xkb1 libxkbcommon-x11-0 libxvidcore4 libyuv0 libzbar0t64 libzimg2
+2025-12-09T11:11:24.2035313Z   libzix-0-0 libzvbi-common libzvbi0t64 libzxing3 ocl-icd-libopencl1
+2025-12-09T11:11:24.2036178Z   session-migration timgm6mb-soundfont xfonts-cyrillic xfonts-encodings
+2025-12-09T11:11:24.2036879Z   xfonts-scalable xfonts-utils
+2025-12-09T11:11:24.2037418Z The following packages will be upgraded:
+2025-12-09T11:11:24.2038159Z   gir1.2-glib-2.0 libcups2t64 libglib2.0-0t64 libglib2.0-bin libglib2.0-data
+2025-12-09T11:11:24.2038748Z   libssh-4
+2025-12-09T11:11:24.2251657Z 6 upgraded, 179 newly installed, 0 to remove and 51 not upgraded.
+2025-12-09T11:11:24.2252115Z Need to get 116 MB of archives.
+2025-12-09T11:11:24.2252510Z After this operation, 363 MB of additional disk space will be used.
+2025-12-09T11:11:24.2253206Z Get:1 file:/etc/apt/apt-mirrors.txt Mirrorlist [144 B]
+2025-12-09T11:11:24.3064724Z Get:2 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 fonts-ipafont-gothic all 00303-21ubuntu1 [3513 kB]
+2025-12-09T11:11:24.4397501Z Get:3 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libglib2.0-data all 2.80.0-6ubuntu3.5 [48.8 kB]
+2025-12-09T11:11:24.5057988Z Get:4 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libglib2.0-bin amd64 2.80.0-6ubuntu3.5 [97.9 kB]
+2025-12-09T11:11:24.5715850Z Get:5 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 gir1.2-glib-2.0 amd64 2.80.0-6ubuntu3.5 [183 kB]
+2025-12-09T11:11:24.6380151Z Get:6 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libglib2.0-0t64 amd64 2.80.0-6ubuntu3.5 [1544 kB]
+2025-12-09T11:11:24.7175432Z Get:7 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 fonts-freefont-ttf all 20211204+svn4273-2 [5641 kB]
+2025-12-09T11:11:24.8663179Z Get:8 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 fonts-tlwg-loma-otf all 1:0.7.3-1 [107 kB]
+2025-12-09T11:11:24.9322707Z Get:9 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 fonts-unifont all 1:15.1.01-1build1 [2993 kB]
+2025-12-09T11:11:25.0216987Z Get:10 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 fonts-wqy-zenhei all 0.9.45-8 [7472 kB]
+2025-12-09T11:11:25.2249033Z Get:11 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libproxy1v5 amd64 0.5.4-4build1 [26.5 kB]
+2025-12-09T11:11:25.2907408Z Get:12 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 glib-networking-common all 2.80.0-1build1 [6702 B]
+2025-12-09T11:11:25.3566951Z Get:13 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 glib-networking-services amd64 2.80.0-1build1 [12.8 kB]
+2025-12-09T11:11:25.4215653Z Get:14 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 session-migration amd64 0.3.9build1 [9034 B]
+2025-12-09T11:11:25.4862119Z Get:15 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 gsettings-desktop-schemas all 46.1-0ubuntu1 [35.6 kB]
+2025-12-09T11:11:25.5516041Z Get:16 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 glib-networking amd64 2.80.0-1build1 [64.1 kB]
+2025-12-09T11:11:25.6171494Z Get:17 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libva2 amd64 2.20.0-2build1 [66.2 kB]
+2025-12-09T11:11:25.6823995Z Get:18 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libva-drm2 amd64 2.20.0-2build1 [7124 B]
+2025-12-09T11:11:25.7477834Z Get:19 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libva-x11-2 amd64 2.20.0-2build1 [12.0 kB]
+2025-12-09T11:11:25.8141625Z Get:20 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libvdpau1 amd64 1.5-2build1 [27.8 kB]
+2025-12-09T11:11:25.8792347Z Get:21 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libvpl2 amd64 2023.3.0-1build1 [99.8 kB]
+2025-12-09T11:11:25.9453455Z Get:22 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 ocl-icd-libopencl1 amd64 2.3.2-1build1 [38.5 kB]
+2025-12-09T11:11:26.0106382Z Get:23 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libavutil58 amd64 7:6.1.1-3ubuntu5 [401 kB]
+2025-12-09T11:11:26.0823887Z Get:24 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libcodec2-1.2 amd64 1.2.0-2build1 [8998 kB]
+2025-12-09T11:11:26.3776730Z Get:25 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libdav1d7 amd64 1.4.1-1build1 [604 kB]
+2025-12-09T11:11:26.4555759Z Get:26 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libgsm1 amd64 1.0.22-1build1 [27.8 kB]
+2025-12-09T11:11:26.5209362Z Get:27 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libhwy1t64 amd64 1.0.7-8.1build1 [584 kB]
+2025-12-09T11:11:26.5969408Z Get:28 http://azure.archive.ubuntu.com/ubuntu noble-updates/universe amd64 libjxl0.7 amd64 0.7.0-10.2ubuntu6.1 [1001 kB]
+2025-12-09T11:11:26.6799814Z Get:29 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libmp3lame0 amd64 3.100-6build1 [142 kB]
+2025-12-09T11:11:26.7463610Z Get:30 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libopus0 amd64 1.4-1build1 [208 kB]
+2025-12-09T11:11:26.8138550Z Get:31 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 librav1e0 amd64 0.7.1-2 [1022 kB]
+2025-12-09T11:11:26.8980648Z Get:32 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 librsvg2-2 amd64 2.58.0+dfsg-1build1 [2135 kB]
+2025-12-09T11:11:27.0054000Z Get:33 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libshine3 amd64 3.1.1-2build1 [23.2 kB]
+2025-12-09T11:11:27.0703599Z Get:34 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libspeex1 amd64 1.2.1-2ubuntu2.24.04.1 [59.6 kB]
+2025-12-09T11:11:27.1424320Z Get:35 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libsvtav1enc1d1 amd64 1.7.0+dfsg-2build1 [2425 kB]
+2025-12-09T11:11:27.2521345Z Get:36 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libsoxr0 amd64 0.1.3-4build3 [80.0 kB]
+2025-12-09T11:11:27.3179242Z Get:37 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libswresample4 amd64 7:6.1.1-3ubuntu5 [63.8 kB]
+2025-12-09T11:11:27.3838527Z Get:38 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libtheora0 amd64 1.1.1+dfsg.1-16.1build3 [211 kB]
+2025-12-09T11:11:27.4524627Z Get:39 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libtwolame0 amd64 0.4.0-2build3 [52.3 kB]
+2025-12-09T11:11:27.5183934Z Get:40 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libvorbisenc2 amd64 1.3.7-1build3 [80.8 kB]
+2025-12-09T11:11:27.5847011Z Get:41 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libvpx9 amd64 1.14.0-1ubuntu2.2 [1143 kB]
+2025-12-09T11:11:27.6717131Z Get:42 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libx264-164 amd64 2:0.164.3108+git31e19f9-1 [604 kB]
+2025-12-09T11:11:27.7508993Z Get:43 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libx265-199 amd64 3.5-2build1 [1226 kB]
+2025-12-09T11:11:27.8373089Z Get:44 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libxvidcore4 amd64 2:1.3.7-1build1 [219 kB]
+2025-12-09T11:11:27.9060980Z Get:45 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libzvbi-common all 0.2.42-2 [42.4 kB]
+2025-12-09T11:11:27.9734770Z Get:46 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libzvbi0t64 amd64 0.2.42-2 [261 kB]
+2025-12-09T11:11:28.0428389Z Get:47 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libavcodec60 amd64 7:6.1.1-3ubuntu5 [5851 kB]
+2025-12-09T11:11:28.2260906Z Get:48 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libunibreak5 amd64 5.1-2build1 [25.0 kB]
+2025-12-09T11:11:28.2923378Z Get:49 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libass9 amd64 1:0.17.1-2build1 [104 kB]
+2025-12-09T11:11:28.3585666Z Get:50 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libudfread0 amd64 1.1.2-1build1 [19.0 kB]
+2025-12-09T11:11:28.4446699Z Get:51 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libbluray2 amd64 1:1.3.4-1build1 [159 kB]
+2025-12-09T11:11:28.5137982Z Get:52 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libchromaprint1 amd64 1.5.1-5 [30.5 kB]
+2025-12-09T11:11:28.5797385Z Get:53 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libgme0 amd64 0.6.3-7build1 [134 kB]
+2025-12-09T11:11:28.6471752Z Get:54 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libmpg123-0t64 amd64 1.32.5-1ubuntu1.1 [169 kB]
+2025-12-09T11:11:28.7141201Z Get:55 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libopenmpt0t64 amd64 0.7.3-1.1build3 [647 kB]
+2025-12-09T11:11:28.7916125Z Get:56 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libcjson1 amd64 1.7.17-1 [24.8 kB]
+2025-12-09T11:11:28.8590187Z Get:57 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libmbedcrypto7t64 amd64 2.28.8-1 [209 kB]
+2025-12-09T11:11:28.9270118Z Get:58 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 librist4 amd64 0.2.10+dfsg-2 [74.9 kB]
+2025-12-09T11:11:28.9933151Z Get:59 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libsrt1.5-gnutls amd64 1.5.3-1build2 [316 kB]
+2025-12-09T11:11:29.0805783Z Get:60 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libssh-gcrypt-4 amd64 0.10.6-2ubuntu0.2 [224 kB]
+2025-12-09T11:11:29.1532454Z Get:61 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libavformat60 amd64 7:6.1.1-3ubuntu5 [1153 kB]
+2025-12-09T11:11:29.2416807Z Get:62 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libbs2b0 amd64 3.1.0+dfsg-7build1 [10.6 kB]
+2025-12-09T11:11:29.3071559Z Get:63 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libflite1 amd64 2.2-6build3 [13.6 MB]
+2025-12-09T11:11:29.6744724Z Get:64 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libserd-0-0 amd64 0.32.2-1 [43.6 kB]
+2025-12-09T11:11:29.7402343Z Get:65 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libzix-0-0 amd64 0.4.2-2build1 [23.6 kB]
+2025-12-09T11:11:29.8080629Z Get:66 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libsord-0-0 amd64 0.16.16-2build1 [15.8 kB]
+2025-12-09T11:11:29.8735168Z Get:67 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libsratom-0-0 amd64 0.6.16-1build1 [17.3 kB]
+2025-12-09T11:11:29.9394219Z Get:68 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 liblilv-0-0 amd64 0.24.22-1build1 [41.0 kB]
+2025-12-09T11:11:30.0051840Z Get:69 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libmysofa1 amd64 1.3.2+dfsg-2ubuntu2 [1158 kB]
+2025-12-09T11:11:30.0870583Z Get:70 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libplacebo338 amd64 6.338.2-2build1 [2654 kB]
+2025-12-09T11:11:30.1951316Z Get:71 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libblas3 amd64 3.12.0-3build1.1 [238 kB]
+2025-12-09T11:11:30.2755142Z Get:72 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 liblapack3 amd64 3.12.0-3build1.1 [2646 kB]
+2025-12-09T11:11:30.4000460Z Get:73 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libasyncns0 amd64 0.8-6build4 [11.3 kB]
+2025-12-09T11:11:30.4654199Z Get:74 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libflac12t64 amd64 1.4.3+ds-2.1ubuntu2 [197 kB]
+2025-12-09T11:11:30.5341940Z Get:75 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libsndfile1 amd64 1.2.2-1ubuntu5.24.04.1 [209 kB]
+2025-12-09T11:11:30.6026315Z Get:76 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libpulse0 amd64 1:16.1+dfsg1-2ubuntu10.1 [292 kB]
+2025-12-09T11:11:30.6709063Z Get:77 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libsphinxbase3t64 amd64 0.8+5prealpha+1-17build2 [126 kB]
+2025-12-09T11:11:30.7376790Z Get:78 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libpocketsphinx3 amd64 0.8.0+real5prealpha+1-15ubuntu5 [133 kB]
+2025-12-09T11:11:30.8046195Z Get:79 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libpostproc57 amd64 7:6.1.1-3ubuntu5 [49.9 kB]
+2025-12-09T11:11:30.8708316Z Get:80 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libsamplerate0 amd64 0.2.2-4build1 [1344 kB]
+2025-12-09T11:11:30.9553363Z Get:81 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 librubberband2 amd64 3.3.0+dfsg-2build1 [130 kB]
+2025-12-09T11:11:31.0224685Z Get:82 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libswscale7 amd64 7:6.1.1-3ubuntu5 [193 kB]
+2025-12-09T11:11:31.0896434Z Get:83 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libvidstab1.1 amd64 1.1.0-2build1 [38.5 kB]
+2025-12-09T11:11:31.1556148Z Get:84 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libzimg2 amd64 3.0.5+ds1-1build1 [254 kB]
+2025-12-09T11:11:31.2230202Z Get:85 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libavfilter9 amd64 7:6.1.1-3ubuntu5 [4235 kB]
+2025-12-09T11:11:31.3690426Z Get:86 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 liborc-0.4-0t64 amd64 1:0.4.38-1ubuntu0.1 [207 kB]
+2025-12-09T11:11:31.4359221Z Get:87 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libgstreamer-plugins-base1.0-0 amd64 1.24.2-1ubuntu0.3 [862 kB]
+2025-12-09T11:11:31.5102949Z Get:88 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 gstreamer1.0-libav amd64 1.24.1-1build1 [103 kB]
+2025-12-09T11:11:31.5767460Z Get:89 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libcdparanoia0 amd64 3.10.2+debian-14build3 [48.5 kB]
+2025-12-09T11:11:31.6425344Z Get:90 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libvisual-0.4-0 amd64 0.4.2-2build1 [115 kB]
+2025-12-09T11:11:31.7090972Z Get:91 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 gstreamer1.0-plugins-base amd64 1.24.2-1ubuntu0.3 [721 kB]
+2025-12-09T11:11:31.7814649Z Get:92 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libaa1 amd64 1.4p5-51.1 [49.9 kB]
+2025-12-09T11:11:31.8597389Z Get:93 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libraw1394-11 amd64 2.1.2-2build3 [26.2 kB]
+2025-12-09T11:11:31.9258463Z Get:94 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libavc1394-0 amd64 0.5.4-5build3 [15.4 kB]
+2025-12-09T11:11:31.9922265Z Get:95 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libcaca0 amd64 0.99.beta20-4build2 [208 kB]
+2025-12-09T11:11:32.0605406Z Get:96 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libdv4t64 amd64 1.0.0-17.1build1 [63.2 kB]
+2025-12-09T11:11:32.1269959Z Get:97 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libgstreamer-plugins-good1.0-0 amd64 1.24.2-1ubuntu1.2 [33.0 kB]
+2025-12-09T11:11:32.1926362Z Get:98 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libiec61883-0 amd64 1.2.0-6build1 [24.5 kB]
+2025-12-09T11:11:32.2587994Z Get:99 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libshout3 amd64 2.4.6-1build2 [50.3 kB]
+2025-12-09T11:11:32.3250724Z Get:100 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libtag1v5-vanilla amd64 1.13.1-1build1 [326 kB]
+2025-12-09T11:11:32.3975469Z Get:101 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libtag1v5 amd64 1.13.1-1build1 [11.7 kB]
+2025-12-09T11:11:32.4661232Z Get:102 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libv4lconvert0t64 amd64 1.26.1-4build3 [87.6 kB]
+2025-12-09T11:11:32.5406013Z Get:103 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libv4l-0t64 amd64 1.26.1-4build3 [46.9 kB]
+2025-12-09T11:11:32.6144542Z Get:104 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libwavpack1 amd64 5.6.0-1build1 [84.6 kB]
+2025-12-09T11:11:32.6873415Z Get:105 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libsoup-3.0-common all 3.4.4-5ubuntu0.5 [11.3 kB]
+2025-12-09T11:11:32.7565564Z Get:106 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libsoup-3.0-0 amd64 3.4.4-5ubuntu0.5 [291 kB]
+2025-12-09T11:11:32.8311591Z Get:107 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 gstreamer1.0-plugins-good amd64 1.24.2-1ubuntu1.2 [2238 kB]
+2025-12-09T11:11:32.9371282Z Get:108 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libabsl20220623t64 amd64 20220623.1-3.1ubuntu3.2 [423 kB]
+2025-12-09T11:11:33.0145143Z Get:109 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libgav1-1 amd64 0.18.0-1build3 [357 kB]
+2025-12-09T11:11:33.0882531Z Get:110 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libyuv0 amd64 0.0~git202401110.af6ac82-1 [178 kB]
+2025-12-09T11:11:33.1595165Z Get:111 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libavif16 amd64 1.0.4-1ubuntu3 [91.2 kB]
+2025-12-09T11:11:33.2272434Z Get:112 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libavtp0 amd64 0.2.0-1build1 [6414 B]
+2025-12-09T11:11:33.2924472Z Get:113 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libcairo-script-interpreter2 amd64 1.18.0-3build1 [60.3 kB]
+2025-12-09T11:11:33.3582994Z Get:114 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libcups2t64 amd64 2.4.7-1.2ubuntu7.9 [273 kB]
+2025-12-09T11:11:33.4291446Z Get:115 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libdc1394-25 amd64 2.2.6-4build1 [90.1 kB]
+2025-12-09T11:11:33.4953950Z Get:116 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libdecor-0-0 amd64 0.2.2-1build2 [16.5 kB]
+2025-12-09T11:11:33.5609334Z Get:117 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libgles2 amd64 1.7.0-1build1 [17.1 kB]
+2025-12-09T11:11:33.6263433Z Get:118 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libdirectfb-1.7-7t64 amd64 1.7.7-11.1ubuntu2 [1035 kB]
+2025-12-09T11:11:33.7179663Z Get:119 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libdvdread8t64 amd64 6.1.3-1.1build1 [54.7 kB]
+2025-12-09T11:11:33.7835914Z Get:120 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libdvdnav4 amd64 6.1.1-3build1 [39.5 kB]
+2025-12-09T11:11:33.8499422Z Get:121 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libegl-mesa0 amd64 25.0.7-0ubuntu0.24.04.2 [124 kB]
+2025-12-09T11:11:33.9162816Z Get:122 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libevent-2.1-7t64 amd64 2.1.12-stable-9ubuntu2 [145 kB]
+2025-12-09T11:11:33.9876145Z Get:123 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libfaad2 amd64 2.11.1-1build1 [207 kB]
+2025-12-09T11:11:34.0566671Z Get:124 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libinstpatch-1.0-2 amd64 1.1.6-1build2 [251 kB]
+2025-12-09T11:11:34.1366372Z Get:125 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libjack-jackd2-0 amd64 1.9.21~dfsg-3ubuntu3 [289 kB]
+2025-12-09T11:11:34.2123553Z Get:126 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libwebrtc-audio-processing1 amd64 0.3.1-0ubuntu6 [290 kB]
+2025-12-09T11:11:34.2858099Z Get:127 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libspa-0.2-modules amd64 1.0.5-1ubuntu3.1 [626 kB]
+2025-12-09T11:11:34.3681845Z Get:128 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libpipewire-0.3-0t64 amd64 1.0.5-1ubuntu3.1 [252 kB]
+2025-12-09T11:11:34.4403411Z Get:129 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libsdl2-2.0-0 amd64 2.30.0+dfsg-1ubuntu3.1 [686 kB]
+2025-12-09T11:11:34.5332711Z Get:130 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 timgm6mb-soundfont all 1.3-5 [5427 kB]
+2025-12-09T11:11:34.7299718Z Get:131 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libfluidsynth3 amd64 2.3.4-1build3 [249 kB]
+2025-12-09T11:11:34.8049695Z Get:132 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libfreeaptx0 amd64 0.1.1-2build1 [13.5 kB]
+2025-12-09T11:11:34.8738792Z Get:133 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libgraphene-1.0-0 amd64 1.10.8-3build2 [46.2 kB]
+2025-12-09T11:11:34.9441434Z Get:134 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libgssdp-1.6-0 amd64 1.6.3-1build3 [40.4 kB]
+2025-12-09T11:11:35.0139529Z Get:135 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libegl1 amd64 1.7.0-1build1 [28.7 kB]
+2025-12-09T11:11:35.0834921Z Get:136 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libgstreamer-gl1.0-0 amd64 1.24.2-1ubuntu0.3 [214 kB]
+2025-12-09T11:11:35.1568039Z Get:137 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libgtk-4-common all 4.14.5+ds-0ubuntu0.7 [1496 kB]
+2025-12-09T11:11:35.2392222Z Get:138 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libgtk-4-1 amd64 4.14.5+ds-0ubuntu0.7 [3294 kB]
+2025-12-09T11:11:35.3815989Z Get:139 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libgupnp-1.6-0 amd64 1.6.6-1build3 [92.7 kB]
+2025-12-09T11:11:35.4522272Z Get:140 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libgupnp-igd-1.6-0 amd64 1.6.0-3build3 [16.5 kB]
+2025-12-09T11:11:35.5217861Z Get:141 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libharfbuzz-icu0 amd64 8.3.0-2build2 [13.3 kB]
+2025-12-09T11:11:35.5910351Z Get:142 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libhyphen0 amd64 2.8.8-7build3 [26.5 kB]
+2025-12-09T11:11:35.6608814Z Get:143 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libimath-3-1-29t64 amd64 3.1.9-3.1ubuntu2 [72.2 kB]
+2025-12-09T11:11:35.7307873Z Get:144 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 liblc3-1 amd64 1.0.4-3build1 [69.7 kB]
+2025-12-09T11:11:35.8005466Z Get:145 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libldacbt-enc2 amd64 2.0.2.3+git20200429+ed310a0-4ubuntu2 [27.1 kB]
+2025-12-09T11:11:35.8711806Z Get:146 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libraptor2-0 amd64 2.0.16-3ubuntu0.1 [165 kB]
+2025-12-09T11:11:35.9415549Z Get:147 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 liblrdf0 amd64 0.6.1-4build1 [18.5 kB]
+2025-12-09T11:11:36.0108464Z Get:148 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libltc11 amd64 1.3.2-1build1 [13.0 kB]
+2025-12-09T11:11:36.0799321Z Get:149 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libmanette-0.2-0 amd64 0.2.7-1build2 [30.6 kB]
+2025-12-09T11:11:36.1490445Z Get:150 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libmfx1 amd64 22.5.4-1 [3124 kB]
+2025-12-09T11:11:36.2930240Z Get:151 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libmjpegutils-2.1-0t64 amd64 1:2.1.0+debian-8.1build1 [25.5 kB]
+2025-12-09T11:11:36.3625108Z Get:152 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libmodplug1 amd64 1:0.8.9.0-3build1 [166 kB]
+2025-12-09T11:11:36.4350170Z Get:153 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libmpcdec6 amd64 2:0.1~r495-2build1 [32.7 kB]
+2025-12-09T11:11:36.5046281Z Get:154 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libmpeg2encpp-2.1-0t64 amd64 1:2.1.0+debian-8.1build1 [75.6 kB]
+2025-12-09T11:11:36.5724953Z Get:155 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libmplex2-2.1-0t64 amd64 1:2.1.0+debian-8.1build1 [46.1 kB]
+2025-12-09T11:11:36.6439306Z Get:156 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libneon27t64 amd64 0.33.0-1.1build3 [102 kB]
+2025-12-09T11:11:36.7136984Z Get:157 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libnice10 amd64 0.1.21-2build3 [157 kB]
+2025-12-09T11:11:36.7852746Z Get:158 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libopenal-data all 1:1.23.1-4build1 [161 kB]
+2025-12-09T11:11:36.8562977Z Get:159 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libopenexr-3-1-30 amd64 3.1.5-5.1build3 [1004 kB]
+2025-12-09T11:11:36.9400538Z Get:160 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libopenh264-7 amd64 2.4.1+dfsg-1 [409 kB]
+2025-12-09T11:11:37.0252637Z Get:161 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libopenni2-0 amd64 2.2.0.33+dfsg-18 [370 kB]
+2025-12-09T11:11:37.1062435Z Get:162 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libqrencode4 amd64 4.1.1-1build2 [25.0 kB]
+2025-12-09T11:11:37.1762113Z Get:163 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libsecret-common all 0.21.4-1build3 [4962 B]
+2025-12-09T11:11:37.2452642Z Get:164 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libsecret-1-0 amd64 0.21.4-1build3 [116 kB]
+2025-12-09T11:11:37.3171791Z Get:165 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libsndio7.0 amd64 1.9.0-0.3build3 [29.6 kB]
+2025-12-09T11:11:37.3869543Z Get:166 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libsoundtouch1 amd64 2.3.2+ds1-1build1 [60.5 kB]
+2025-12-09T11:11:37.4575442Z Get:167 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libspandsp2t64 amd64 0.0.6+dfsg-2.1build1 [311 kB]
+2025-12-09T11:11:37.5376385Z Get:168 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libsrtp2-1 amd64 2.5.0-3build1 [41.9 kB]
+2025-12-09T11:11:37.6105456Z Get:169 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libssh-4 amd64 0.10.6-2ubuntu0.2 [188 kB]
+2025-12-09T11:11:37.6836894Z Get:170 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libwildmidi2 amd64 0.4.3-1build3 [68.5 kB]
+2025-12-09T11:11:37.7555575Z Get:171 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libwoff1 amd64 1.0.2-2build1 [45.3 kB]
+2025-12-09T11:11:37.8299093Z Get:172 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libxcb-xkb1 amd64 1.15-1ubuntu2 [32.3 kB]
+2025-12-09T11:11:37.8996408Z Get:173 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libxkbcommon-x11-0 amd64 1.6.0-1build1 [14.5 kB]
+2025-12-09T11:11:37.9688323Z Get:174 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libzbar0t64 amd64 0.23.93-4build3 [123 kB]
+2025-12-09T11:11:38.0418833Z Get:175 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libzxing3 amd64 2.2.1-3 [583 kB]
+2025-12-09T11:11:38.1193002Z Get:176 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 xfonts-encodings all 1:1.0.5-0ubuntu2 [578 kB]
+2025-12-09T11:11:38.2237360Z Get:177 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 xfonts-utils amd64 1:7.7+6build3 [94.4 kB]
+2025-12-09T11:11:38.2938118Z Get:178 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 xfonts-cyrillic all 1:1.0.5+nmu1 [384 kB]
+2025-12-09T11:11:38.3817733Z Get:179 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 xfonts-scalable all 1:1.0.3-1.3 [304 kB]
+2025-12-09T11:11:38.4647437Z Get:180 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libgstreamer-plugins-bad1.0-0 amd64 1.24.2-1ubuntu4 [797 kB]
+2025-12-09T11:11:38.5788437Z Get:181 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libdca0 amd64 0.0.7-2build1 [93.8 kB]
+2025-12-09T11:11:38.6480206Z Get:182 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libopenal1 amd64 1:1.23.1-4build1 [540 kB]
+2025-12-09T11:11:38.7390253Z Get:183 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libsbc1 amd64 2.0-1build1 [33.9 kB]
+2025-12-09T11:11:38.8047906Z Get:184 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libvo-aacenc0 amd64 0.1.3-2build1 [67.8 kB]
+2025-12-09T11:11:38.8718397Z Get:185 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libvo-amrwbenc0 amd64 0.1.3-2build1 [76.7 kB]
+2025-12-09T11:11:38.9412462Z Get:186 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 gstreamer1.0-plugins-bad amd64 1.24.2-1ubuntu4 [3081 kB]
+2025-12-09T11:11:39.5480439Z Fetched 116 MB in 15s (7809 kB/s)
+2025-12-09T11:11:39.5773190Z Selecting previously unselected package fonts-ipafont-gothic.
+2025-12-09T11:11:39.6100315Z (Reading database ... 
+2025-12-09T11:11:39.6100869Z (Reading database ... 5%
+2025-12-09T11:11:39.6101402Z (Reading database ... 10%
+2025-12-09T11:11:39.6101917Z (Reading database ... 15%
+2025-12-09T11:11:39.6102426Z (Reading database ... 20%
+2025-12-09T11:11:39.6102924Z (Reading database ... 25%
+2025-12-09T11:11:39.6103466Z (Reading database ... 30%
+2025-12-09T11:11:39.6104175Z (Reading database ... 35%
+2025-12-09T11:11:39.6104659Z (Reading database ... 40%
+2025-12-09T11:11:39.6104982Z (Reading database ... 45%
+2025-12-09T11:11:39.6105306Z (Reading database ... 50%
+2025-12-09T11:11:39.6204115Z (Reading database ... 55%
+2025-12-09T11:11:39.7464451Z (Reading database ... 60%
+2025-12-09T11:11:39.8896286Z (Reading database ... 65%
+2025-12-09T11:11:39.9361037Z (Reading database ... 70%
+2025-12-09T11:11:40.0196078Z (Reading database ... 75%
+2025-12-09T11:11:40.2085394Z (Reading database ... 80%
+2025-12-09T11:11:40.3100445Z (Reading database ... 85%
+2025-12-09T11:11:40.4801280Z (Reading database ... 90%
+2025-12-09T11:11:40.6672545Z (Reading database ... 95%
+2025-12-09T11:11:40.6673059Z (Reading database ... 100%
+2025-12-09T11:11:40.6674063Z (Reading database ... 217049 files and directories currently installed.)
+2025-12-09T11:11:40.6717340Z Preparing to unpack .../000-fonts-ipafont-gothic_00303-21ubuntu1_all.deb ...
+2025-12-09T11:11:40.6809321Z Unpacking fonts-ipafont-gothic (00303-21ubuntu1) ...
+2025-12-09T11:11:40.9192599Z Preparing to unpack .../001-libglib2.0-data_2.80.0-6ubuntu3.5_all.deb ...
+2025-12-09T11:11:40.9215693Z Unpacking libglib2.0-data (2.80.0-6ubuntu3.5) over (2.80.0-6ubuntu3.4) ...
+2025-12-09T11:11:40.9566419Z Preparing to unpack .../002-libglib2.0-bin_2.80.0-6ubuntu3.5_amd64.deb ...
+2025-12-09T11:11:40.9592929Z Unpacking libglib2.0-bin (2.80.0-6ubuntu3.5) over (2.80.0-6ubuntu3.4) ...
+2025-12-09T11:11:41.0122697Z Preparing to unpack .../003-gir1.2-glib-2.0_2.80.0-6ubuntu3.5_amd64.deb ...
+2025-12-09T11:11:41.0150456Z Unpacking gir1.2-glib-2.0:amd64 (2.80.0-6ubuntu3.5) over (2.80.0-6ubuntu3.4) ...
+2025-12-09T11:11:41.0574596Z Preparing to unpack .../004-libglib2.0-0t64_2.80.0-6ubuntu3.5_amd64.deb ...
+2025-12-09T11:11:41.0651020Z Unpacking libglib2.0-0t64:amd64 (2.80.0-6ubuntu3.5) over (2.80.0-6ubuntu3.4) ...
+2025-12-09T11:11:41.1142518Z Selecting previously unselected package fonts-freefont-ttf.
+2025-12-09T11:11:41.1280219Z Preparing to unpack .../005-fonts-freefont-ttf_20211204+svn4273-2_all.deb ...
+2025-12-09T11:11:41.1290077Z Unpacking fonts-freefont-ttf (20211204+svn4273-2) ...
+2025-12-09T11:11:41.2217618Z Selecting previously unselected package fonts-tlwg-loma-otf.
+2025-12-09T11:11:41.2351265Z Preparing to unpack .../006-fonts-tlwg-loma-otf_1%3a0.7.3-1_all.deb ...
+2025-12-09T11:11:41.2361623Z Unpacking fonts-tlwg-loma-otf (1:0.7.3-1) ...
+2025-12-09T11:11:41.2583041Z Selecting previously unselected package fonts-unifont.
+2025-12-09T11:11:41.2717319Z Preparing to unpack .../007-fonts-unifont_1%3a15.1.01-1build1_all.deb ...
+2025-12-09T11:11:41.2725808Z Unpacking fonts-unifont (1:15.1.01-1build1) ...
+2025-12-09T11:11:41.3901166Z Selecting previously unselected package fonts-wqy-zenhei.
+2025-12-09T11:11:41.4036170Z Preparing to unpack .../008-fonts-wqy-zenhei_0.9.45-8_all.deb ...
+2025-12-09T11:11:41.4140028Z Unpacking fonts-wqy-zenhei (0.9.45-8) ...
+2025-12-09T11:11:41.8805311Z Selecting previously unselected package libproxy1v5:amd64.
+2025-12-09T11:11:41.8938947Z Preparing to unpack .../009-libproxy1v5_0.5.4-4build1_amd64.deb ...
+2025-12-09T11:11:41.8950087Z Unpacking libproxy1v5:amd64 (0.5.4-4build1) ...
+2025-12-09T11:11:41.9165730Z Selecting previously unselected package glib-networking-common.
+2025-12-09T11:11:41.9299023Z Preparing to unpack .../010-glib-networking-common_2.80.0-1build1_all.deb ...
+2025-12-09T11:11:41.9308033Z Unpacking glib-networking-common (2.80.0-1build1) ...
+2025-12-09T11:11:41.9506933Z Selecting previously unselected package glib-networking-services.
+2025-12-09T11:11:41.9638916Z Preparing to unpack .../011-glib-networking-services_2.80.0-1build1_amd64.deb ...
+2025-12-09T11:11:41.9648169Z Unpacking glib-networking-services (2.80.0-1build1) ...
+2025-12-09T11:11:41.9863933Z Selecting previously unselected package session-migration.
+2025-12-09T11:11:41.9997045Z Preparing to unpack .../012-session-migration_0.3.9build1_amd64.deb ...
+2025-12-09T11:11:42.0008144Z Unpacking session-migration (0.3.9build1) ...
+2025-12-09T11:11:42.0226531Z Selecting previously unselected package gsettings-desktop-schemas.
+2025-12-09T11:11:42.0357144Z Preparing to unpack .../013-gsettings-desktop-schemas_46.1-0ubuntu1_all.deb ...
+2025-12-09T11:11:42.0366586Z Unpacking gsettings-desktop-schemas (46.1-0ubuntu1) ...
+2025-12-09T11:11:42.0628532Z Selecting previously unselected package glib-networking:amd64.
+2025-12-09T11:11:42.0760762Z Preparing to unpack .../014-glib-networking_2.80.0-1build1_amd64.deb ...
+2025-12-09T11:11:42.0769751Z Unpacking glib-networking:amd64 (2.80.0-1build1) ...
+2025-12-09T11:11:42.1024065Z Selecting previously unselected package libva2:amd64.
+2025-12-09T11:11:42.1156258Z Preparing to unpack .../015-libva2_2.20.0-2build1_amd64.deb ...
+2025-12-09T11:11:42.1165498Z Unpacking libva2:amd64 (2.20.0-2build1) ...
+2025-12-09T11:11:42.1380376Z Selecting previously unselected package libva-drm2:amd64.
+2025-12-09T11:11:42.1514120Z Preparing to unpack .../016-libva-drm2_2.20.0-2build1_amd64.deb ...
+2025-12-09T11:11:42.1522557Z Unpacking libva-drm2:amd64 (2.20.0-2build1) ...
+2025-12-09T11:11:42.1730934Z Selecting previously unselected package libva-x11-2:amd64.
+2025-12-09T11:11:42.1861540Z Preparing to unpack .../017-libva-x11-2_2.20.0-2build1_amd64.deb ...
+2025-12-09T11:11:42.1871775Z Unpacking libva-x11-2:amd64 (2.20.0-2build1) ...
+2025-12-09T11:11:42.2103406Z Selecting previously unselected package libvdpau1:amd64.
+2025-12-09T11:11:42.2233412Z Preparing to unpack .../018-libvdpau1_1.5-2build1_amd64.deb ...
+2025-12-09T11:11:42.2245165Z Unpacking libvdpau1:amd64 (1.5-2build1) ...
+2025-12-09T11:11:42.2458719Z Selecting previously unselected package libvpl2.
+2025-12-09T11:11:42.2588601Z Preparing to unpack .../019-libvpl2_2023.3.0-1build1_amd64.deb ...
+2025-12-09T11:11:42.2598114Z Unpacking libvpl2 (2023.3.0-1build1) ...
+2025-12-09T11:11:42.2815838Z Selecting previously unselected package ocl-icd-libopencl1:amd64.
+2025-12-09T11:11:42.2946978Z Preparing to unpack .../020-ocl-icd-libopencl1_2.3.2-1build1_amd64.deb ...
+2025-12-09T11:11:42.2956622Z Unpacking ocl-icd-libopencl1:amd64 (2.3.2-1build1) ...
+2025-12-09T11:11:42.3239625Z Selecting previously unselected package libavutil58:amd64.
+2025-12-09T11:11:42.3370855Z Preparing to unpack .../021-libavutil58_7%3a6.1.1-3ubuntu5_amd64.deb ...
+2025-12-09T11:11:42.3379917Z Unpacking libavutil58:amd64 (7:6.1.1-3ubuntu5) ...
+2025-12-09T11:11:42.3645096Z Selecting previously unselected package libcodec2-1.2:amd64.
+2025-12-09T11:11:42.3775070Z Preparing to unpack .../022-libcodec2-1.2_1.2.0-2build1_amd64.deb ...
+2025-12-09T11:11:42.3784889Z Unpacking libcodec2-1.2:amd64 (1.2.0-2build1) ...
+2025-12-09T11:11:42.4592451Z Selecting previously unselected package libdav1d7:amd64.
+2025-12-09T11:11:42.4725794Z Preparing to unpack .../023-libdav1d7_1.4.1-1build1_amd64.deb ...
+2025-12-09T11:11:42.4742863Z Unpacking libdav1d7:amd64 (1.4.1-1build1) ...
+2025-12-09T11:11:42.5058280Z Selecting previously unselected package libgsm1:amd64.
+2025-12-09T11:11:42.5190483Z Preparing to unpack .../024-libgsm1_1.0.22-1build1_amd64.deb ...
+2025-12-09T11:11:42.5201913Z Unpacking libgsm1:amd64 (1.0.22-1build1) ...
+2025-12-09T11:11:42.5464360Z Selecting previously unselected package libhwy1t64:amd64.
+2025-12-09T11:11:42.5596911Z Preparing to unpack .../025-libhwy1t64_1.0.7-8.1build1_amd64.deb ...
+2025-12-09T11:11:42.5605976Z Unpacking libhwy1t64:amd64 (1.0.7-8.1build1) ...
+2025-12-09T11:11:42.5955025Z Selecting previously unselected package libjxl0.7:amd64.
+2025-12-09T11:11:42.6088344Z Preparing to unpack .../026-libjxl0.7_0.7.0-10.2ubuntu6.1_amd64.deb ...
+2025-12-09T11:11:42.6100738Z Unpacking libjxl0.7:amd64 (0.7.0-10.2ubuntu6.1) ...
+2025-12-09T11:11:42.6491755Z Selecting previously unselected package libmp3lame0:amd64.
+2025-12-09T11:11:42.6624010Z Preparing to unpack .../027-libmp3lame0_3.100-6build1_amd64.deb ...
+2025-12-09T11:11:42.6632888Z Unpacking libmp3lame0:amd64 (3.100-6build1) ...
+2025-12-09T11:11:42.6863349Z Selecting previously unselected package libopus0:amd64.
+2025-12-09T11:11:42.6996122Z Preparing to unpack .../028-libopus0_1.4-1build1_amd64.deb ...
+2025-12-09T11:11:42.7007902Z Unpacking libopus0:amd64 (1.4-1build1) ...
+2025-12-09T11:11:42.7263122Z Selecting previously unselected package librav1e0:amd64.
+2025-12-09T11:11:42.7395226Z Preparing to unpack .../029-librav1e0_0.7.1-2_amd64.deb ...
+2025-12-09T11:11:42.7405310Z Unpacking librav1e0:amd64 (0.7.1-2) ...
+2025-12-09T11:11:42.7758822Z Selecting previously unselected package librsvg2-2:amd64.
+2025-12-09T11:11:42.7891524Z Preparing to unpack .../030-librsvg2-2_2.58.0+dfsg-1build1_amd64.deb ...
+2025-12-09T11:11:42.7899892Z Unpacking librsvg2-2:amd64 (2.58.0+dfsg-1build1) ...
+2025-12-09T11:11:42.8390835Z Selecting previously unselected package libshine3:amd64.
+2025-12-09T11:11:42.8522764Z Preparing to unpack .../031-libshine3_3.1.1-2build1_amd64.deb ...
+2025-12-09T11:11:42.8534118Z Unpacking libshine3:amd64 (3.1.1-2build1) ...
+2025-12-09T11:11:42.8741711Z Selecting previously unselected package libspeex1:amd64.
+2025-12-09T11:11:42.8875095Z Preparing to unpack .../032-libspeex1_1.2.1-2ubuntu2.24.04.1_amd64.deb ...
+2025-12-09T11:11:42.8884147Z Unpacking libspeex1:amd64 (1.2.1-2ubuntu2.24.04.1) ...
+2025-12-09T11:11:42.9095725Z Selecting previously unselected package libsvtav1enc1d1:amd64.
+2025-12-09T11:11:42.9227496Z Preparing to unpack .../033-libsvtav1enc1d1_1.7.0+dfsg-2build1_amd64.deb ...
+2025-12-09T11:11:42.9236634Z Unpacking libsvtav1enc1d1:amd64 (1.7.0+dfsg-2build1) ...
+2025-12-09T11:11:42.9772115Z Selecting previously unselected package libsoxr0:amd64.
+2025-12-09T11:11:42.9905998Z Preparing to unpack .../034-libsoxr0_0.1.3-4build3_amd64.deb ...
+2025-12-09T11:11:42.9915716Z Unpacking libsoxr0:amd64 (0.1.3-4build3) ...
+2025-12-09T11:11:43.0141518Z Selecting previously unselected package libswresample4:amd64.
+2025-12-09T11:11:43.0272312Z Preparing to unpack .../035-libswresample4_7%3a6.1.1-3ubuntu5_amd64.deb ...
+2025-12-09T11:11:43.0283127Z Unpacking libswresample4:amd64 (7:6.1.1-3ubuntu5) ...
+2025-12-09T11:11:43.0507859Z Selecting previously unselected package libtheora0:amd64.
+2025-12-09T11:11:43.0638480Z Preparing to unpack .../036-libtheora0_1.1.1+dfsg.1-16.1build3_amd64.deb ...
+2025-12-09T11:11:43.0649031Z Unpacking libtheora0:amd64 (1.1.1+dfsg.1-16.1build3) ...
+2025-12-09T11:11:43.0896430Z Selecting previously unselected package libtwolame0:amd64.
+2025-12-09T11:11:43.1027299Z Preparing to unpack .../037-libtwolame0_0.4.0-2build3_amd64.deb ...
+2025-12-09T11:11:43.1040641Z Unpacking libtwolame0:amd64 (0.4.0-2build3) ...
+2025-12-09T11:11:43.1269209Z Selecting previously unselected package libvorbisenc2:amd64.
+2025-12-09T11:11:43.1400245Z Preparing to unpack .../038-libvorbisenc2_1.3.7-1build3_amd64.deb ...
+2025-12-09T11:11:43.1412707Z Unpacking libvorbisenc2:amd64 (1.3.7-1build3) ...
+2025-12-09T11:11:43.1655997Z Selecting previously unselected package libvpx9:amd64.
+2025-12-09T11:11:43.1788675Z Preparing to unpack .../039-libvpx9_1.14.0-1ubuntu2.2_amd64.deb ...
+2025-12-09T11:11:43.1801380Z Unpacking libvpx9:amd64 (1.14.0-1ubuntu2.2) ...
+2025-12-09T11:11:43.2166266Z Selecting previously unselected package libx264-164:amd64.
+2025-12-09T11:11:43.2300033Z Preparing to unpack .../040-libx264-164_2%3a0.164.3108+git31e19f9-1_amd64.deb ...
+2025-12-09T11:11:43.2311013Z Unpacking libx264-164:amd64 (2:0.164.3108+git31e19f9-1) ...
+2025-12-09T11:11:43.2623626Z Selecting previously unselected package libx265-199:amd64.
+2025-12-09T11:11:43.2757391Z Preparing to unpack .../041-libx265-199_3.5-2build1_amd64.deb ...
+2025-12-09T11:11:43.2766720Z Unpacking libx265-199:amd64 (3.5-2build1) ...
+2025-12-09T11:11:43.3555826Z Selecting previously unselected package libxvidcore4:amd64.
+2025-12-09T11:11:43.3688240Z Preparing to unpack .../042-libxvidcore4_2%3a1.3.7-1build1_amd64.deb ...
+2025-12-09T11:11:43.3698611Z Unpacking libxvidcore4:amd64 (2:1.3.7-1build1) ...
+2025-12-09T11:11:43.3950577Z Selecting previously unselected package libzvbi-common.
+2025-12-09T11:11:43.4084052Z Preparing to unpack .../043-libzvbi-common_0.2.42-2_all.deb ...
+2025-12-09T11:11:43.4094727Z Unpacking libzvbi-common (0.2.42-2) ...
+2025-12-09T11:11:43.4550138Z Selecting previously unselected package libzvbi0t64:amd64.
+2025-12-09T11:11:43.4682711Z Preparing to unpack .../044-libzvbi0t64_0.2.42-2_amd64.deb ...
+2025-12-09T11:11:43.4696639Z Unpacking libzvbi0t64:amd64 (0.2.42-2) ...
+2025-12-09T11:11:43.4952911Z Selecting previously unselected package libavcodec60:amd64.
+2025-12-09T11:11:43.5084772Z Preparing to unpack .../045-libavcodec60_7%3a6.1.1-3ubuntu5_amd64.deb ...
+2025-12-09T11:11:43.5100179Z Unpacking libavcodec60:amd64 (7:6.1.1-3ubuntu5) ...
+2025-12-09T11:11:43.6007591Z Selecting previously unselected package libunibreak5:amd64.
+2025-12-09T11:11:43.6139520Z Preparing to unpack .../046-libunibreak5_5.1-2build1_amd64.deb ...
+2025-12-09T11:11:43.6149047Z Unpacking libunibreak5:amd64 (5.1-2build1) ...
+2025-12-09T11:11:43.6373079Z Selecting previously unselected package libass9:amd64.
+2025-12-09T11:11:43.6506635Z Preparing to unpack .../047-libass9_1%3a0.17.1-2build1_amd64.deb ...
+2025-12-09T11:11:43.6515831Z Unpacking libass9:amd64 (1:0.17.1-2build1) ...
+2025-12-09T11:11:43.6785696Z Selecting previously unselected package libudfread0:amd64.
+2025-12-09T11:11:43.6917619Z Preparing to unpack .../048-libudfread0_1.1.2-1build1_amd64.deb ...
+2025-12-09T11:11:43.6933412Z Unpacking libudfread0:amd64 (1.1.2-1build1) ...
+2025-12-09T11:11:43.7153446Z Selecting previously unselected package libbluray2:amd64.
+2025-12-09T11:11:43.7284796Z Preparing to unpack .../049-libbluray2_1%3a1.3.4-1build1_amd64.deb ...
+2025-12-09T11:11:43.7293476Z Unpacking libbluray2:amd64 (1:1.3.4-1build1) ...
+2025-12-09T11:11:43.7539400Z Selecting previously unselected package libchromaprint1:amd64.
+2025-12-09T11:11:43.7671548Z Preparing to unpack .../050-libchromaprint1_1.5.1-5_amd64.deb ...
+2025-12-09T11:11:43.7680216Z Unpacking libchromaprint1:amd64 (1.5.1-5) ...
+2025-12-09T11:11:43.7918413Z Selecting previously unselected package libgme0:amd64.
+2025-12-09T11:11:43.8049754Z Preparing to unpack .../051-libgme0_0.6.3-7build1_amd64.deb ...
+2025-12-09T11:11:43.8059705Z Unpacking libgme0:amd64 (0.6.3-7build1) ...
+2025-12-09T11:11:43.8317533Z Selecting previously unselected package libmpg123-0t64:amd64.
+2025-12-09T11:11:43.8449515Z Preparing to unpack .../052-libmpg123-0t64_1.32.5-1ubuntu1.1_amd64.deb ...
+2025-12-09T11:11:43.8459821Z Unpacking libmpg123-0t64:amd64 (1.32.5-1ubuntu1.1) ...
+2025-12-09T11:11:43.8697775Z Selecting previously unselected package libopenmpt0t64:amd64.
+2025-12-09T11:11:43.8830053Z Preparing to unpack .../053-libopenmpt0t64_0.7.3-1.1build3_amd64.deb ...
+2025-12-09T11:11:43.8843090Z Unpacking libopenmpt0t64:amd64 (0.7.3-1.1build3) ...
+2025-12-09T11:11:43.9149831Z Selecting previously unselected package libcjson1:amd64.
+2025-12-09T11:11:43.9280972Z Preparing to unpack .../054-libcjson1_1.7.17-1_amd64.deb ...
+2025-12-09T11:11:43.9299020Z Unpacking libcjson1:amd64 (1.7.17-1) ...
+2025-12-09T11:11:43.9528332Z Selecting previously unselected package libmbedcrypto7t64:amd64.
+2025-12-09T11:11:43.9660774Z Preparing to unpack .../055-libmbedcrypto7t64_2.28.8-1_amd64.deb ...
+2025-12-09T11:11:43.9669940Z Unpacking libmbedcrypto7t64:amd64 (2.28.8-1) ...
+2025-12-09T11:11:43.9927693Z Selecting previously unselected package librist4:amd64.
+2025-12-09T11:11:44.0059627Z Preparing to unpack .../056-librist4_0.2.10+dfsg-2_amd64.deb ...
+2025-12-09T11:11:44.0073824Z Unpacking librist4:amd64 (0.2.10+dfsg-2) ...
+2025-12-09T11:11:44.0295652Z Selecting previously unselected package libsrt1.5-gnutls:amd64.
+2025-12-09T11:11:44.0427963Z Preparing to unpack .../057-libsrt1.5-gnutls_1.5.3-1build2_amd64.deb ...
+2025-12-09T11:11:44.0442866Z Unpacking libsrt1.5-gnutls:amd64 (1.5.3-1build2) ...
+2025-12-09T11:11:44.0711495Z Selecting previously unselected package libssh-gcrypt-4:amd64.
+2025-12-09T11:11:44.0844803Z Preparing to unpack .../058-libssh-gcrypt-4_0.10.6-2ubuntu0.2_amd64.deb ...
+2025-12-09T11:11:44.0858348Z Unpacking libssh-gcrypt-4:amd64 (0.10.6-2ubuntu0.2) ...
+2025-12-09T11:11:44.1127935Z Selecting previously unselected package libavformat60:amd64.
+2025-12-09T11:11:44.1261365Z Preparing to unpack .../059-libavformat60_7%3a6.1.1-3ubuntu5_amd64.deb ...
+2025-12-09T11:11:44.1277481Z Unpacking libavformat60:amd64 (7:6.1.1-3ubuntu5) ...
+2025-12-09T11:11:44.1633538Z Selecting previously unselected package libbs2b0:amd64.
+2025-12-09T11:11:44.1768193Z Preparing to unpack .../060-libbs2b0_3.1.0+dfsg-7build1_amd64.deb ...
+2025-12-09T11:11:44.1777444Z Unpacking libbs2b0:amd64 (3.1.0+dfsg-7build1) ...
+2025-12-09T11:11:44.2019194Z Selecting previously unselected package libflite1:amd64.
+2025-12-09T11:11:44.2152637Z Preparing to unpack .../061-libflite1_2.2-6build3_amd64.deb ...
+2025-12-09T11:11:44.2162069Z Unpacking libflite1:amd64 (2.2-6build3) ...
+2025-12-09T11:11:44.3392668Z Selecting previously unselected package libserd-0-0:amd64.
+2025-12-09T11:11:44.3524874Z Preparing to unpack .../062-libserd-0-0_0.32.2-1_amd64.deb ...
+2025-12-09T11:11:44.3536290Z Unpacking libserd-0-0:amd64 (0.32.2-1) ...
+2025-12-09T11:11:44.3768155Z Selecting previously unselected package libzix-0-0:amd64.
+2025-12-09T11:11:44.3901742Z Preparing to unpack .../063-libzix-0-0_0.4.2-2build1_amd64.deb ...
+2025-12-09T11:11:44.3914664Z Unpacking libzix-0-0:amd64 (0.4.2-2build1) ...
+2025-12-09T11:11:44.4141600Z Selecting previously unselected package libsord-0-0:amd64.
+2025-12-09T11:11:44.4275370Z Preparing to unpack .../064-libsord-0-0_0.16.16-2build1_amd64.deb ...
+2025-12-09T11:11:44.4289413Z Unpacking libsord-0-0:amd64 (0.16.16-2build1) ...
+2025-12-09T11:11:44.4509158Z Selecting previously unselected package libsratom-0-0:amd64.
+2025-12-09T11:11:44.4641628Z Preparing to unpack .../065-libsratom-0-0_0.6.16-1build1_amd64.deb ...
+2025-12-09T11:11:44.4651570Z Unpacking libsratom-0-0:amd64 (0.6.16-1build1) ...
+2025-12-09T11:11:44.4900606Z Selecting previously unselected package liblilv-0-0:amd64.
+2025-12-09T11:11:44.5033059Z Preparing to unpack .../066-liblilv-0-0_0.24.22-1build1_amd64.deb ...
+2025-12-09T11:11:44.5043456Z Unpacking liblilv-0-0:amd64 (0.24.22-1build1) ...
+2025-12-09T11:11:44.5270691Z Selecting previously unselected package libmysofa1:amd64.
+2025-12-09T11:11:44.5403235Z Preparing to unpack .../067-libmysofa1_1.3.2+dfsg-2ubuntu2_amd64.deb ...
+2025-12-09T11:11:44.5412603Z Unpacking libmysofa1:amd64 (1.3.2+dfsg-2ubuntu2) ...
+2025-12-09T11:11:44.5699122Z Selecting previously unselected package libplacebo338:amd64.
+2025-12-09T11:11:44.5832162Z Preparing to unpack .../068-libplacebo338_6.338.2-2build1_amd64.deb ...
+2025-12-09T11:11:44.5843310Z Unpacking libplacebo338:amd64 (6.338.2-2build1) ...
+2025-12-09T11:11:44.6447405Z Selecting previously unselected package libblas3:amd64.
+2025-12-09T11:11:44.6580745Z Preparing to unpack .../069-libblas3_3.12.0-3build1.1_amd64.deb ...
+2025-12-09T11:11:44.6617971Z Unpacking libblas3:amd64 (3.12.0-3build1.1) ...
+2025-12-09T11:11:44.6875952Z Selecting previously unselected package liblapack3:amd64.
+2025-12-09T11:11:44.7008783Z Preparing to unpack .../070-liblapack3_3.12.0-3build1.1_amd64.deb ...
+2025-12-09T11:11:44.7042870Z Unpacking liblapack3:amd64 (3.12.0-3build1.1) ...
+2025-12-09T11:11:44.7572372Z Selecting previously unselected package libasyncns0:amd64.
+2025-12-09T11:11:44.7705468Z Preparing to unpack .../071-libasyncns0_0.8-6build4_amd64.deb ...
+2025-12-09T11:11:44.7717839Z Unpacking libasyncns0:amd64 (0.8-6build4) ...
+2025-12-09T11:11:44.7995625Z Selecting previously unselected package libflac12t64:amd64.
+2025-12-09T11:11:44.8128311Z Preparing to unpack .../072-libflac12t64_1.4.3+ds-2.1ubuntu2_amd64.deb ...
+2025-12-09T11:11:44.8140749Z Unpacking libflac12t64:amd64 (1.4.3+ds-2.1ubuntu2) ...
+2025-12-09T11:11:44.8389178Z Selecting previously unselected package libsndfile1:amd64.
+2025-12-09T11:11:44.8522363Z Preparing to unpack .../073-libsndfile1_1.2.2-1ubuntu5.24.04.1_amd64.deb ...
+2025-12-09T11:11:44.8530982Z Unpacking libsndfile1:amd64 (1.2.2-1ubuntu5.24.04.1) ...
+2025-12-09T11:11:44.8823841Z Selecting previously unselected package libpulse0:amd64.
+2025-12-09T11:11:44.8959237Z Preparing to unpack .../074-libpulse0_1%3a16.1+dfsg1-2ubuntu10.1_amd64.deb ...
+2025-12-09T11:11:44.9027653Z Unpacking libpulse0:amd64 (1:16.1+dfsg1-2ubuntu10.1) ...
+2025-12-09T11:11:44.9300791Z Selecting previously unselected package libsphinxbase3t64:amd64.
+2025-12-09T11:11:44.9433095Z Preparing to unpack .../075-libsphinxbase3t64_0.8+5prealpha+1-17build2_amd64.deb ...
+2025-12-09T11:11:44.9444930Z Unpacking libsphinxbase3t64:amd64 (0.8+5prealpha+1-17build2) ...
+2025-12-09T11:11:44.9676322Z Selecting previously unselected package libpocketsphinx3:amd64.
+2025-12-09T11:11:44.9809642Z Preparing to unpack .../076-libpocketsphinx3_0.8.0+real5prealpha+1-15ubuntu5_amd64.deb ...
+2025-12-09T11:11:44.9820205Z Unpacking libpocketsphinx3:amd64 (0.8.0+real5prealpha+1-15ubuntu5) ...
+2025-12-09T11:11:45.0105210Z Selecting previously unselected package libpostproc57:amd64.
+2025-12-09T11:11:45.0239791Z Preparing to unpack .../077-libpostproc57_7%3a6.1.1-3ubuntu5_amd64.deb ...
+2025-12-09T11:11:45.0249920Z Unpacking libpostproc57:amd64 (7:6.1.1-3ubuntu5) ...
+2025-12-09T11:11:45.0479109Z Selecting previously unselected package libsamplerate0:amd64.
+2025-12-09T11:11:45.0614036Z Preparing to unpack .../078-libsamplerate0_0.2.2-4build1_amd64.deb ...
+2025-12-09T11:11:45.0625509Z Unpacking libsamplerate0:amd64 (0.2.2-4build1) ...
+2025-12-09T11:11:45.1027477Z Selecting previously unselected package librubberband2:amd64.
+2025-12-09T11:11:45.1159866Z Preparing to unpack .../079-librubberband2_3.3.0+dfsg-2build1_amd64.deb ...
+2025-12-09T11:11:45.1202798Z Unpacking librubberband2:amd64 (3.3.0+dfsg-2build1) ...
+2025-12-09T11:11:45.1474894Z Selecting previously unselected package libswscale7:amd64.
+2025-12-09T11:11:45.1608657Z Preparing to unpack .../080-libswscale7_7%3a6.1.1-3ubuntu5_amd64.deb ...
+2025-12-09T11:11:45.1618026Z Unpacking libswscale7:amd64 (7:6.1.1-3ubuntu5) ...
+2025-12-09T11:11:45.1863636Z Selecting previously unselected package libvidstab1.1:amd64.
+2025-12-09T11:11:45.1997489Z Preparing to unpack .../081-libvidstab1.1_1.1.0-2build1_amd64.deb ...
+2025-12-09T11:11:45.2007332Z Unpacking libvidstab1.1:amd64 (1.1.0-2build1) ...
+2025-12-09T11:11:45.2237097Z Selecting previously unselected package libzimg2:amd64.
+2025-12-09T11:11:45.2371767Z Preparing to unpack .../082-libzimg2_3.0.5+ds1-1build1_amd64.deb ...
+2025-12-09T11:11:45.2385530Z Unpacking libzimg2:amd64 (3.0.5+ds1-1build1) ...
+2025-12-09T11:11:45.2652725Z Selecting previously unselected package libavfilter9:amd64.
+2025-12-09T11:11:45.2785457Z Preparing to unpack .../083-libavfilter9_7%3a6.1.1-3ubuntu5_amd64.deb ...
+2025-12-09T11:11:45.2795518Z Unpacking libavfilter9:amd64 (7:6.1.1-3ubuntu5) ...
+2025-12-09T11:11:45.4020574Z Selecting previously unselected package liborc-0.4-0t64:amd64.
+2025-12-09T11:11:45.4153858Z Preparing to unpack .../084-liborc-0.4-0t64_1%3a0.4.38-1ubuntu0.1_amd64.deb ...
+2025-12-09T11:11:45.4164480Z Unpacking liborc-0.4-0t64:amd64 (1:0.4.38-1ubuntu0.1) ...
+2025-12-09T11:11:45.4431642Z Selecting previously unselected package libgstreamer-plugins-base1.0-0:amd64.
+2025-12-09T11:11:45.4566622Z Preparing to unpack .../085-libgstreamer-plugins-base1.0-0_1.24.2-1ubuntu0.3_amd64.deb ...
+2025-12-09T11:11:45.4578882Z Unpacking libgstreamer-plugins-base1.0-0:amd64 (1.24.2-1ubuntu0.3) ...
+2025-12-09T11:11:45.4936316Z Selecting previously unselected package gstreamer1.0-libav:amd64.
+2025-12-09T11:11:45.5070823Z Preparing to unpack .../086-gstreamer1.0-libav_1.24.1-1build1_amd64.deb ...
+2025-12-09T11:11:45.5081765Z Unpacking gstreamer1.0-libav:amd64 (1.24.1-1build1) ...
+2025-12-09T11:11:45.5334227Z Selecting previously unselected package libcdparanoia0:amd64.
+2025-12-09T11:11:45.5466999Z Preparing to unpack .../087-libcdparanoia0_3.10.2+debian-14build3_amd64.deb ...
+2025-12-09T11:11:45.5481754Z Unpacking libcdparanoia0:amd64 (3.10.2+debian-14build3) ...
+2025-12-09T11:11:45.5726228Z Selecting previously unselected package libvisual-0.4-0:amd64.
+2025-12-09T11:11:45.5858970Z Preparing to unpack .../088-libvisual-0.4-0_0.4.2-2build1_amd64.deb ...
+2025-12-09T11:11:45.5868780Z Unpacking libvisual-0.4-0:amd64 (0.4.2-2build1) ...
+2025-12-09T11:11:45.6129461Z Selecting previously unselected package gstreamer1.0-plugins-base:amd64.
+2025-12-09T11:11:45.6263075Z Preparing to unpack .../089-gstreamer1.0-plugins-base_1.24.2-1ubuntu0.3_amd64.deb ...
+2025-12-09T11:11:45.6276083Z Unpacking gstreamer1.0-plugins-base:amd64 (1.24.2-1ubuntu0.3) ...
+2025-12-09T11:11:45.6672926Z Selecting previously unselected package libaa1:amd64.
+2025-12-09T11:11:45.6806470Z Preparing to unpack .../090-libaa1_1.4p5-51.1_amd64.deb ...
+2025-12-09T11:11:45.6818911Z Unpacking libaa1:amd64 (1.4p5-51.1) ...
+2025-12-09T11:11:45.7087979Z Selecting previously unselected package libraw1394-11:amd64.
+2025-12-09T11:11:45.7219647Z Preparing to unpack .../091-libraw1394-11_2.1.2-2build3_amd64.deb ...
+2025-12-09T11:11:45.7231686Z Unpacking libraw1394-11:amd64 (2.1.2-2build3) ...
+2025-12-09T11:11:45.7525848Z Selecting previously unselected package libavc1394-0:amd64.
+2025-12-09T11:11:45.7659357Z Preparing to unpack .../092-libavc1394-0_0.5.4-5build3_amd64.deb ...
+2025-12-09T11:11:45.7672741Z Unpacking libavc1394-0:amd64 (0.5.4-5build3) ...
+2025-12-09T11:11:45.7929643Z Selecting previously unselected package libcaca0:amd64.
+2025-12-09T11:11:45.8062784Z Preparing to unpack .../093-libcaca0_0.99.beta20-4build2_amd64.deb ...
+2025-12-09T11:11:45.8072780Z Unpacking libcaca0:amd64 (0.99.beta20-4build2) ...
+2025-12-09T11:11:45.8372201Z Selecting previously unselected package libdv4t64:amd64.
+2025-12-09T11:11:45.8504475Z Preparing to unpack .../094-libdv4t64_1.0.0-17.1build1_amd64.deb ...
+2025-12-09T11:11:45.8520985Z Unpacking libdv4t64:amd64 (1.0.0-17.1build1) ...
+2025-12-09T11:11:45.8762756Z Selecting previously unselected package libgstreamer-plugins-good1.0-0:amd64.
+2025-12-09T11:11:45.8898802Z Preparing to unpack .../095-libgstreamer-plugins-good1.0-0_1.24.2-1ubuntu1.2_amd64.deb ...
+2025-12-09T11:11:45.9026854Z Unpacking libgstreamer-plugins-good1.0-0:amd64 (1.24.2-1ubuntu1.2) ...
+2025-12-09T11:11:45.9275053Z Selecting previously unselected package libiec61883-0:amd64.
+2025-12-09T11:11:45.9406832Z Preparing to unpack .../096-libiec61883-0_1.2.0-6build1_amd64.deb ...
+2025-12-09T11:11:45.9422513Z Unpacking libiec61883-0:amd64 (1.2.0-6build1) ...
+2025-12-09T11:11:45.9674455Z Selecting previously unselected package libshout3:amd64.
+2025-12-09T11:11:45.9806638Z Preparing to unpack .../097-libshout3_2.4.6-1build2_amd64.deb ...
+2025-12-09T11:11:45.9817332Z Unpacking libshout3:amd64 (2.4.6-1build2) ...
+2025-12-09T11:11:46.0064813Z Selecting previously unselected package libtag1v5-vanilla:amd64.
+2025-12-09T11:11:46.0196667Z Preparing to unpack .../098-libtag1v5-vanilla_1.13.1-1build1_amd64.deb ...
+2025-12-09T11:11:46.0215561Z Unpacking libtag1v5-vanilla:amd64 (1.13.1-1build1) ...
+2025-12-09T11:11:46.0468507Z Selecting previously unselected package libtag1v5:amd64.
+2025-12-09T11:11:46.0600880Z Preparing to unpack .../099-libtag1v5_1.13.1-1build1_amd64.deb ...
+2025-12-09T11:11:46.0610389Z Unpacking libtag1v5:amd64 (1.13.1-1build1) ...
+2025-12-09T11:11:46.0858889Z Selecting previously unselected package libv4lconvert0t64:amd64.
+2025-12-09T11:11:46.0990593Z Preparing to unpack .../100-libv4lconvert0t64_1.26.1-4build3_amd64.deb ...
+2025-12-09T11:11:46.1000689Z Unpacking libv4lconvert0t64:amd64 (1.26.1-4build3) ...
+2025-12-09T11:11:46.1289040Z Selecting previously unselected package libv4l-0t64:amd64.
+2025-12-09T11:11:46.1421142Z Preparing to unpack .../101-libv4l-0t64_1.26.1-4build3_amd64.deb ...
+2025-12-09T11:11:46.1431718Z Unpacking libv4l-0t64:amd64 (1.26.1-4build3) ...
+2025-12-09T11:11:46.1693964Z Selecting previously unselected package libwavpack1:amd64.
+2025-12-09T11:11:46.1827663Z Preparing to unpack .../102-libwavpack1_5.6.0-1build1_amd64.deb ...
+2025-12-09T11:11:46.1838709Z Unpacking libwavpack1:amd64 (5.6.0-1build1) ...
+2025-12-09T11:11:46.2047325Z Selecting previously unselected package libsoup-3.0-common.
+2025-12-09T11:11:46.2179972Z Preparing to unpack .../103-libsoup-3.0-common_3.4.4-5ubuntu0.5_all.deb ...
+2025-12-09T11:11:46.2189327Z Unpacking libsoup-3.0-common (3.4.4-5ubuntu0.5) ...
+2025-12-09T11:11:46.2403058Z Selecting previously unselected package libsoup-3.0-0:amd64.
+2025-12-09T11:11:46.2535703Z Preparing to unpack .../104-libsoup-3.0-0_3.4.4-5ubuntu0.5_amd64.deb ...
+2025-12-09T11:11:46.2545814Z Unpacking libsoup-3.0-0:amd64 (3.4.4-5ubuntu0.5) ...
+2025-12-09T11:11:46.2784280Z Selecting previously unselected package gstreamer1.0-plugins-good:amd64.
+2025-12-09T11:11:46.2916818Z Preparing to unpack .../105-gstreamer1.0-plugins-good_1.24.2-1ubuntu1.2_amd64.deb ...
+2025-12-09T11:11:46.2924672Z Unpacking gstreamer1.0-plugins-good:amd64 (1.24.2-1ubuntu1.2) ...
+2025-12-09T11:11:46.3536746Z Selecting previously unselected package libabsl20220623t64:amd64.
+2025-12-09T11:11:46.3671169Z Preparing to unpack .../106-libabsl20220623t64_20220623.1-3.1ubuntu3.2_amd64.deb ...
+2025-12-09T11:11:46.3682686Z Unpacking libabsl20220623t64:amd64 (20220623.1-3.1ubuntu3.2) ...
+2025-12-09T11:11:46.4127342Z Selecting previously unselected package libgav1-1:amd64.
+2025-12-09T11:11:46.4261587Z Preparing to unpack .../107-libgav1-1_0.18.0-1build3_amd64.deb ...
+2025-12-09T11:11:46.4270809Z Unpacking libgav1-1:amd64 (0.18.0-1build3) ...
+2025-12-09T11:11:46.4526948Z Selecting previously unselected package libyuv0:amd64.
+2025-12-09T11:11:46.4660471Z Preparing to unpack .../108-libyuv0_0.0~git202401110.af6ac82-1_amd64.deb ...
+2025-12-09T11:11:46.4671395Z Unpacking libyuv0:amd64 (0.0~git202401110.af6ac82-1) ...
+2025-12-09T11:11:46.4922190Z Selecting previously unselected package libavif16:amd64.
+2025-12-09T11:11:46.5054506Z Preparing to unpack .../109-libavif16_1.0.4-1ubuntu3_amd64.deb ...
+2025-12-09T11:11:46.5067106Z Unpacking libavif16:amd64 (1.0.4-1ubuntu3) ...
+2025-12-09T11:11:46.5280515Z Selecting previously unselected package libavtp0:amd64.
+2025-12-09T11:11:46.5412413Z Preparing to unpack .../110-libavtp0_0.2.0-1build1_amd64.deb ...
+2025-12-09T11:11:46.5422292Z Unpacking libavtp0:amd64 (0.2.0-1build1) ...
+2025-12-09T11:11:46.5636432Z Selecting previously unselected package libcairo-script-interpreter2:amd64.
+2025-12-09T11:11:46.5769204Z Preparing to unpack .../111-libcairo-script-interpreter2_1.18.0-3build1_amd64.deb ...
+2025-12-09T11:11:46.5778544Z Unpacking libcairo-script-interpreter2:amd64 (1.18.0-3build1) ...
+2025-12-09T11:11:46.6141295Z Preparing to unpack .../112-libcups2t64_2.4.7-1.2ubuntu7.9_amd64.deb ...
+2025-12-09T11:11:46.6172113Z Unpacking libcups2t64:amd64 (2.4.7-1.2ubuntu7.9) over (2.4.7-1.2ubuntu7.4) ...
+2025-12-09T11:11:46.6458893Z Selecting previously unselected package libdc1394-25:amd64.
+2025-12-09T11:11:46.6593999Z Preparing to unpack .../113-libdc1394-25_2.2.6-4build1_amd64.deb ...
+2025-12-09T11:11:46.6603402Z Unpacking libdc1394-25:amd64 (2.2.6-4build1) ...
+2025-12-09T11:11:46.6839180Z Selecting previously unselected package libdecor-0-0:amd64.
+2025-12-09T11:11:46.6971045Z Preparing to unpack .../114-libdecor-0-0_0.2.2-1build2_amd64.deb ...
+2025-12-09T11:11:46.6979751Z Unpacking libdecor-0-0:amd64 (0.2.2-1build2) ...
+2025-12-09T11:11:46.7190081Z Selecting previously unselected package libgles2:amd64.
+2025-12-09T11:11:46.7321686Z Preparing to unpack .../115-libgles2_1.7.0-1build1_amd64.deb ...
+2025-12-09T11:11:46.7329359Z Unpacking libgles2:amd64 (1.7.0-1build1) ...
+2025-12-09T11:11:46.7543446Z Selecting previously unselected package libdirectfb-1.7-7t64:amd64.
+2025-12-09T11:11:46.7674637Z Preparing to unpack .../116-libdirectfb-1.7-7t64_1.7.7-11.1ubuntu2_amd64.deb ...
+2025-12-09T11:11:46.7685339Z Unpacking libdirectfb-1.7-7t64:amd64 (1.7.7-11.1ubuntu2) ...
+2025-12-09T11:11:46.8112104Z Selecting previously unselected package libdvdread8t64:amd64.
+2025-12-09T11:11:46.8245428Z Preparing to unpack .../117-libdvdread8t64_6.1.3-1.1build1_amd64.deb ...
+2025-12-09T11:11:46.8254918Z Unpacking libdvdread8t64:amd64 (6.1.3-1.1build1) ...
+2025-12-09T11:11:46.8495090Z Selecting previously unselected package libdvdnav4:amd64.
+2025-12-09T11:11:46.8628710Z Preparing to unpack .../118-libdvdnav4_6.1.1-3build1_amd64.deb ...
+2025-12-09T11:11:46.8638029Z Unpacking libdvdnav4:amd64 (6.1.1-3build1) ...
+2025-12-09T11:11:46.8864686Z Selecting previously unselected package libegl-mesa0:amd64.
+2025-12-09T11:11:46.8997549Z Preparing to unpack .../119-libegl-mesa0_25.0.7-0ubuntu0.24.04.2_amd64.deb ...
+2025-12-09T11:11:46.9006179Z Unpacking libegl-mesa0:amd64 (25.0.7-0ubuntu0.24.04.2) ...
+2025-12-09T11:11:46.9251768Z Selecting previously unselected package libevent-2.1-7t64:amd64.
+2025-12-09T11:11:46.9385566Z Preparing to unpack .../120-libevent-2.1-7t64_2.1.12-stable-9ubuntu2_amd64.deb ...
+2025-12-09T11:11:46.9395029Z Unpacking libevent-2.1-7t64:amd64 (2.1.12-stable-9ubuntu2) ...
+2025-12-09T11:11:46.9630132Z Selecting previously unselected package libfaad2:amd64.
+2025-12-09T11:11:46.9763951Z Preparing to unpack .../121-libfaad2_2.11.1-1build1_amd64.deb ...
+2025-12-09T11:11:46.9772832Z Unpacking libfaad2:amd64 (2.11.1-1build1) ...
+2025-12-09T11:11:47.0015576Z Selecting previously unselected package libinstpatch-1.0-2:amd64.
+2025-12-09T11:11:47.0152493Z Preparing to unpack .../122-libinstpatch-1.0-2_1.1.6-1build2_amd64.deb ...
+2025-12-09T11:11:47.0161917Z Unpacking libinstpatch-1.0-2:amd64 (1.1.6-1build2) ...
+2025-12-09T11:11:47.0409526Z Selecting previously unselected package libjack-jackd2-0:amd64.
+2025-12-09T11:11:47.0543323Z Preparing to unpack .../123-libjack-jackd2-0_1.9.21~dfsg-3ubuntu3_amd64.deb ...
+2025-12-09T11:11:47.0551084Z Unpacking libjack-jackd2-0:amd64 (1.9.21~dfsg-3ubuntu3) ...
+2025-12-09T11:11:47.0821973Z Selecting previously unselected package libwebrtc-audio-processing1:amd64.
+2025-12-09T11:11:47.0956626Z Preparing to unpack .../124-libwebrtc-audio-processing1_0.3.1-0ubuntu6_amd64.deb ...
+2025-12-09T11:11:47.0965130Z Unpacking libwebrtc-audio-processing1:amd64 (0.3.1-0ubuntu6) ...
+2025-12-09T11:11:47.1200588Z Selecting previously unselected package libspa-0.2-modules:amd64.
+2025-12-09T11:11:47.1336029Z Preparing to unpack .../125-libspa-0.2-modules_1.0.5-1ubuntu3.1_amd64.deb ...
+2025-12-09T11:11:47.1346799Z Unpacking libspa-0.2-modules:amd64 (1.0.5-1ubuntu3.1) ...
+2025-12-09T11:11:47.1695496Z Selecting previously unselected package libpipewire-0.3-0t64:amd64.
+2025-12-09T11:11:47.1830797Z Preparing to unpack .../126-libpipewire-0.3-0t64_1.0.5-1ubuntu3.1_amd64.deb ...
+2025-12-09T11:11:47.1839578Z Unpacking libpipewire-0.3-0t64:amd64 (1.0.5-1ubuntu3.1) ...
+2025-12-09T11:11:47.2112749Z Selecting previously unselected package libsdl2-2.0-0:amd64.
+2025-12-09T11:11:47.2247911Z Preparing to unpack .../127-libsdl2-2.0-0_2.30.0+dfsg-1ubuntu3.1_amd64.deb ...
+2025-12-09T11:11:47.2262507Z Unpacking libsdl2-2.0-0:amd64 (2.30.0+dfsg-1ubuntu3.1) ...
+2025-12-09T11:11:47.2567450Z Selecting previously unselected package timgm6mb-soundfont.
+2025-12-09T11:11:47.2701340Z Preparing to unpack .../128-timgm6mb-soundfont_1.3-5_all.deb ...
+2025-12-09T11:11:47.2712334Z Unpacking timgm6mb-soundfont (1.3-5) ...
+2025-12-09T11:11:47.6118911Z Selecting previously unselected package libfluidsynth3:amd64.
+2025-12-09T11:11:47.6252266Z Preparing to unpack .../129-libfluidsynth3_2.3.4-1build3_amd64.deb ...
+2025-12-09T11:11:47.6260998Z Unpacking libfluidsynth3:amd64 (2.3.4-1build3) ...
+2025-12-09T11:11:47.6512175Z Selecting previously unselected package libfreeaptx0:amd64.
+2025-12-09T11:11:47.6647329Z Preparing to unpack .../130-libfreeaptx0_0.1.1-2build1_amd64.deb ...
+2025-12-09T11:11:47.6655950Z Unpacking libfreeaptx0:amd64 (0.1.1-2build1) ...
+2025-12-09T11:11:47.6873219Z Selecting previously unselected package libgraphene-1.0-0:amd64.
+2025-12-09T11:11:47.7008338Z Preparing to unpack .../131-libgraphene-1.0-0_1.10.8-3build2_amd64.deb ...
+2025-12-09T11:11:47.7018620Z Unpacking libgraphene-1.0-0:amd64 (1.10.8-3build2) ...
+2025-12-09T11:11:47.7241992Z Selecting previously unselected package libgssdp-1.6-0:amd64.
+2025-12-09T11:11:47.7376176Z Preparing to unpack .../132-libgssdp-1.6-0_1.6.3-1build3_amd64.deb ...
+2025-12-09T11:11:47.7384979Z Unpacking libgssdp-1.6-0:amd64 (1.6.3-1build3) ...
+2025-12-09T11:11:47.7610744Z Selecting previously unselected package libegl1:amd64.
+2025-12-09T11:11:47.7744376Z Preparing to unpack .../133-libegl1_1.7.0-1build1_amd64.deb ...
+2025-12-09T11:11:47.7753074Z Unpacking libegl1:amd64 (1.7.0-1build1) ...
+2025-12-09T11:11:47.7976262Z Selecting previously unselected package libgstreamer-gl1.0-0:amd64.
+2025-12-09T11:11:47.8111318Z Preparing to unpack .../134-libgstreamer-gl1.0-0_1.24.2-1ubuntu0.3_amd64.deb ...
+2025-12-09T11:11:47.8123181Z Unpacking libgstreamer-gl1.0-0:amd64 (1.24.2-1ubuntu0.3) ...
+2025-12-09T11:11:47.8357653Z Selecting previously unselected package libgtk-4-common.
+2025-12-09T11:11:47.8491912Z Preparing to unpack .../135-libgtk-4-common_4.14.5+ds-0ubuntu0.7_all.deb ...
+2025-12-09T11:11:47.8502141Z Unpacking libgtk-4-common (4.14.5+ds-0ubuntu0.7) ...
+2025-12-09T11:11:47.9014971Z Selecting previously unselected package libgtk-4-1:amd64.
+2025-12-09T11:11:47.9153206Z Preparing to unpack .../136-libgtk-4-1_4.14.5+ds-0ubuntu0.7_amd64.deb ...
+2025-12-09T11:11:47.9162686Z Unpacking libgtk-4-1:amd64 (4.14.5+ds-0ubuntu0.7) ...
+2025-12-09T11:11:47.9850649Z Selecting previously unselected package libgupnp-1.6-0:amd64.
+2025-12-09T11:11:47.9987235Z Preparing to unpack .../137-libgupnp-1.6-0_1.6.6-1build3_amd64.deb ...
+2025-12-09T11:11:47.9996896Z Unpacking libgupnp-1.6-0:amd64 (1.6.6-1build3) ...
+2025-12-09T11:11:48.0272521Z Selecting previously unselected package libgupnp-igd-1.6-0:amd64.
+2025-12-09T11:11:48.0407691Z Preparing to unpack .../138-libgupnp-igd-1.6-0_1.6.0-3build3_amd64.deb ...
+2025-12-09T11:11:48.0417233Z Unpacking libgupnp-igd-1.6-0:amd64 (1.6.0-3build3) ...
+2025-12-09T11:11:48.0637957Z Selecting previously unselected package libharfbuzz-icu0:amd64.
+2025-12-09T11:11:48.0774288Z Preparing to unpack .../139-libharfbuzz-icu0_8.3.0-2build2_amd64.deb ...
+2025-12-09T11:11:48.0785691Z Unpacking libharfbuzz-icu0:amd64 (8.3.0-2build2) ...
+2025-12-09T11:11:48.1010265Z Selecting previously unselected package libhyphen0:amd64.
+2025-12-09T11:11:48.1144594Z Preparing to unpack .../140-libhyphen0_2.8.8-7build3_amd64.deb ...
+2025-12-09T11:11:48.1154885Z Unpacking libhyphen0:amd64 (2.8.8-7build3) ...
+2025-12-09T11:11:48.1377705Z Selecting previously unselected package libimath-3-1-29t64:amd64.
+2025-12-09T11:11:48.1511921Z Preparing to unpack .../141-libimath-3-1-29t64_3.1.9-3.1ubuntu2_amd64.deb ...
+2025-12-09T11:11:48.1522312Z Unpacking libimath-3-1-29t64:amd64 (3.1.9-3.1ubuntu2) ...
+2025-12-09T11:11:48.1761254Z Selecting previously unselected package liblc3-1:amd64.
+2025-12-09T11:11:48.1895693Z Preparing to unpack .../142-liblc3-1_1.0.4-3build1_amd64.deb ...
+2025-12-09T11:11:48.1906297Z Unpacking liblc3-1:amd64 (1.0.4-3build1) ...
+2025-12-09T11:11:48.2132079Z Selecting previously unselected package libldacbt-enc2:amd64.
+2025-12-09T11:11:48.2266359Z Preparing to unpack .../143-libldacbt-enc2_2.0.2.3+git20200429+ed310a0-4ubuntu2_amd64.deb ...
+2025-12-09T11:11:48.2279060Z Unpacking libldacbt-enc2:amd64 (2.0.2.3+git20200429+ed310a0-4ubuntu2) ...
+2025-12-09T11:11:48.2526493Z Selecting previously unselected package libraptor2-0:amd64.
+2025-12-09T11:11:48.2660550Z Preparing to unpack .../144-libraptor2-0_2.0.16-3ubuntu0.1_amd64.deb ...
+2025-12-09T11:11:48.2672879Z Unpacking libraptor2-0:amd64 (2.0.16-3ubuntu0.1) ...
+2025-12-09T11:11:48.2917962Z Selecting previously unselected package liblrdf0:amd64.
+2025-12-09T11:11:48.3050807Z Preparing to unpack .../145-liblrdf0_0.6.1-4build1_amd64.deb ...
+2025-12-09T11:11:48.3061189Z Unpacking liblrdf0:amd64 (0.6.1-4build1) ...
+2025-12-09T11:11:48.3309860Z Selecting previously unselected package libltc11:amd64.
+2025-12-09T11:11:48.3439529Z Preparing to unpack .../146-libltc11_1.3.2-1build1_amd64.deb ...
+2025-12-09T11:11:48.3449635Z Unpacking libltc11:amd64 (1.3.2-1build1) ...
+2025-12-09T11:11:48.3684559Z Selecting previously unselected package libmanette-0.2-0:amd64.
+2025-12-09T11:11:48.3814353Z Preparing to unpack .../147-libmanette-0.2-0_0.2.7-1build2_amd64.deb ...
+2025-12-09T11:11:48.3826757Z Unpacking libmanette-0.2-0:amd64 (0.2.7-1build2) ...
+2025-12-09T11:11:48.4052721Z Selecting previously unselected package libmfx1:amd64.
+2025-12-09T11:11:48.4181626Z Preparing to unpack .../148-libmfx1_22.5.4-1_amd64.deb ...
+2025-12-09T11:11:48.4190834Z Unpacking libmfx1:amd64 (22.5.4-1) ...
+2025-12-09T11:11:48.5252122Z Selecting previously unselected package libmjpegutils-2.1-0t64:amd64.
+2025-12-09T11:11:48.5386619Z Preparing to unpack .../149-libmjpegutils-2.1-0t64_1%3a2.1.0+debian-8.1build1_amd64.deb ...
+2025-12-09T11:11:48.5395930Z Unpacking libmjpegutils-2.1-0t64:amd64 (1:2.1.0+debian-8.1build1) ...
+2025-12-09T11:11:48.5629738Z Selecting previously unselected package libmodplug1:amd64.
+2025-12-09T11:11:48.5764744Z Preparing to unpack .../150-libmodplug1_1%3a0.8.9.0-3build1_amd64.deb ...
+2025-12-09T11:11:48.5773397Z Unpacking libmodplug1:amd64 (1:0.8.9.0-3build1) ...
+2025-12-09T11:11:48.6015711Z Selecting previously unselected package libmpcdec6:amd64.
+2025-12-09T11:11:48.6152762Z Preparing to unpack .../151-libmpcdec6_2%3a0.1~r495-2build1_amd64.deb ...
+2025-12-09T11:11:48.6161487Z Unpacking libmpcdec6:amd64 (2:0.1~r495-2build1) ...
+2025-12-09T11:11:48.6376963Z Selecting previously unselected package libmpeg2encpp-2.1-0t64:amd64.
+2025-12-09T11:11:48.6510300Z Preparing to unpack .../152-libmpeg2encpp-2.1-0t64_1%3a2.1.0+debian-8.1build1_amd64.deb ...
+2025-12-09T11:11:48.6520924Z Unpacking libmpeg2encpp-2.1-0t64:amd64 (1:2.1.0+debian-8.1build1) ...
+2025-12-09T11:11:48.6741807Z Selecting previously unselected package libmplex2-2.1-0t64:amd64.
+2025-12-09T11:11:48.6876215Z Preparing to unpack .../153-libmplex2-2.1-0t64_1%3a2.1.0+debian-8.1build1_amd64.deb ...
+2025-12-09T11:11:48.6885045Z Unpacking libmplex2-2.1-0t64:amd64 (1:2.1.0+debian-8.1build1) ...
+2025-12-09T11:11:48.7140284Z Selecting previously unselected package libneon27t64:amd64.
+2025-12-09T11:11:48.7275488Z Preparing to unpack .../154-libneon27t64_0.33.0-1.1build3_amd64.deb ...
+2025-12-09T11:11:48.7284655Z Unpacking libneon27t64:amd64 (0.33.0-1.1build3) ...
+2025-12-09T11:11:48.7519476Z Selecting previously unselected package libnice10:amd64.
+2025-12-09T11:11:48.7654571Z Preparing to unpack .../155-libnice10_0.1.21-2build3_amd64.deb ...
+2025-12-09T11:11:48.7663634Z Unpacking libnice10:amd64 (0.1.21-2build3) ...
+2025-12-09T11:11:48.7915704Z Selecting previously unselected package libopenal-data.
+2025-12-09T11:11:48.8052503Z Preparing to unpack .../156-libopenal-data_1%3a1.23.1-4build1_all.deb ...
+2025-12-09T11:11:48.8103177Z Unpacking libopenal-data (1:1.23.1-4build1) ...
+2025-12-09T11:11:48.8350343Z Selecting previously unselected package libopenexr-3-1-30:amd64.
+2025-12-09T11:11:48.8484095Z Preparing to unpack .../157-libopenexr-3-1-30_3.1.5-5.1build3_amd64.deb ...
+2025-12-09T11:11:48.8492514Z Unpacking libopenexr-3-1-30:amd64 (3.1.5-5.1build3) ...
+2025-12-09T11:11:48.8883441Z Selecting previously unselected package libopenh264-7:amd64.
+2025-12-09T11:11:48.9017327Z Preparing to unpack .../158-libopenh264-7_2.4.1+dfsg-1_amd64.deb ...
+2025-12-09T11:11:48.9026232Z Unpacking libopenh264-7:amd64 (2.4.1+dfsg-1) ...
+2025-12-09T11:11:48.9334889Z Selecting previously unselected package libopenni2-0:amd64.
+2025-12-09T11:11:48.9471842Z Preparing to unpack .../159-libopenni2-0_2.2.0.33+dfsg-18_amd64.deb ...
+2025-12-09T11:11:48.9507847Z Unpacking libopenni2-0:amd64 (2.2.0.33+dfsg-18) ...
+2025-12-09T11:11:48.9798149Z Selecting previously unselected package libqrencode4:amd64.
+2025-12-09T11:11:48.9935099Z Preparing to unpack .../160-libqrencode4_4.1.1-1build2_amd64.deb ...
+2025-12-09T11:11:48.9945649Z Unpacking libqrencode4:amd64 (4.1.1-1build2) ...
+2025-12-09T11:11:49.0166516Z Selecting previously unselected package libsecret-common.
+2025-12-09T11:11:49.0347210Z Preparing to unpack .../161-libsecret-common_0.21.4-1build3_all.deb ...
+2025-12-09T11:11:49.0638841Z Unpacking libsecret-common (0.21.4-1build3) ...
+2025-12-09T11:11:49.0876052Z Selecting previously unselected package libsecret-1-0:amd64.
+2025-12-09T11:11:49.1011735Z Preparing to unpack .../162-libsecret-1-0_0.21.4-1build3_amd64.deb ...
+2025-12-09T11:11:49.1026196Z Unpacking libsecret-1-0:amd64 (0.21.4-1build3) ...
+2025-12-09T11:11:49.1273916Z Selecting previously unselected package libsndio7.0:amd64.
+2025-12-09T11:11:49.1409696Z Preparing to unpack .../163-libsndio7.0_1.9.0-0.3build3_amd64.deb ...
+2025-12-09T11:11:49.1439913Z Unpacking libsndio7.0:amd64 (1.9.0-0.3build3) ...
+2025-12-09T11:11:49.1666686Z Selecting previously unselected package libsoundtouch1:amd64.
+2025-12-09T11:11:49.1801738Z Preparing to unpack .../164-libsoundtouch1_2.3.2+ds1-1build1_amd64.deb ...
+2025-12-09T11:11:49.1813521Z Unpacking libsoundtouch1:amd64 (2.3.2+ds1-1build1) ...
+2025-12-09T11:11:49.2058586Z Selecting previously unselected package libspandsp2t64:amd64.
+2025-12-09T11:11:49.2193914Z Preparing to unpack .../165-libspandsp2t64_0.0.6+dfsg-2.1build1_amd64.deb ...
+2025-12-09T11:11:49.2205974Z Unpacking libspandsp2t64:amd64 (0.0.6+dfsg-2.1build1) ...
+2025-12-09T11:11:49.2481264Z Selecting previously unselected package libsrtp2-1:amd64.
+2025-12-09T11:11:49.2616913Z Preparing to unpack .../166-libsrtp2-1_2.5.0-3build1_amd64.deb ...
+2025-12-09T11:11:49.2625649Z Unpacking libsrtp2-1:amd64 (2.5.0-3build1) ...
+2025-12-09T11:11:49.3019545Z Preparing to unpack .../167-libssh-4_0.10.6-2ubuntu0.2_amd64.deb ...
+2025-12-09T11:11:49.3492963Z Unpacking libssh-4:amd64 (0.10.6-2ubuntu0.2) over (0.10.6-2ubuntu0.1) ...
+2025-12-09T11:11:49.3855771Z Selecting previously unselected package libwildmidi2:amd64.
+2025-12-09T11:11:49.3996045Z Preparing to unpack .../168-libwildmidi2_0.4.3-1build3_amd64.deb ...
+2025-12-09T11:11:49.4004691Z Unpacking libwildmidi2:amd64 (0.4.3-1build3) ...
+2025-12-09T11:11:49.4257077Z Selecting previously unselected package libwoff1:amd64.
+2025-12-09T11:11:49.4393601Z Preparing to unpack .../169-libwoff1_1.0.2-2build1_amd64.deb ...
+2025-12-09T11:11:49.4402393Z Unpacking libwoff1:amd64 (1.0.2-2build1) ...
+2025-12-09T11:11:49.4635388Z Selecting previously unselected package libxcb-xkb1:amd64.
+2025-12-09T11:11:49.4769613Z Preparing to unpack .../170-libxcb-xkb1_1.15-1ubuntu2_amd64.deb ...
+2025-12-09T11:11:49.4780284Z Unpacking libxcb-xkb1:amd64 (1.15-1ubuntu2) ...
+2025-12-09T11:11:49.5017648Z Selecting previously unselected package libxkbcommon-x11-0:amd64.
+2025-12-09T11:11:49.5151656Z Preparing to unpack .../171-libxkbcommon-x11-0_1.6.0-1build1_amd64.deb ...
+2025-12-09T11:11:49.5160635Z Unpacking libxkbcommon-x11-0:amd64 (1.6.0-1build1) ...
+2025-12-09T11:11:49.5381553Z Selecting previously unselected package libzbar0t64:amd64.
+2025-12-09T11:11:49.5516499Z Preparing to unpack .../172-libzbar0t64_0.23.93-4build3_amd64.deb ...
+2025-12-09T11:11:49.5525255Z Unpacking libzbar0t64:amd64 (0.23.93-4build3) ...
+2025-12-09T11:11:49.5751921Z Selecting previously unselected package libzxing3:amd64.
+2025-12-09T11:11:49.5893006Z Preparing to unpack .../173-libzxing3_2.2.1-3_amd64.deb ...
+2025-12-09T11:11:49.5903546Z Unpacking libzxing3:amd64 (2.2.1-3) ...
+2025-12-09T11:11:49.6174111Z Selecting previously unselected package xfonts-encodings.
+2025-12-09T11:11:49.6315415Z Preparing to unpack .../174-xfonts-encodings_1%3a1.0.5-0ubuntu2_all.deb ...
+2025-12-09T11:11:49.6324249Z Unpacking xfonts-encodings (1:1.0.5-0ubuntu2) ...
+2025-12-09T11:11:49.6622402Z Selecting previously unselected package xfonts-utils.
+2025-12-09T11:11:49.6757287Z Preparing to unpack .../175-xfonts-utils_1%3a7.7+6build3_amd64.deb ...
+2025-12-09T11:11:49.6766453Z Unpacking xfonts-utils (1:7.7+6build3) ...
+2025-12-09T11:11:49.7172320Z Selecting previously unselected package xfonts-cyrillic.
+2025-12-09T11:11:49.7309612Z Preparing to unpack .../176-xfonts-cyrillic_1%3a1.0.5+nmu1_all.deb ...
+2025-12-09T11:11:49.7318682Z Unpacking xfonts-cyrillic (1:1.0.5+nmu1) ...
+2025-12-09T11:11:49.7679416Z Selecting previously unselected package xfonts-scalable.
+2025-12-09T11:11:49.7818778Z Preparing to unpack .../177-xfonts-scalable_1%3a1.0.3-1.3_all.deb ...
+2025-12-09T11:11:49.7833302Z Unpacking xfonts-scalable (1:1.0.3-1.3) ...
+2025-12-09T11:11:49.8096421Z Selecting previously unselected package libgstreamer-plugins-bad1.0-0:amd64.
+2025-12-09T11:11:49.8232283Z Preparing to unpack .../178-libgstreamer-plugins-bad1.0-0_1.24.2-1ubuntu4_amd64.deb ...
+2025-12-09T11:11:49.8242370Z Unpacking libgstreamer-plugins-bad1.0-0:amd64 (1.24.2-1ubuntu4) ...
+2025-12-09T11:11:49.8657351Z Selecting previously unselected package libdca0:amd64.
+2025-12-09T11:11:49.8792315Z Preparing to unpack .../179-libdca0_0.0.7-2build1_amd64.deb ...
+2025-12-09T11:11:49.8801096Z Unpacking libdca0:amd64 (0.0.7-2build1) ...
+2025-12-09T11:11:49.9044084Z Selecting previously unselected package libopenal1:amd64.
+2025-12-09T11:11:49.9179656Z Preparing to unpack .../180-libopenal1_1%3a1.23.1-4build1_amd64.deb ...
+2025-12-09T11:11:49.9190248Z Unpacking libopenal1:amd64 (1:1.23.1-4build1) ...
+2025-12-09T11:11:49.9475691Z Selecting previously unselected package libsbc1:amd64.
+2025-12-09T11:11:49.9611771Z Preparing to unpack .../181-libsbc1_2.0-1build1_amd64.deb ...
+2025-12-09T11:11:49.9622351Z Unpacking libsbc1:amd64 (2.0-1build1) ...
+2025-12-09T11:11:49.9837105Z Selecting previously unselected package libvo-aacenc0:amd64.
+2025-12-09T11:11:49.9978163Z Preparing to unpack .../182-libvo-aacenc0_0.1.3-2build1_amd64.deb ...
+2025-12-09T11:11:49.9987211Z Unpacking libvo-aacenc0:amd64 (0.1.3-2build1) ...
+2025-12-09T11:11:50.0217587Z Selecting previously unselected package libvo-amrwbenc0:amd64.
+2025-12-09T11:11:50.0359293Z Preparing to unpack .../183-libvo-amrwbenc0_0.1.3-2build1_amd64.deb ...
+2025-12-09T11:11:50.0369371Z Unpacking libvo-amrwbenc0:amd64 (0.1.3-2build1) ...
+2025-12-09T11:11:50.0589601Z Selecting previously unselected package gstreamer1.0-plugins-bad:amd64.
+2025-12-09T11:11:50.0729398Z Preparing to unpack .../184-gstreamer1.0-plugins-bad_1.24.2-1ubuntu4_amd64.deb ...
+2025-12-09T11:11:50.0738535Z Unpacking gstreamer1.0-plugins-bad:amd64 (1.24.2-1ubuntu4) ...
+2025-12-09T11:11:50.2518549Z Setting up libgme0:amd64 (0.6.3-7build1) ...
+2025-12-09T11:11:50.2554929Z Setting up libchromaprint1:amd64 (1.5.1-5) ...
+2025-12-09T11:11:50.2577393Z Setting up libssh-gcrypt-4:amd64 (0.10.6-2ubuntu0.2) ...
+2025-12-09T11:11:50.2636256Z Setting up libhwy1t64:amd64 (1.0.7-8.1build1) ...
+2025-12-09T11:11:50.2660865Z Setting up libcairo-script-interpreter2:amd64 (1.18.0-3build1) ...
+2025-12-09T11:11:50.2683859Z Setting up libfreeaptx0:amd64 (0.1.1-2build1) ...
+2025-12-09T11:11:50.2708562Z Setting up libdvdread8t64:amd64 (6.1.3-1.1build1) ...
+2025-12-09T11:11:50.2731660Z Setting up libudfread0:amd64 (1.1.2-1build1) ...
+2025-12-09T11:11:50.2756745Z Setting up libmodplug1:amd64 (1:0.8.9.0-3build1) ...
+2025-12-09T11:11:50.2781108Z Setting up libcdparanoia0:amd64 (3.10.2+debian-14build3) ...
+2025-12-09T11:11:50.2804440Z Setting up libvo-amrwbenc0:amd64 (0.1.3-2build1) ...
+2025-12-09T11:11:50.2826768Z Setting up libraw1394-11:amd64 (2.1.2-2build3) ...
+2025-12-09T11:11:50.2850828Z Setting up libsbc1:amd64 (2.0-1build1) ...
+2025-12-09T11:11:50.2876270Z Setting up libneon27t64:amd64 (0.33.0-1.1build3) ...
+2025-12-09T11:11:50.2898980Z Setting up libtag1v5-vanilla:amd64 (1.13.1-1build1) ...
+2025-12-09T11:11:50.2923819Z Setting up libharfbuzz-icu0:amd64 (8.3.0-2build2) ...
+2025-12-09T11:11:50.2948892Z Setting up libopenni2-0:amd64 (2.2.0.33+dfsg-18) ...
+2025-12-09T11:11:50.3201272Z Setting up libspeex1:amd64 (1.2.1-2ubuntu2.24.04.1) ...
+2025-12-09T11:11:50.3226602Z Setting up libshine3:amd64 (3.1.1-2build1) ...
+2025-12-09T11:11:50.3250802Z Setting up libcaca0:amd64 (0.99.beta20-4build2) ...
+2025-12-09T11:11:50.3273858Z Setting up libvpl2 (2023.3.0-1build1) ...
+2025-12-09T11:11:50.3301221Z Setting up libv4lconvert0t64:amd64 (1.26.1-4build3) ...
+2025-12-09T11:11:50.3324351Z Setting up libx264-164:amd64 (2:0.164.3108+git31e19f9-1) ...
+2025-12-09T11:11:50.3344758Z Setting up libtwolame0:amd64 (0.4.0-2build3) ...
+2025-12-09T11:11:50.3373808Z Setting up libmbedcrypto7t64:amd64 (2.28.8-1) ...
+2025-12-09T11:11:50.3396351Z Setting up libwoff1:amd64 (1.0.2-2build1) ...
+2025-12-09T11:11:50.3419222Z Setting up liblc3-1:amd64 (1.0.4-3build1) ...
+2025-12-09T11:11:50.3443239Z Setting up libqrencode4:amd64 (4.1.1-1build2) ...
+2025-12-09T11:11:50.3465550Z Setting up libhyphen0:amd64 (2.8.8-7build3) ...
+2025-12-09T11:11:50.3487040Z Setting up libgsm1:amd64 (1.0.22-1build1) ...
+2025-12-09T11:11:50.3512959Z Setting up libvisual-0.4-0:amd64 (0.4.2-2build1) ...
+2025-12-09T11:11:50.3537064Z Setting up libsoxr0:amd64 (0.1.3-4build3) ...
+2025-12-09T11:11:50.3561056Z Setting up libzix-0-0:amd64 (0.4.2-2build1) ...
+2025-12-09T11:11:50.3586322Z Setting up libcodec2-1.2:amd64 (1.2.0-2build1) ...
+2025-12-09T11:11:50.3609920Z Setting up libsrtp2-1:amd64 (2.5.0-3build1) ...
+2025-12-09T11:11:50.3634578Z Setting up libmysofa1:amd64 (1.3.2+dfsg-2ubuntu2) ...
+2025-12-09T11:11:50.3657229Z Setting up libraptor2-0:amd64 (2.0.16-3ubuntu0.1) ...
+2025-12-09T11:11:50.3683522Z Setting up libldacbt-enc2:amd64 (2.0.2.3+git20200429+ed310a0-4ubuntu2) ...
+2025-12-09T11:11:50.3739167Z Setting up fonts-wqy-zenhei (0.9.45-8) ...
+2025-12-09T11:11:50.3874235Z Setting up libwebrtc-audio-processing1:amd64 (0.3.1-0ubuntu6) ...
+2025-12-09T11:11:50.3899385Z Setting up fonts-freefont-ttf (20211204+svn4273-2) ...
+2025-12-09T11:11:50.3922947Z Setting up libevent-2.1-7t64:amd64 (2.1.12-stable-9ubuntu2) ...
+2025-12-09T11:11:50.3947050Z Setting up libsvtav1enc1d1:amd64 (1.7.0+dfsg-2build1) ...
+2025-12-09T11:11:50.3975143Z Setting up libsoup-3.0-common (3.4.4-5ubuntu0.5) ...
+2025-12-09T11:11:50.3996651Z Setting up libmpg123-0t64:amd64 (1.32.5-1ubuntu1.1) ...
+2025-12-09T11:11:50.4027664Z Setting up libcjson1:amd64 (1.7.17-1) ...
+2025-12-09T11:11:50.4060695Z Setting up libxvidcore4:amd64 (2:1.3.7-1build1) ...
+2025-12-09T11:11:50.4087049Z Setting up libmpcdec6:amd64 (2:0.1~r495-2build1) ...
+2025-12-09T11:11:50.4115958Z Setting up libmjpegutils-2.1-0t64:amd64 (1:2.1.0+debian-8.1build1) ...
+2025-12-09T11:11:50.4138769Z Setting up librav1e0:amd64 (0.7.1-2) ...
+2025-12-09T11:11:50.4162160Z Setting up liborc-0.4-0t64:amd64 (1:0.4.38-1ubuntu0.1) ...
+2025-12-09T11:11:50.4188978Z Setting up libxcb-xkb1:amd64 (1.15-1ubuntu2) ...
+2025-12-09T11:11:50.4216719Z Setting up libvo-aacenc0:amd64 (0.1.3-2build1) ...
+2025-12-09T11:11:50.4239693Z Setting up librist4:amd64 (0.2.10+dfsg-2) ...
+2025-12-09T11:11:50.4265498Z Setting up libglib2.0-0t64:amd64 (2.80.0-6ubuntu3.5) ...
+2025-12-09T11:11:50.4468419Z Setting up libblas3:amd64 (3.12.0-3build1.1) ...
+2025-12-09T11:11:50.4530770Z update-alternatives: using /usr/lib/x86_64-linux-gnu/blas/libblas.so.3 to provide /usr/lib/x86_64-linux-gnu/libblas.so.3 (libblas.so.3-x86_64-linux-gnu) in auto mode
+2025-12-09T11:11:50.4549088Z Setting up libegl-mesa0:amd64 (25.0.7-0ubuntu0.24.04.2) ...
+2025-12-09T11:11:50.4577050Z Setting up libsoundtouch1:amd64 (2.3.2+ds1-1build1) ...
+2025-12-09T11:11:50.4603173Z Setting up libglib2.0-data (2.80.0-6ubuntu3.5) ...
+2025-12-09T11:11:50.4629420Z Setting up libplacebo338:amd64 (6.338.2-2build1) ...
+2025-12-09T11:11:50.4652296Z Setting up libgles2:amd64 (1.7.0-1build1) ...
+2025-12-09T11:11:50.4682114Z Setting up fonts-tlwg-loma-otf (1:0.7.3-1) ...
+2025-12-09T11:11:50.4704741Z Setting up libva2:amd64 (2.20.0-2build1) ...
+2025-12-09T11:11:50.4732106Z Setting up libspa-0.2-modules:amd64 (1.0.5-1ubuntu3.1) ...
+2025-12-09T11:11:50.4755981Z Setting up libzxing3:amd64 (2.2.1-3) ...
+2025-12-09T11:11:50.4779232Z Setting up xfonts-encodings (1:1.0.5-0ubuntu2) ...
+2025-12-09T11:11:50.4804371Z Setting up libopus0:amd64 (1.4-1build1) ...
+2025-12-09T11:11:50.4873453Z Setting up libfaad2:amd64 (2.11.1-1build1) ...
+2025-12-09T11:11:50.4897357Z Setting up libxkbcommon-x11-0:amd64 (1.6.0-1build1) ...
+2025-12-09T11:11:50.4917672Z Setting up libdc1394-25:amd64 (2.2.6-4build1) ...
+2025-12-09T11:11:50.4943825Z Setting up libimath-3-1-29t64:amd64 (3.1.9-3.1ubuntu2) ...
+2025-12-09T11:11:50.4967364Z Setting up libunibreak5:amd64 (5.1-2build1) ...
+2025-12-09T11:11:50.4993457Z Setting up libdv4t64:amd64 (1.0.0-17.1build1) ...
+2025-12-09T11:11:50.5020098Z Setting up gir1.2-glib-2.0:amd64 (2.80.0-6ubuntu3.5) ...
+2025-12-09T11:11:50.5044477Z Setting up libjxl0.7:amd64 (0.7.0-10.2ubuntu6.1) ...
+2025-12-09T11:11:50.5069826Z Setting up libssh-4:amd64 (0.10.6-2ubuntu0.2) ...
+2025-12-09T11:11:50.5093315Z Setting up libopenh264-7:amd64 (2.4.1+dfsg-1) ...
+2025-12-09T11:11:50.5116584Z Setting up libltc11:amd64 (1.3.2-1build1) ...
+2025-12-09T11:11:50.5141865Z Setting up libx265-199:amd64 (3.5-2build1) ...
+2025-12-09T11:11:50.5165923Z Setting up libv4l-0t64:amd64 (1.26.1-4build3) ...
+2025-12-09T11:11:50.5189708Z Setting up libavtp0:amd64 (0.2.0-1build1) ...
+2025-12-09T11:11:50.5215990Z Setting up libsndio7.0:amd64 (1.9.0-0.3build3) ...
+2025-12-09T11:11:50.5239067Z Setting up libdirectfb-1.7-7t64:amd64 (1.7.7-11.1ubuntu2) ...
+2025-12-09T11:11:50.5381330Z Setting up libspandsp2t64:amd64 (0.0.6+dfsg-2.1build1) ...
+2025-12-09T11:11:50.5410218Z Setting up libvidstab1.1:amd64 (1.1.0-2build1) ...
+2025-12-09T11:11:50.5432130Z Setting up libvpx9:amd64 (1.14.0-1ubuntu2.2) ...
+2025-12-09T11:11:50.5456030Z Setting up libsrt1.5-gnutls:amd64 (1.5.3-1build2) ...
+2025-12-09T11:11:50.5485943Z Setting up libtag1v5:amd64 (1.13.1-1build1) ...
+2025-12-09T11:11:50.5518839Z Setting up libflite1:amd64 (2.2-6build3) ...
+2025-12-09T11:11:50.5552951Z Setting up libdav1d7:amd64 (1.4.1-1build1) ...
+2025-12-09T11:11:50.5578220Z Setting up libva-drm2:amd64 (2.20.0-2build1) ...
+2025-12-09T11:11:50.5600988Z Setting up fonts-ipafont-gothic (00303-21ubuntu1) ...
+2025-12-09T11:11:50.5673073Z update-alternatives: using /usr/share/fonts/opentype/ipafont-gothic/ipag.ttf to provide /usr/share/fonts/truetype/fonts-japanese-gothic.ttf (fonts-japanese-gothic.ttf) in auto mode
+2025-12-09T11:11:50.5693480Z Setting up ocl-icd-libopencl1:amd64 (2.3.2-1build1) ...
+2025-12-09T11:11:50.5717748Z Setting up libasyncns0:amd64 (0.8-6build4) ...
+2025-12-09T11:11:50.5745264Z Setting up libwildmidi2:amd64 (0.4.3-1build3) ...
+2025-12-09T11:11:50.5769828Z Setting up libvdpau1:amd64 (1.5-2build1) ...
+2025-12-09T11:11:50.5800028Z Setting up libwavpack1:amd64 (5.6.0-1build1) ...
+2025-12-09T11:11:50.5826245Z Setting up libbs2b0:amd64 (3.1.0+dfsg-7build1) ...
+2025-12-09T11:11:50.5851846Z Setting up libtheora0:amd64 (1.1.1+dfsg.1-16.1build3) ...
+2025-12-09T11:11:50.5876655Z Setting up libegl1:amd64 (1.7.0-1build1) ...
+2025-12-09T11:11:50.5900308Z Setting up libdecor-0-0:amd64 (0.2.2-1build2) ...
+2025-12-09T11:11:50.5922215Z Setting up libdca0:amd64 (0.0.7-2build1) ...
+2025-12-09T11:11:50.6006452Z Setting up libzimg2:amd64 (3.0.5+ds1-1build1) ...
+2025-12-09T11:11:50.6040799Z Setting up libopenal-data (1:1.23.1-4build1) ...
+2025-12-09T11:11:50.6073078Z Setting up libabsl20220623t64:amd64 (20220623.1-3.1ubuntu3.2) ...
+2025-12-09T11:11:50.6103284Z Setting up libflac12t64:amd64 (1.4.3+ds-2.1ubuntu2) ...
+2025-12-09T11:11:50.6130638Z Setting up libgtk-4-common (4.14.5+ds-0ubuntu0.7) ...
+2025-12-09T11:11:50.6165131Z Setting up libmpeg2encpp-2.1-0t64:amd64 (1:2.1.0+debian-8.1build1) ...
+2025-12-09T11:11:50.6197346Z Setting up glib-networking-common (2.80.0-1build1) ...
+2025-12-09T11:11:50.6219319Z Setting up libmfx1:amd64 (22.5.4-1) ...
+2025-12-09T11:11:50.6241930Z Setting up libbluray2:amd64 (1:1.3.4-1build1) ...
+2025-12-09T11:11:50.6269592Z Setting up libsamplerate0:amd64 (0.2.2-4build1) ...
+2025-12-09T11:11:50.6306219Z Setting up timgm6mb-soundfont (1.3-5) ...
+2025-12-09T11:11:50.6399787Z update-alternatives: using /usr/share/sounds/sf2/TimGM6mb.sf2 to provide /usr/share/sounds/sf2/default-GM.sf2 (default-GM.sf2) in auto mode
+2025-12-09T11:11:50.6442379Z update-alternatives: using /usr/share/sounds/sf2/TimGM6mb.sf2 to provide /usr/share/sounds/sf3/default-GM.sf3 (default-GM.sf3) in auto mode
+2025-12-09T11:11:50.6462393Z Setting up libva-x11-2:amd64 (2.20.0-2build1) ...
+2025-12-09T11:11:50.6497000Z Setting up libyuv0:amd64 (0.0~git202401110.af6ac82-1) ...
+2025-12-09T11:11:50.6522768Z Setting up libmplex2-2.1-0t64:amd64 (1:2.1.0+debian-8.1build1) ...
+2025-12-09T11:11:50.6547062Z Setting up libpipewire-0.3-0t64:amd64 (1.0.5-1ubuntu3.1) ...
+2025-12-09T11:11:50.6572431Z Setting up libcups2t64:amd64 (2.4.7-1.2ubuntu7.9) ...
+2025-12-09T11:11:50.6610497Z Setting up libopenmpt0t64:amd64 (0.7.3-1.1build3) ...
+2025-12-09T11:11:50.6638134Z Setting up libzvbi-common (0.2.42-2) ...
+2025-12-09T11:11:50.6667430Z Setting up libsecret-common (0.21.4-1build3) ...
+2025-12-09T11:11:50.6695895Z Setting up libmp3lame0:amd64 (3.100-6build1) ...
+2025-12-09T11:11:50.6722045Z Setting up libgraphene-1.0-0:amd64 (1.10.8-3build2) ...
+2025-12-09T11:11:50.6752733Z Setting up libvorbisenc2:amd64 (1.3.7-1build3) ...
+2025-12-09T11:11:50.6807457Z Setting up libdvdnav4:amd64 (6.1.1-3build1) ...
+2025-12-09T11:11:50.6836432Z Setting up fonts-unifont (1:15.1.01-1build1) ...
+2025-12-09T11:11:50.6865605Z Setting up libaa1:amd64 (1.4p5-51.1) ...
+2025-12-09T11:11:50.6900170Z Setting up libiec61883-0:amd64 (1.2.0-6build1) ...
+2025-12-09T11:11:50.6935468Z Setting up libserd-0-0:amd64 (0.32.2-1) ...
+2025-12-09T11:11:50.6962648Z Setting up libavc1394-0:amd64 (0.5.4-5build3) ...
+2025-12-09T11:11:50.6989733Z Setting up session-migration (0.3.9build1) ...
+2025-12-09T11:11:50.8232019Z Created symlink /etc/systemd/user/graphical-session-pre.target.wants/session-migration.service → /usr/lib/systemd/user/session-migration.service.
+2025-12-09T11:11:50.8232679Z 
+2025-12-09T11:11:50.8263420Z Setting up liblapack3:amd64 (3.12.0-3build1.1) ...
+2025-12-09T11:11:50.8334452Z update-alternatives: using /usr/lib/x86_64-linux-gnu/lapack/liblapack.so.3 to provide /usr/lib/x86_64-linux-gnu/liblapack.so.3 (liblapack.so.3-x86_64-linux-gnu) in auto mode
+2025-12-09T11:11:50.8357380Z Setting up libproxy1v5:amd64 (0.5.4-4build1) ...
+2025-12-09T11:11:50.8378637Z Setting up libzvbi0t64:amd64 (0.2.42-2) ...
+2025-12-09T11:11:50.8404542Z Setting up liblrdf0:amd64 (0.6.1-4build1) ...
+2025-12-09T11:11:50.8444520Z Setting up libmanette-0.2-0:amd64 (0.2.7-1build2) ...
+2025-12-09T11:11:50.8467753Z Setting up libglib2.0-bin (2.80.0-6ubuntu3.5) ...
+2025-12-09T11:11:50.8498954Z Setting up libzbar0t64:amd64 (0.23.93-4build3) ...
+2025-12-09T11:11:50.8523564Z Setting up libgstreamer-plugins-base1.0-0:amd64 (1.24.2-1ubuntu0.3) ...
+2025-12-09T11:11:50.8550018Z Setting up libavutil58:amd64 (7:6.1.1-3ubuntu5) ...
+2025-12-09T11:11:50.8578261Z Setting up libopenal1:amd64 (1:1.23.1-4build1) ...
+2025-12-09T11:11:50.8600651Z Setting up xfonts-utils (1:7.7+6build3) ...
+2025-12-09T11:11:50.8646053Z Setting up librsvg2-2:amd64 (2.58.0+dfsg-1build1) ...
+2025-12-09T11:11:50.8677052Z Setting up libsecret-1-0:amd64 (0.21.4-1build3) ...
+2025-12-09T11:11:50.8700622Z Setting up libgstreamer-plugins-good1.0-0:amd64 (1.24.2-1ubuntu1.2) ...
+2025-12-09T11:11:50.8723301Z Setting up libgstreamer-gl1.0-0:amd64 (1.24.2-1ubuntu0.3) ...
+2025-12-09T11:11:50.8747583Z Setting up gstreamer1.0-plugins-base:amd64 (1.24.2-1ubuntu0.3) ...
+2025-12-09T11:11:50.8770435Z Setting up libass9:amd64 (1:0.17.1-2build1) ...
+2025-12-09T11:11:50.8795977Z Setting up libswresample4:amd64 (7:6.1.1-3ubuntu5) ...
+2025-12-09T11:11:50.8826328Z Setting up libopenexr-3-1-30:amd64 (3.1.5-5.1build3) ...
+2025-12-09T11:11:50.8850891Z Setting up libshout3:amd64 (2.4.6-1build2) ...
+2025-12-09T11:11:50.8875800Z Setting up libgav1-1:amd64 (0.18.0-1build3) ...
+2025-12-09T11:11:50.8907401Z Setting up libavcodec60:amd64 (7:6.1.1-3ubuntu5) ...
+2025-12-09T11:11:50.8940322Z Setting up librubberband2:amd64 (3.3.0+dfsg-2build1) ...
+2025-12-09T11:11:50.8971783Z Setting up libjack-jackd2-0:amd64 (1.9.21~dfsg-3ubuntu3) ...
+2025-12-09T11:11:50.9001651Z Setting up libsord-0-0:amd64 (0.16.16-2build1) ...
+2025-12-09T11:11:50.9031059Z Setting up xfonts-cyrillic (1:1.0.5+nmu1) ...
+2025-12-09T11:11:50.9339622Z Setting up libpostproc57:amd64 (7:6.1.1-3ubuntu5) ...
+2025-12-09T11:11:50.9370434Z Setting up libsratom-0-0:amd64 (0.6.16-1build1) ...
+2025-12-09T11:11:50.9396756Z Setting up libgtk-4-1:amd64 (4.14.5+ds-0ubuntu0.7) ...
+2025-12-09T11:11:51.1867667Z Setting up libsndfile1:amd64 (1.2.2-1ubuntu5.24.04.1) ...
+2025-12-09T11:11:51.1895743Z Setting up liblilv-0-0:amd64 (0.24.22-1build1) ...
+2025-12-09T11:11:51.1920098Z Setting up libinstpatch-1.0-2:amd64 (1.1.6-1build2) ...
+2025-12-09T11:11:51.1951194Z Setting up xfonts-scalable (1:1.0.3-1.3) ...
+2025-12-09T11:11:51.2350608Z Setting up libswscale7:amd64 (7:6.1.1-3ubuntu5) ...
+2025-12-09T11:11:51.2378573Z Setting up gsettings-desktop-schemas (46.1-0ubuntu1) ...
+2025-12-09T11:11:51.2414146Z Setting up glib-networking-services (2.80.0-1build1) ...
+2025-12-09T11:11:51.2446652Z Setting up libavif16:amd64 (1.0.4-1ubuntu3) ...
+2025-12-09T11:11:51.2472433Z Setting up libpulse0:amd64 (1:16.1+dfsg1-2ubuntu10.1) ...
+2025-12-09T11:11:51.2559159Z Setting up libavformat60:amd64 (7:6.1.1-3ubuntu5) ...
+2025-12-09T11:11:51.2580809Z Setting up libsphinxbase3t64:amd64 (0.8+5prealpha+1-17build2) ...
+2025-12-09T11:11:51.2603429Z Setting up glib-networking:amd64 (2.80.0-1build1) ...
+2025-12-09T11:11:51.2641788Z Setting up libsdl2-2.0-0:amd64 (2.30.0+dfsg-1ubuntu3.1) ...
+2025-12-09T11:11:51.2702343Z Setting up libfluidsynth3:amd64 (2.3.4-1build3) ...
+2025-12-09T11:11:51.2723393Z Setting up libsoup-3.0-0:amd64 (3.4.4-5ubuntu0.5) ...
+2025-12-09T11:11:51.2749471Z Setting up libpocketsphinx3:amd64 (0.8.0+real5prealpha+1-15ubuntu5) ...
+2025-12-09T11:11:51.2778195Z Setting up libgssdp-1.6-0:amd64 (1.6.3-1build3) ...
+2025-12-09T11:11:51.2803500Z Setting up gstreamer1.0-plugins-good:amd64 (1.24.2-1ubuntu1.2) ...
+2025-12-09T11:11:51.2834409Z Setting up libgupnp-1.6-0:amd64 (1.6.6-1build3) ...
+2025-12-09T11:11:51.2862434Z Setting up libavfilter9:amd64 (7:6.1.1-3ubuntu5) ...
+2025-12-09T11:11:51.2884720Z Setting up libgupnp-igd-1.6-0:amd64 (1.6.0-3build3) ...
+2025-12-09T11:11:51.2910808Z Setting up gstreamer1.0-libav:amd64 (1.24.1-1build1) ...
+2025-12-09T11:11:51.2942176Z Setting up libnice10:amd64 (0.1.21-2build3) ...
+2025-12-09T11:11:51.2970916Z Setting up libgstreamer-plugins-bad1.0-0:amd64 (1.24.2-1ubuntu4) ...
+2025-12-09T11:11:51.2995190Z Setting up gstreamer1.0-plugins-bad:amd64 (1.24.2-1ubuntu4) ...
+2025-12-09T11:11:51.3033296Z Processing triggers for libc-bin (2.39-0ubuntu8.6) ...
+2025-12-09T11:11:51.3466943Z Processing triggers for man-db (2.12.0-4build2) ...
+2025-12-09T11:11:51.3497929Z Not building database; man-db/auto-update is not 'true'.
+2025-12-09T11:11:51.3515975Z Processing triggers for fontconfig (2.15.0-1.1ubuntu2) ...
+2025-12-09T11:11:52.0211461Z 
+2025-12-09T11:11:52.0212079Z Running kernel seems to be up-to-date.
+2025-12-09T11:11:52.0212508Z 
+2025-12-09T11:11:52.0212721Z Restarting services...
+2025-12-09T11:11:52.0642782Z  systemctl restart packagekit.service php8.3-fpm.service polkit.service udisks2.service
+2025-12-09T11:11:52.1919369Z 
+2025-12-09T11:11:52.1920267Z Service restarts being deferred:
+2025-12-09T11:11:52.1921221Z  systemctl restart ModemManager.service
+2025-12-09T11:11:52.1922004Z  systemctl restart networkd-dispatcher.service
+2025-12-09T11:11:52.1928960Z 
+2025-12-09T11:11:52.1929232Z No containers need to be restarted.
+2025-12-09T11:11:52.1929529Z 
+2025-12-09T11:11:52.1929792Z No user sessions are running outdated binaries.
+2025-12-09T11:11:52.1930106Z 
+2025-12-09T11:11:52.1930567Z No VM guests are running outdated hypervisor (qemu) binaries on this host.
+2025-12-09T11:11:53.1051102Z Downloading Chromium 141.0.7390.37 (playwright build v1194) from https://cdn.playwright.dev/dbazure/download/playwright/builds/chromium/1194/chromium-linux.zip
+2025-12-09T11:11:53.2604946Z |                                                                                |   0% of 173.9 MiB
+2025-12-09T11:11:53.3821651Z |■■■■■■■■                                                                        |  10% of 173.9 MiB
+2025-12-09T11:11:53.4679284Z |■■■■■■■■■■■■■■■■                                                                |  20% of 173.9 MiB
+2025-12-09T11:11:53.5534310Z |■■■■■■■■■■■■■■■■■■■■■■■■                                                        |  30% of 173.9 MiB
+2025-12-09T11:11:53.6262580Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■                                                |  40% of 173.9 MiB
+2025-12-09T11:11:53.6866681Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■                                        |  50% of 173.9 MiB
+2025-12-09T11:11:53.7493128Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■                                |  60% of 173.9 MiB
+2025-12-09T11:11:53.8117889Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■                        |  70% of 173.9 MiB
+2025-12-09T11:11:53.8748922Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■                |  80% of 173.9 MiB
+2025-12-09T11:11:53.9471704Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■        |  90% of 173.9 MiB
+2025-12-09T11:11:54.0167803Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■| 100% of 173.9 MiB
+2025-12-09T11:11:57.2608252Z Chromium 141.0.7390.37 (playwright build v1194) downloaded to /home/runner/.cache/ms-playwright/chromium-1194
+2025-12-09T11:11:57.2612260Z Downloading Chromium Headless Shell 141.0.7390.37 (playwright build v1194) from https://cdn.playwright.dev/dbazure/download/playwright/builds/chromium/1194/chromium-headless-shell-linux.zip
+2025-12-09T11:11:57.3928571Z |                                                                                |   0% of 104.3 MiB
+2025-12-09T11:11:57.4771235Z |■■■■■■■■                                                                        |  10% of 104.3 MiB
+2025-12-09T11:11:57.5291219Z |■■■■■■■■■■■■■■■■                                                                |  20% of 104.3 MiB
+2025-12-09T11:11:57.5683860Z |■■■■■■■■■■■■■■■■■■■■■■■■                                                        |  30% of 104.3 MiB
+2025-12-09T11:11:57.6116260Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■                                                |  40% of 104.3 MiB
+2025-12-09T11:11:57.6523197Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■                                        |  50% of 104.3 MiB
+2025-12-09T11:11:57.6887816Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■                                |  60% of 104.3 MiB
+2025-12-09T11:11:57.7245100Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■                        |  70% of 104.3 MiB
+2025-12-09T11:11:57.7673073Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■                |  80% of 104.3 MiB
+2025-12-09T11:11:57.8118522Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■        |  90% of 104.3 MiB
+2025-12-09T11:11:57.8516482Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■| 100% of 104.3 MiB
+2025-12-09T11:11:59.6027955Z Chromium Headless Shell 141.0.7390.37 (playwright build v1194) downloaded to /home/runner/.cache/ms-playwright/chromium_headless_shell-1194
+2025-12-09T11:11:59.6031105Z Downloading Firefox 142.0.1 (playwright build v1495) from https://cdn.playwright.dev/dbazure/download/playwright/builds/firefox/1495/firefox-ubuntu-24.04.zip
+2025-12-09T11:11:59.7356017Z |                                                                                |   0% of 96.7 MiB
+2025-12-09T11:11:59.8079281Z |■■■■■■■■                                                                        |  10% of 96.7 MiB
+2025-12-09T11:11:59.8688151Z |■■■■■■■■■■■■■■■■                                                                |  20% of 96.7 MiB
+2025-12-09T11:11:59.9104869Z |■■■■■■■■■■■■■■■■■■■■■■■■                                                        |  30% of 96.7 MiB
+2025-12-09T11:11:59.9562495Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■                                                |  40% of 96.7 MiB
+2025-12-09T11:11:59.9914515Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■                                        |  50% of 96.7 MiB
+2025-12-09T11:12:00.0295985Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■                                |  60% of 96.7 MiB
+2025-12-09T11:12:00.0728361Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■                        |  70% of 96.7 MiB
+2025-12-09T11:12:00.1113422Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■                |  80% of 96.7 MiB
+2025-12-09T11:12:00.1455648Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■        |  90% of 96.7 MiB
+2025-12-09T11:12:00.1856708Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■| 100% of 96.7 MiB
+2025-12-09T11:12:01.8197065Z Firefox 142.0.1 (playwright build v1495) downloaded to /home/runner/.cache/ms-playwright/firefox-1495
+2025-12-09T11:12:01.8200512Z Downloading Webkit 26.0 (playwright build v2215) from https://cdn.playwright.dev/dbazure/download/playwright/builds/webkit/2215/webkit-ubuntu-24.04.zip
+2025-12-09T11:12:01.9452774Z |                                                                                |   0% of 94.6 MiB
+2025-12-09T11:12:02.0165566Z |■■■■■■■■                                                                        |  10% of 94.6 MiB
+2025-12-09T11:12:02.0780918Z |■■■■■■■■■■■■■■■■                                                                |  20% of 94.6 MiB
+2025-12-09T11:12:02.1277819Z |■■■■■■■■■■■■■■■■■■■■■■■■                                                        |  30% of 94.6 MiB
+2025-12-09T11:12:02.1847322Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■                                                |  40% of 94.6 MiB
+2025-12-09T11:12:02.2223336Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■                                        |  50% of 94.6 MiB
+2025-12-09T11:12:02.2614197Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■                                |  60% of 94.6 MiB
+2025-12-09T11:12:02.2998015Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■                        |  70% of 94.6 MiB
+2025-12-09T11:12:02.3395312Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■                |  80% of 94.6 MiB
+2025-12-09T11:12:02.3769720Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■        |  90% of 94.6 MiB
+2025-12-09T11:12:02.4135509Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■| 100% of 94.6 MiB
+2025-12-09T11:12:04.0856938Z Webkit 26.0 (playwright build v2215) downloaded to /home/runner/.cache/ms-playwright/webkit-2215
+2025-12-09T11:12:04.0860604Z Downloading FFMPEG playwright build v1011 from https://cdn.playwright.dev/dbazure/download/playwright/builds/ffmpeg/1011/ffmpeg-linux.zip
+2025-12-09T11:12:04.2234068Z |                                                                                |   0% of 2.3 MiB
+2025-12-09T11:12:04.2271874Z |■■■■■■■■                                                                        |  10% of 2.3 MiB
+2025-12-09T11:12:04.2303989Z |■■■■■■■■■■■■■■■■                                                                |  20% of 2.3 MiB
+2025-12-09T11:12:04.2372609Z |■■■■■■■■■■■■■■■■■■■■■■■■                                                        |  30% of 2.3 MiB
+2025-12-09T11:12:04.2396751Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■                                                |  40% of 2.3 MiB
+2025-12-09T11:12:04.2428132Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■                                        |  50% of 2.3 MiB
+2025-12-09T11:12:04.2446996Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■                                |  60% of 2.3 MiB
+2025-12-09T11:12:04.2467004Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■                        |  70% of 2.3 MiB
+2025-12-09T11:12:04.2483635Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■                |  80% of 2.3 MiB
+2025-12-09T11:12:04.2497894Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■        |  90% of 2.3 MiB
+2025-12-09T11:12:04.2513035Z |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■| 100% of 2.3 MiB
+2025-12-09T11:12:04.3079359Z FFMPEG playwright build v1011 downloaded to /home/runner/.cache/ms-playwright/ffmpeg-1011
+2025-12-09T11:12:04.7541382Z ##[group]Run npx tsc --noEmit
+2025-12-09T11:12:04.7541863Z [36;1mnpx tsc --noEmit[0m
+2025-12-09T11:12:04.7589311Z shell: /usr/bin/bash -e {0}
+2025-12-09T11:12:04.7589678Z ##[endgroup]
+2025-12-09T11:12:06.3140843Z ##[group]Run npx playwright test --grep "@critical" --reporter=html
+2025-12-09T11:12:06.3141316Z [36;1mnpx playwright test --grep "@critical" --reporter=html[0m
+2025-12-09T11:12:06.3175410Z shell: /usr/bin/bash -e {0}
+2025-12-09T11:12:06.3175637Z env:
+2025-12-09T11:12:06.3175804Z   CI: true
+2025-12-09T11:12:06.3175975Z ##[endgroup]
+2025-12-09T11:12:09.5200669Z 
+2025-12-09T11:12:09.5201221Z Running 20 tests using 1 worker
+2025-12-09T11:12:14.4123121Z ····Course link href: /myFreecodecampLearning/pages/s100101-Certified-Full-Stack-Developer-Curriculum/Home-Certified-Full-Stack-Developer-Curriculum.html
+2025-12-09T11:12:14.4443300Z Navigation response status: [33m200[39m
+2025-12-09T11:12:14.4445176Z Navigation URL: http://localhost:4000/myFreecodecampLearning/pages/s100101-Certified-Full-Stack-Developer-Curriculum/Home-Certified-Full-Stack-Developer-Curriculum.html
+2025-12-09T11:12:21.1029431Z ·····Course link href: /myFreecodecampLearning/pages/s100101-Certified-Full-Stack-Developer-Curriculum/Home-Certified-Full-Stack-Developer-Curriculum.html
+2025-12-09T11:12:21.1754957Z Navigation response status: [33m200[39m
+2025-12-09T11:12:21.1758158Z Navigation URL: http://localhost:4000/myFreecodecampLearning/pages/s100101-Certified-Full-Stack-Developer-Curriculum/Home-Certified-Full-Stack-Developer-Curriculum.html
+2025-12-09T11:12:32.3491563Z ·····Course link href: /myFreecodecampLearning/pages/s100101-Certified-Full-Stack-Developer-Curriculum/Home-Certified-Full-Stack-Developer-Curriculum.html
+2025-12-09T11:12:32.3883555Z Navigation response status: [33m200[39m
+2025-12-09T11:12:32.3885637Z Navigation URL: http://localhost:4000/myFreecodecampLearning/pages/s100101-Certified-Full-Stack-Developer-Curriculum/Home-Certified-Full-Stack-Developer-Curriculum.html
+2025-12-09T11:12:58.8293571Z ·····Course link href: /myFreecodecampLearning/pages/s100101-Certified-Full-Stack-Developer-Curriculum/Home-Certified-Full-Stack-Developer-Curriculum.html
+2025-12-09T11:12:58.8788881Z Navigation response status: [33m200[39m
+2025-12-09T11:12:58.8791420Z Navigation URL: http://localhost:4000/myFreecodecampLearning/pages/s100101-Certified-Full-Stack-Developer-Curriculum/Home-Certified-Full-Stack-Developer-Curriculum.html
+2025-12-09T11:13:06.2509257Z ·
+2025-12-09T11:13:06.2514012Z   20 passed (58.8s)
+2025-12-09T11:13:06.2959438Z ##[group]Run actions/upload-artifact@v4
+2025-12-09T11:13:06.2959724Z with:
+2025-12-09T11:13:06.2959958Z   name: playwright-report-staging-pre-deployment
+2025-12-09T11:13:06.2960259Z   path: playwright-report/
+2025-12-09T11:13:06.2960482Z   retention-days: 7
+2025-12-09T11:13:06.2960677Z   if-no-files-found: warn
+2025-12-09T11:13:06.2960883Z   compression-level: 6
+2025-12-09T11:13:06.2961300Z   overwrite: false
+2025-12-09T11:13:06.2961497Z   include-hidden-files: false
+2025-12-09T11:13:06.2961711Z ##[endgroup]
+2025-12-09T11:13:06.5097372Z With the provided path, there will be 1 file uploaded
+2025-12-09T11:13:06.5102792Z Artifact name is valid!
+2025-12-09T11:13:06.5104071Z Root directory input is valid!
+2025-12-09T11:13:06.8438867Z Beginning upload of artifact content to blob storage
+2025-12-09T11:13:07.3520572Z Uploaded bytes 203073
+2025-12-09T11:13:07.4291156Z Finished uploading artifact content to blob storage!
+2025-12-09T11:13:07.4294403Z SHA256 digest of uploaded artifact zip is 26431a81bd5ae41822267894292b666cb7444cd037e5d7407d930dc5790a0acd
+2025-12-09T11:13:07.4295553Z Finalizing artifact upload
+2025-12-09T11:13:07.6249808Z Artifact playwright-report-staging-pre-deployment.zip successfully finalized. Artifact ID 4809678795
+2025-12-09T11:13:07.6252173Z Artifact playwright-report-staging-pre-deployment has been successfully uploaded! Final size is 203073 bytes. Artifact ID is 4809678795
+2025-12-09T11:13:07.6257898Z Artifact download URL: https://github.com/T193R-W00D5/myFreecodecampLearning/actions/runs/20061398824/artifacts/4809678795
+2025-12-09T11:13:07.6379676Z Post job cleanup.
+2025-12-09T11:13:07.7906005Z Cache hit occurred on the primary key node-cache-Linux-x64-npm-e3fade3f30968ac95fccac45edc85cd25eaa881f6a1cdb7268c834223e952c45, not saving cache.
+2025-12-09T11:13:07.8038414Z Post job cleanup.
+2025-12-09T11:13:07.8996687Z [command]/usr/bin/git version
+2025-12-09T11:13:07.9032222Z git version 2.52.0
+2025-12-09T11:13:07.9077817Z Temporarily overriding HOME='/home/runner/work/_temp/cc93591b-f25b-4016-9d22-772bbc4c52ed' before making global git config changes
+2025-12-09T11:13:07.9079023Z Adding repository directory to the temporary git global config as a safe directory
+2025-12-09T11:13:07.9083396Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/myFreecodecampLearning/myFreecodecampLearning
+2025-12-09T11:13:07.9119227Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+2025-12-09T11:13:07.9150457Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+2025-12-09T11:13:07.9379949Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+2025-12-09T11:13:07.9401819Z http.https://github.com/.extraheader
+2025-12-09T11:13:07.9414736Z [command]/usr/bin/git config --local --unset-all http.https://github.com/.extraheader
+2025-12-09T11:13:07.9445504Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+2025-12-09T11:13:07.9667162Z [command]/usr/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+2025-12-09T11:13:07.9700893Z [command]/usr/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+2025-12-09T11:13:08.0023557Z Cleaning up orphan processes
+
+logs for deploy-staging job
+2025-12-09T11:13:15.9528723Z Current runner version: '2.329.0'
+2025-12-09T11:13:15.9554705Z ##[group]Runner Image Provisioner
+2025-12-09T11:13:15.9555879Z Hosted Compute Agent
+2025-12-09T11:13:15.9556412Z Version: 20251124.448
+2025-12-09T11:13:15.9557118Z Commit: fda5086b43ec66ade217e5fcd18146c879571177
+2025-12-09T11:13:15.9557833Z Build Date: 2025-11-24T21:16:26Z
+2025-12-09T11:13:15.9558391Z ##[endgroup]
+2025-12-09T11:13:15.9558961Z ##[group]Operating System
+2025-12-09T11:13:15.9559513Z Ubuntu
+2025-12-09T11:13:15.9560029Z 24.04.3
+2025-12-09T11:13:15.9560487Z LTS
+2025-12-09T11:13:15.9561018Z ##[endgroup]
+2025-12-09T11:13:15.9561496Z ##[group]Runner Image
+2025-12-09T11:13:15.9562032Z Image: ubuntu-24.04
+2025-12-09T11:13:15.9562611Z Version: 20251126.144.1
+2025-12-09T11:13:15.9563609Z Included Software: https://github.com/actions/runner-images/blob/ubuntu24/20251126.144/images/ubuntu/Ubuntu2404-Readme.md
+2025-12-09T11:13:15.9565359Z Image Release: https://github.com/actions/runner-images/releases/tag/ubuntu24%2F20251126.144
+2025-12-09T11:13:15.9566389Z ##[endgroup]
+2025-12-09T11:13:15.9569206Z ##[group]GITHUB_TOKEN Permissions
+2025-12-09T11:13:15.9571611Z Actions: write
+2025-12-09T11:13:15.9572155Z ArtifactMetadata: write
+2025-12-09T11:13:15.9572814Z Attestations: write
+2025-12-09T11:13:15.9573300Z Checks: write
+2025-12-09T11:13:15.9573793Z Contents: write
+2025-12-09T11:13:15.9574360Z Deployments: write
+2025-12-09T11:13:15.9574880Z Discussions: write
+2025-12-09T11:13:15.9575552Z Issues: write
+2025-12-09T11:13:15.9576071Z Metadata: read
+2025-12-09T11:13:15.9576589Z Models: read
+2025-12-09T11:13:15.9577044Z Packages: write
+2025-12-09T11:13:15.9577581Z Pages: write
+2025-12-09T11:13:15.9578097Z PullRequests: write
+2025-12-09T11:13:15.9578632Z RepositoryProjects: write
+2025-12-09T11:13:15.9579347Z SecurityEvents: write
+2025-12-09T11:13:15.9579873Z Statuses: write
+2025-12-09T11:13:15.9580368Z ##[endgroup]
+2025-12-09T11:13:15.9582464Z Secret source: Actions
+2025-12-09T11:13:15.9583717Z Prepare workflow directory
+2025-12-09T11:13:15.9925959Z Prepare all required actions
+2025-12-09T11:13:15.9966822Z Getting action download info
+2025-12-09T11:13:16.3621535Z Download action repository 'actions/checkout@v4' (SHA:34e114876b0b11c390a56381ad16ebd13914f8d5)
+2025-12-09T11:13:16.7722882Z Download action repository 'ruby/setup-ruby@v1' (SHA:d697be2f83c6234b20877c3b5eac7a7f342f0d0c)
+2025-12-09T11:13:17.1447454Z Download action repository 'peaceiris/actions-gh-pages@v4' (SHA:4f9cc6602d3f66b9c108549d475ec49e8ef4d45e)
+2025-12-09T11:13:17.5980707Z Complete job name: deploy-staging
+2025-12-09T11:13:17.6842956Z ##[group]Run actions/checkout@v4
+2025-12-09T11:13:17.6844262Z with:
+2025-12-09T11:13:17.6844949Z   ref: main
+2025-12-09T11:13:17.6845966Z   repository: T193R-W00D5/myFreecodecampLearning
+2025-12-09T11:13:17.6847435Z   token: ***
+2025-12-09T11:13:17.6848166Z   ssh-strict: true
+2025-12-09T11:13:17.6848910Z   ssh-user: git
+2025-12-09T11:13:17.6849676Z   persist-credentials: true
+2025-12-09T11:13:17.6850543Z   clean: true
+2025-12-09T11:13:17.6851317Z   sparse-checkout-cone-mode: true
+2025-12-09T11:13:17.6852293Z   fetch-depth: 1
+2025-12-09T11:13:17.6853056Z   fetch-tags: false
+2025-12-09T11:13:17.6853837Z   show-progress: true
+2025-12-09T11:13:17.6854638Z   lfs: false
+2025-12-09T11:13:17.6855497Z   submodules: false
+2025-12-09T11:13:17.6856314Z   set-safe-directory: true
+2025-12-09T11:13:17.6857462Z ##[endgroup]
+2025-12-09T11:13:17.8028294Z Syncing repository: T193R-W00D5/myFreecodecampLearning
+2025-12-09T11:13:17.8031494Z ##[group]Getting Git version info
+2025-12-09T11:13:17.8033336Z Working directory is '/home/runner/work/myFreecodecampLearning/myFreecodecampLearning'
+2025-12-09T11:13:17.8036331Z [command]/usr/bin/git version
+2025-12-09T11:13:17.8085869Z git version 2.52.0
+2025-12-09T11:13:17.8115174Z ##[endgroup]
+2025-12-09T11:13:17.8132395Z Temporarily overriding HOME='/home/runner/work/_temp/3e04af8c-cb1a-4b9b-82e5-2f459fb7a845' before making global git config changes
+2025-12-09T11:13:17.8135199Z Adding repository directory to the temporary git global config as a safe directory
+2025-12-09T11:13:17.8146387Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/myFreecodecampLearning/myFreecodecampLearning
+2025-12-09T11:13:17.8189566Z Deleting the contents of '/home/runner/work/myFreecodecampLearning/myFreecodecampLearning'
+2025-12-09T11:13:17.8192945Z ##[group]Initializing the repository
+2025-12-09T11:13:17.8197766Z [command]/usr/bin/git init /home/runner/work/myFreecodecampLearning/myFreecodecampLearning
+2025-12-09T11:13:17.8313591Z hint: Using 'master' as the name for the initial branch. This default branch name
+2025-12-09T11:13:17.8317039Z hint: will change to "main" in Git 3.0. To configure the initial branch name
+2025-12-09T11:13:17.8319053Z hint: to use in all of your new repositories, which will suppress this warning,
+2025-12-09T11:13:17.8320493Z hint: call:
+2025-12-09T11:13:17.8321258Z hint:
+2025-12-09T11:13:17.8322580Z hint: 	git config --global init.defaultBranch <name>
+2025-12-09T11:13:17.8323905Z hint:
+2025-12-09T11:13:17.8325022Z hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
+2025-12-09T11:13:17.8327319Z hint: 'development'. The just-created branch can be renamed via this command:
+2025-12-09T11:13:17.8329212Z hint:
+2025-12-09T11:13:17.8329974Z hint: 	git branch -m <name>
+2025-12-09T11:13:17.8330853Z hint:
+2025-12-09T11:13:17.8332027Z hint: Disable this message with "git config set advice.defaultBranchName false"
+2025-12-09T11:13:17.8334504Z Initialized empty Git repository in /home/runner/work/myFreecodecampLearning/myFreecodecampLearning/.git/
+2025-12-09T11:13:17.8338622Z [command]/usr/bin/git remote add origin https://github.com/T193R-W00D5/myFreecodecampLearning
+2025-12-09T11:13:17.8368172Z ##[endgroup]
+2025-12-09T11:13:17.8369786Z ##[group]Disabling automatic garbage collection
+2025-12-09T11:13:17.8371716Z [command]/usr/bin/git config --local gc.auto 0
+2025-12-09T11:13:17.8402889Z ##[endgroup]
+2025-12-09T11:13:17.8404206Z ##[group]Setting up auth
+2025-12-09T11:13:17.8409455Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+2025-12-09T11:13:17.8442024Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+2025-12-09T11:13:17.8788669Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+2025-12-09T11:13:17.8822017Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+2025-12-09T11:13:17.9051801Z [command]/usr/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+2025-12-09T11:13:17.9084725Z [command]/usr/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+2025-12-09T11:13:17.9334698Z [command]/usr/bin/git config --local http.https://github.com/.extraheader AUTHORIZATION: basic ***
+2025-12-09T11:13:17.9375819Z ##[endgroup]
+2025-12-09T11:13:17.9378259Z ##[group]Fetching the repository
+2025-12-09T11:13:17.9388390Z [command]/usr/bin/git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +refs/heads/main*:refs/remotes/origin/main* +refs/tags/main*:refs/tags/main*
+2025-12-09T11:13:18.3707293Z From https://github.com/T193R-W00D5/myFreecodecampLearning
+2025-12-09T11:13:18.3709864Z  * [new branch]      main       -> origin/main
+2025-12-09T11:13:18.3742388Z ##[endgroup]
+2025-12-09T11:13:18.3744018Z ##[group]Determining the checkout info
+2025-12-09T11:13:18.3748558Z [command]/usr/bin/git branch --list --remote origin/main
+2025-12-09T11:13:18.3772724Z   origin/main
+2025-12-09T11:13:18.3779022Z ##[endgroup]
+2025-12-09T11:13:18.3782374Z [command]/usr/bin/git sparse-checkout disable
+2025-12-09T11:13:18.3821868Z [command]/usr/bin/git config --local --unset-all extensions.worktreeConfig
+2025-12-09T11:13:18.3849989Z ##[group]Checking out the ref
+2025-12-09T11:13:18.3852595Z [command]/usr/bin/git checkout --progress --force -B main refs/remotes/origin/main
+2025-12-09T11:13:18.4203767Z Switched to a new branch 'main'
+2025-12-09T11:13:18.4205840Z branch 'main' set up to track 'origin/main'.
+2025-12-09T11:13:18.4216889Z ##[endgroup]
+2025-12-09T11:13:18.4255519Z [command]/usr/bin/git log -1 --format=%H
+2025-12-09T11:13:18.4278987Z d1c48a37612e974c398263097bde7994acc3f9b6
+2025-12-09T11:13:18.4481715Z ##[group]Run echo "🧪 STAGING DEPLOYMENT" >> $GITHUB_STEP_SUMMARY
+2025-12-09T11:13:18.4483308Z [36;1mecho "🧪 STAGING DEPLOYMENT" >> $GITHUB_STEP_SUMMARY[0m
+2025-12-09T11:13:18.4484976Z [36;1mecho "**Commit being deployed:** $(git rev-parse HEAD)" >> $GITHUB_STEP_SUMMARY[0m
+2025-12-09T11:13:18.4487134Z [36;1mecho "**Commit details:** $(git log --oneline -n 1)" >> $GITHUB_STEP_SUMMARY[0m
+2025-12-09T11:13:18.4526173Z shell: /usr/bin/bash -e {0}
+2025-12-09T11:13:18.4527084Z ##[endgroup]
+2025-12-09T11:13:18.4768090Z ##[group]Run ruby/setup-ruby@v1
+2025-12-09T11:13:18.4769033Z with:
+2025-12-09T11:13:18.4769706Z   ruby-version: 3.3
+2025-12-09T11:13:18.4770463Z   bundler-cache: false
+2025-12-09T11:13:18.4771254Z ##[endgroup]
+2025-12-09T11:13:18.6743269Z ##[group]Modifying PATH
+2025-12-09T11:13:18.6748539Z Entries added to PATH to use selected Ruby:
+2025-12-09T11:13:18.6752945Z   /opt/hostedtoolcache/Ruby/3.3.10/x64/bin
+2025-12-09T11:13:18.6761849Z ##[endgroup]
+2025-12-09T11:13:18.6764140Z ##[group]Print Ruby version
+2025-12-09T11:13:18.6893915Z [command]/opt/hostedtoolcache/Ruby/3.3.10/x64/bin/ruby --version
+2025-12-09T11:13:19.0226844Z ruby 3.3.10 (2025-10-23 revision 343ea05002) [x86_64-linux]
+2025-12-09T11:13:19.0260782Z Took   0.35 seconds
+2025-12-09T11:13:19.0262573Z ##[endgroup]
+2025-12-09T11:13:19.0263975Z ##[group]Installing Bundler
+2025-12-09T11:13:19.0268531Z Using Bundler 2.7.2 from Gemfile.lock BUNDLED WITH 2.7.2
+2025-12-09T11:13:19.0273251Z [command]/opt/hostedtoolcache/Ruby/3.3.10/x64/bin/gem install bundler -v 2.7.2
+2025-12-09T11:13:20.6827652Z Successfully installed bundler-2.7.2
+2025-12-09T11:13:20.6828313Z 1 gem installed
+2025-12-09T11:13:20.6890898Z Took   1.66 seconds
+2025-12-09T11:13:20.6892143Z ##[endgroup]
+2025-12-09T11:13:20.6980869Z ##[group]Run rm -rf _site
+2025-12-09T11:13:20.6981178Z [36;1mrm -rf _site[0m
+2025-12-09T11:13:20.6981390Z [36;1mrm -rf .sass-cache[0m
+2025-12-09T11:13:20.6981712Z [36;1mecho "Cleaned existing build artifacts" >> $GITHUB_STEP_SUMMARY[0m
+2025-12-09T11:13:20.7018616Z shell: /usr/bin/bash -e {0}
+2025-12-09T11:13:20.7018879Z ##[endgroup]
+2025-12-09T11:13:20.7199126Z ##[group]Run bundle config set --local frozen false
+2025-12-09T11:13:20.7199561Z [36;1mbundle config set --local frozen false[0m
+2025-12-09T11:13:20.7199830Z [36;1mbundle install[0m
+2025-12-09T11:13:20.7200042Z [36;1m[0m
+2025-12-09T11:13:20.7200235Z [36;1m# Debug Jekyll environment[0m
+2025-12-09T11:13:20.7200662Z [36;1mecho "Jekyll version: $(bundle exec jekyll --version)" >> $GITHUB_STEP_SUMMARY[0m
+2025-12-09T11:13:20.7201113Z [36;1mecho "Ruby version: $(ruby --version)" >> $GITHUB_STEP_SUMMARY[0m
+2025-12-09T11:13:20.7201512Z [36;1mecho "Current directory: $(pwd)" >> $GITHUB_STEP_SUMMARY[0m
+2025-12-09T11:13:20.7201807Z [36;1m[0m
+2025-12-09T11:13:20.7202031Z [36;1m# Build with staging baseurl and verbose output[0m
+2025-12-09T11:13:20.7202416Z [36;1mecho "Starting Jekyll build for staging..." >> $GITHUB_STEP_SUMMARY[0m
+2025-12-09T11:13:20.7202891Z [36;1mbundle exec jekyll build --baseurl "/myFreecodecampLearning/staging" --verbose[0m
+2025-12-09T11:13:20.7203291Z [36;1m[0m
+2025-12-09T11:13:20.7203595Z [36;1mecho "Jekyll staging build completed. Contents of _site:" >> $GITHUB_STEP_SUMMARY[0m
+2025-12-09T11:13:20.7203998Z [36;1mls -la _site/ >> $GITHUB_STEP_SUMMARY[0m
+2025-12-09T11:13:20.7204373Z [36;1mecho "Checking for Liquid syntax in generated files:" >> $GITHUB_STEP_SUMMARY[0m
+2025-12-09T11:13:20.7204906Z [36;1mgrep -n "{{" _site/index.html || echo "✅ No unprocessed Liquid syntax found" >> $GITHUB_STEP_SUMMARY[0m
+2025-12-09T11:13:20.7205921Z [36;1mecho "Checking CSS link paths:" >> $GITHUB_STEP_SUMMARY[0m
+2025-12-09T11:13:20.7206430Z [36;1mgrep -n "css" _site/index.html >> $GITHUB_STEP_SUMMARY || echo "No CSS links found" >> $GITHUB_STEP_SUMMARY[0m
+2025-12-09T11:13:20.7241286Z shell: /usr/bin/bash -e {0}
+2025-12-09T11:13:20.7241573Z ##[endgroup]
+2025-12-09T11:13:22.7889263Z Fetching gem metadata from https://rubygems.org/..........
+2025-12-09T11:13:22.7941642Z Fetching rake 13.3.1
+2025-12-09T11:13:22.8555688Z Installing rake 13.3.1
+2025-12-09T11:13:22.8705712Z Fetching public_suffix 7.0.0
+2025-12-09T11:13:22.8708271Z Fetching base64 0.3.0
+2025-12-09T11:13:22.8708667Z Fetching bigdecimal 3.3.1
+2025-12-09T11:13:22.8709085Z Fetching colorator 1.1.0
+2025-12-09T11:13:22.8807678Z Installing base64 0.3.0
+2025-12-09T11:13:22.8876185Z Installing colorator 1.1.0
+2025-12-09T11:13:22.8884668Z Installing public_suffix 7.0.0
+2025-12-09T11:13:22.8950441Z Fetching concurrent-ruby 1.3.5
+2025-12-09T11:13:22.8973604Z Installing bigdecimal 3.3.1 with native extensions
+2025-12-09T11:13:22.9049578Z Fetching csv 3.3.5
+2025-12-09T11:13:22.9191445Z Installing csv 3.3.5
+2025-12-09T11:13:22.9247351Z Fetching eventmachine 1.2.7
+2025-12-09T11:13:22.9514493Z Installing concurrent-ruby 1.3.5
+2025-12-09T11:13:22.9669018Z Installing eventmachine 1.2.7 with native extensions
+2025-12-09T11:13:23.0093918Z Fetching http_parser.rb 0.8.0
+2025-12-09T11:13:23.0395384Z Installing http_parser.rb 0.8.0 with native extensions
+2025-12-09T11:13:23.1454682Z Fetching ffi 1.17.2 (x86_64-linux-gnu)
+2025-12-09T11:13:23.1799127Z Installing ffi 1.17.2 (x86_64-linux-gnu)
+2025-12-09T11:13:23.2500232Z Fetching forwardable-extended 2.6.0
+2025-12-09T11:13:23.2544033Z Installing forwardable-extended 2.6.0
+2025-12-09T11:13:23.2573445Z Fetching rb-fsevent 0.11.2
+2025-12-09T11:13:23.2645855Z Installing rb-fsevent 0.11.2
+2025-12-09T11:13:23.2797870Z Fetching json 2.17.1
+2025-12-09T11:13:23.2963349Z Installing json 2.17.1 with native extensions
+2025-12-09T11:13:25.8893781Z Fetching liquid 4.0.4
+2025-12-09T11:13:25.9112499Z Installing liquid 4.0.4
+2025-12-09T11:13:25.9828950Z Fetching mercenary 0.4.0
+2025-12-09T11:13:26.0106793Z Installing mercenary 0.4.0
+2025-12-09T11:13:26.0501702Z Fetching rouge 4.6.1
+2025-12-09T11:13:26.0860379Z Installing rouge 4.6.1
+2025-12-09T11:13:26.2523237Z Fetching safe_yaml 1.0.5
+2025-12-09T11:13:26.2617921Z Installing safe_yaml 1.0.5
+2025-12-09T11:13:26.2803796Z Fetching unicode-display_width 2.6.0
+2025-12-09T11:13:26.2871593Z Installing unicode-display_width 2.6.0
+2025-12-09T11:13:26.2918721Z Fetching webrick 1.9.2
+2025-12-09T11:13:26.2996229Z Installing webrick 1.9.2
+2025-12-09T11:13:26.3218576Z Fetching addressable 2.8.8
+2025-12-09T11:13:26.3326889Z Installing addressable 2.8.8
+2025-12-09T11:13:26.3446678Z Fetching i18n 1.14.7
+2025-12-09T11:13:26.3523602Z Installing i18n 1.14.7
+2025-12-09T11:13:26.3674986Z Fetching rb-inotify 0.11.1
+2025-12-09T11:13:26.3732344Z Installing rb-inotify 0.11.1
+2025-12-09T11:13:26.3802439Z Fetching pathutil 0.16.2
+2025-12-09T11:13:26.3869145Z Installing pathutil 0.16.2
+2025-12-09T11:13:26.3909728Z Fetching kramdown 2.5.1
+2025-12-09T11:13:26.4061881Z Installing kramdown 2.5.1
+2025-12-09T11:13:26.5459674Z Fetching terminal-table 3.0.2
+2025-12-09T11:13:26.5527457Z Installing terminal-table 3.0.2
+2025-12-09T11:13:26.5620892Z Fetching listen 3.9.0
+2025-12-09T11:13:26.5682827Z Installing listen 3.9.0
+2025-12-09T11:13:26.5823320Z Fetching kramdown-parser-gfm 1.1.0
+2025-12-09T11:13:26.5896067Z Installing kramdown-parser-gfm 1.1.0
+2025-12-09T11:13:26.6008944Z Fetching jekyll-watch 2.2.1
+2025-12-09T11:13:26.6085908Z Installing jekyll-watch 2.2.1
+2025-12-09T11:13:34.0414927Z Fetching google-protobuf 4.33.1 (x86_64-linux-gnu)
+2025-12-09T11:13:34.0862412Z Installing google-protobuf 4.33.1 (x86_64-linux-gnu)
+2025-12-09T11:13:34.1460310Z Fetching sass-embedded 1.94.2 (x86_64-linux-gnu)
+2025-12-09T11:13:34.2484058Z Installing sass-embedded 1.94.2 (x86_64-linux-gnu)
+2025-12-09T11:13:34.3492528Z Fetching jekyll-sass-converter 3.1.0
+2025-12-09T11:13:34.3535014Z Installing jekyll-sass-converter 3.1.0
+2025-12-09T11:13:40.8441514Z Fetching em-websocket 0.5.3
+2025-12-09T11:13:40.8546775Z Installing em-websocket 0.5.3
+2025-12-09T11:13:40.8649882Z Fetching jekyll 4.4.1
+2025-12-09T11:13:40.8868672Z Installing jekyll 4.4.1
+2025-12-09T11:13:40.9175030Z Fetching jekyll-feed 0.17.0
+2025-12-09T11:13:40.9179169Z Fetching jekyll-seo-tag 2.8.0
+2025-12-09T11:13:40.9179581Z Fetching jekyll-sitemap 1.4.0
+2025-12-09T11:13:40.9247846Z Installing jekyll-feed 0.17.0
+2025-12-09T11:13:40.9382494Z Installing jekyll-seo-tag 2.8.0
+2025-12-09T11:13:40.9465583Z Installing jekyll-sitemap 1.4.0
+2025-12-09T11:13:40.9845784Z Bundle complete! 9 Gemfile dependencies, 38 gems now installed.
+2025-12-09T11:13:40.9846452Z Use `bundle info [gemname]` to see where a bundled gem is installed.
+2025-12-09T11:13:42.2174235Z   Logging at level: debug
+2025-12-09T11:13:42.2174842Z     Jekyll Version: 4.4.1
+2025-12-09T11:13:42.2182946Z Configuration file: /home/runner/work/myFreecodecampLearning/myFreecodecampLearning/_config.yml
+2025-12-09T11:13:42.2280565Z          Requiring: jekyll-feed
+2025-12-09T11:13:42.2281017Z          Requiring: jekyll-sitemap
+2025-12-09T11:13:42.2281440Z          Requiring: jekyll-seo-tag
+2025-12-09T11:13:42.2282715Z             Source: /home/runner/work/myFreecodecampLearning/myFreecodecampLearning
+2025-12-09T11:13:42.2283638Z        Destination: /home/runner/work/myFreecodecampLearning/myFreecodecampLearning/_site
+2025-12-09T11:13:42.2284443Z  Incremental build: disabled. Enable with --incremental
+2025-12-09T11:13:42.2284962Z       Generating... 
+2025-12-09T11:13:42.2297625Z            Reading: /_layouts/default.html
+2025-12-09T11:13:42.2315635Z        EntryFilter: excluded /jest.config.js
+2025-12-09T11:13:42.2316165Z        EntryFilter: excluded /.jekyll-cache
+2025-12-09T11:13:42.2316667Z        EntryFilter: excluded /playwright.config.ts
+2025-12-09T11:13:42.2317176Z        EntryFilter: excluded /Gemfile
+2025-12-09T11:13:42.2318274Z        EntryFilter: excluded /package-lock.json
+2025-12-09T11:13:42.2319507Z        EntryFilter: excluded /Gemfile.lock
+2025-12-09T11:13:42.2323078Z        EntryFilter: excluded /package.json
+2025-12-09T11:13:42.2327008Z        EntryFilter: excluded /__tests__
+2025-12-09T11:13:42.2358306Z            Reading: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100201-Lecture-Welcome-Message-from-Quincy-Larson.html
+2025-12-09T11:13:42.2369593Z            Reading: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100101-10101-example-page-h1-h2-p.html
+2025-12-09T11:13:42.2371131Z            Reading: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Home-Basic-HTML.html
+2025-12-09T11:13:42.2372632Z            Reading: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100101-10201-example-page-final-page.html
+2025-12-09T11:13:42.2374308Z            Reading: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100901-Lecture-HTML-Fundamentals.html
+2025-12-09T11:13:42.2377258Z            Reading: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100601-Lecture-Understanding-the-HTML-Boilerplate.html
+2025-12-09T11:13:42.2380293Z            Reading: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100101-Workshop-Build-a-Curriculum-Outline.html
+2025-12-09T11:13:42.2382751Z            Reading: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100401-Lecture-Understanding-HTML-Attributes.html
+2025-12-09T11:13:42.2395707Z            Reading: pages/s100101-Certified-Full-Stack-Developer-Curriculum/Home-Certified-Full-Stack-Developer-Curriculum.html
+2025-12-09T11:13:42.2396822Z            Reading: pages/interactive-features.html
+2025-12-09T11:13:42.2460803Z            Reading: index.html
+2025-12-09T11:13:42.2473503Z        Jekyll Feed: Generating feed for posts
+2025-12-09T11:13:42.2485797Z         Generating: JekyllFeed::Generator finished in 0.000580911 seconds.
+2025-12-09T11:13:42.2504728Z         Generating: Jekyll::JekyllSitemap finished in 0.002518651 seconds.
+2025-12-09T11:13:42.2506050Z          Rendering: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100101-10101-example-page-h1-h2-p.html
+2025-12-09T11:13:42.2508462Z   Pre-Render Hooks: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100101-10101-example-page-h1-h2-p.html
+2025-12-09T11:13:42.2510074Z   Rendering Liquid: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100101-10101-example-page-h1-h2-p.html
+2025-12-09T11:13:42.2957784Z   Rendering Markup: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100101-10101-example-page-h1-h2-p.html
+2025-12-09T11:13:42.2959496Z Post-Convert Hooks: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100101-10101-example-page-h1-h2-p.html
+2025-12-09T11:13:42.2961429Z          Rendering: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100101-10201-example-page-final-page.html
+2025-12-09T11:13:42.2963353Z   Pre-Render Hooks: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100101-10201-example-page-final-page.html
+2025-12-09T11:13:42.2965191Z   Rendering Liquid: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100101-10201-example-page-final-page.html
+2025-12-09T11:13:42.2967322Z   Rendering Markup: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100101-10201-example-page-final-page.html
+2025-12-09T11:13:42.2969112Z Post-Convert Hooks: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100101-10201-example-page-final-page.html
+2025-12-09T11:13:42.2970837Z          Rendering: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100101-Workshop-Build-a-Curriculum-Outline.html
+2025-12-09T11:13:42.2972645Z   Pre-Render Hooks: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100101-Workshop-Build-a-Curriculum-Outline.html
+2025-12-09T11:13:42.2974507Z   Rendering Liquid: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100101-Workshop-Build-a-Curriculum-Outline.html
+2025-12-09T11:13:42.2977079Z   Rendering Markup: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100101-Workshop-Build-a-Curriculum-Outline.html
+2025-12-09T11:13:42.2978917Z Post-Convert Hooks: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100101-Workshop-Build-a-Curriculum-Outline.html
+2025-12-09T11:13:42.2980751Z   Rendering Layout: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100101-Workshop-Build-a-Curriculum-Outline.html
+2025-12-09T11:13:42.2992722Z          Rendering: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100201-Lecture-Welcome-Message-from-Quincy-Larson.html
+2025-12-09T11:13:42.2994769Z   Pre-Render Hooks: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100201-Lecture-Welcome-Message-from-Quincy-Larson.html
+2025-12-09T11:13:42.2996972Z   Rendering Markup: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100201-Lecture-Welcome-Message-from-Quincy-Larson.html
+2025-12-09T11:13:42.2999072Z Post-Convert Hooks: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100201-Lecture-Welcome-Message-from-Quincy-Larson.html
+2025-12-09T11:13:42.3001096Z   Rendering Layout: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100201-Lecture-Welcome-Message-from-Quincy-Larson.html
+2025-12-09T11:13:42.3003029Z          Rendering: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100401-Lecture-Understanding-HTML-Attributes.html
+2025-12-09T11:13:42.3005396Z   Pre-Render Hooks: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100401-Lecture-Understanding-HTML-Attributes.html
+2025-12-09T11:13:42.3007335Z   Rendering Markup: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100401-Lecture-Understanding-HTML-Attributes.html
+2025-12-09T11:13:42.3009252Z Post-Convert Hooks: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100401-Lecture-Understanding-HTML-Attributes.html
+2025-12-09T11:13:42.3011202Z   Rendering Layout: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100401-Lecture-Understanding-HTML-Attributes.html
+2025-12-09T11:13:42.3013131Z          Rendering: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100601-Lecture-Understanding-the-HTML-Boilerplate.html
+2025-12-09T11:13:42.3015036Z   Pre-Render Hooks: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100601-Lecture-Understanding-the-HTML-Boilerplate.html
+2025-12-09T11:13:42.3017231Z   Rendering Markup: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100601-Lecture-Understanding-the-HTML-Boilerplate.html
+2025-12-09T11:13:42.3019215Z Post-Convert Hooks: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100601-Lecture-Understanding-the-HTML-Boilerplate.html
+2025-12-09T11:13:42.3021157Z   Rendering Layout: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100601-Lecture-Understanding-the-HTML-Boilerplate.html
+2025-12-09T11:13:42.3022991Z          Rendering: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100901-Lecture-HTML-Fundamentals.html
+2025-12-09T11:13:42.3024631Z   Pre-Render Hooks: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100901-Lecture-HTML-Fundamentals.html
+2025-12-09T11:13:42.3026615Z   Rendering Markup: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100901-Lecture-HTML-Fundamentals.html
+2025-12-09T11:13:42.3028365Z Post-Convert Hooks: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100901-Lecture-HTML-Fundamentals.html
+2025-12-09T11:13:42.3030630Z   Rendering Layout: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100901-Lecture-HTML-Fundamentals.html
+2025-12-09T11:13:42.3032213Z          Rendering: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Home-Basic-HTML.html
+2025-12-09T11:13:42.3033571Z   Pre-Render Hooks: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Home-Basic-HTML.html
+2025-12-09T11:13:42.3034909Z   Rendering Liquid: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Home-Basic-HTML.html
+2025-12-09T11:13:42.3036416Z   Rendering Markup: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Home-Basic-HTML.html
+2025-12-09T11:13:42.3037754Z Post-Convert Hooks: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Home-Basic-HTML.html
+2025-12-09T11:13:42.3039080Z   Rendering Layout: pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Home-Basic-HTML.html
+2025-12-09T11:13:42.3040498Z          Rendering: pages/s100101-Certified-Full-Stack-Developer-Curriculum/Home-Certified-Full-Stack-Developer-Curriculum.html
+2025-12-09T11:13:42.3042054Z   Pre-Render Hooks: pages/s100101-Certified-Full-Stack-Developer-Curriculum/Home-Certified-Full-Stack-Developer-Curriculum.html
+2025-12-09T11:13:42.3043604Z   Rendering Liquid: pages/s100101-Certified-Full-Stack-Developer-Curriculum/Home-Certified-Full-Stack-Developer-Curriculum.html
+2025-12-09T11:13:42.3045151Z   Rendering Markup: pages/s100101-Certified-Full-Stack-Developer-Curriculum/Home-Certified-Full-Stack-Developer-Curriculum.html
+2025-12-09T11:13:42.3047106Z Post-Convert Hooks: pages/s100101-Certified-Full-Stack-Developer-Curriculum/Home-Certified-Full-Stack-Developer-Curriculum.html
+2025-12-09T11:13:42.3048670Z   Rendering Layout: pages/s100101-Certified-Full-Stack-Developer-Curriculum/Home-Certified-Full-Stack-Developer-Curriculum.html
+2025-12-09T11:13:42.3049680Z          Rendering: index.html
+2025-12-09T11:13:42.3050058Z   Pre-Render Hooks: index.html
+2025-12-09T11:13:42.3050501Z   Rendering Liquid: index.html
+2025-12-09T11:13:42.3050871Z   Rendering Markup: index.html
+2025-12-09T11:13:42.3051254Z Post-Convert Hooks: index.html
+2025-12-09T11:13:42.3051652Z   Rendering Layout: index.html
+2025-12-09T11:13:42.3052070Z          Rendering: pages/interactive-features.html
+2025-12-09T11:13:42.3052600Z   Pre-Render Hooks: pages/interactive-features.html
+2025-12-09T11:13:42.3053143Z   Rendering Liquid: pages/interactive-features.html
+2025-12-09T11:13:42.3053696Z   Rendering Markup: pages/interactive-features.html
+2025-12-09T11:13:42.3054255Z Post-Convert Hooks: pages/interactive-features.html
+2025-12-09T11:13:42.3054803Z   Rendering Layout: pages/interactive-features.html
+2025-12-09T11:13:42.3055457Z          Rendering: feed.xml
+2025-12-09T11:13:42.3055849Z   Pre-Render Hooks: feed.xml
+2025-12-09T11:13:42.3056221Z   Rendering Liquid: feed.xml
+2025-12-09T11:13:42.3534578Z   Rendering Markup: feed.xml
+2025-12-09T11:13:42.3535066Z Post-Convert Hooks: feed.xml
+2025-12-09T11:13:42.3535708Z   Rendering Layout: feed.xml
+2025-12-09T11:13:42.3536117Z          Rendering: sitemap.xml
+2025-12-09T11:13:42.3536535Z   Pre-Render Hooks: sitemap.xml
+2025-12-09T11:13:42.3536898Z   Rendering Liquid: sitemap.xml
+2025-12-09T11:13:42.3595732Z   Rendering Markup: sitemap.xml
+2025-12-09T11:13:42.3597163Z Post-Convert Hooks: sitemap.xml
+2025-12-09T11:13:42.3597587Z   Rendering Layout: sitemap.xml
+2025-12-09T11:13:42.3598011Z          Rendering: robots.txt
+2025-12-09T11:13:42.3598407Z   Pre-Render Hooks: robots.txt
+2025-12-09T11:13:42.3598834Z   Rendering Liquid: robots.txt
+2025-12-09T11:13:42.3600372Z   Rendering Markup: robots.txt
+2025-12-09T11:13:42.3600786Z Post-Convert Hooks: robots.txt
+2025-12-09T11:13:42.3601174Z   Rendering Layout: robots.txt
+2025-12-09T11:13:42.3627562Z            Writing: /home/runner/work/myFreecodecampLearning/myFreecodecampLearning/_site/pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100101-10101-example-page-h1-h2-p.html
+2025-12-09T11:13:42.3630552Z            Writing: /home/runner/work/myFreecodecampLearning/myFreecodecampLearning/_site/pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100101-10201-example-page-final-page.html
+2025-12-09T11:13:42.3633298Z            Writing: /home/runner/work/myFreecodecampLearning/myFreecodecampLearning/_site/pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100101-Workshop-Build-a-Curriculum-Outline.html
+2025-12-09T11:13:42.3636308Z            Writing: /home/runner/work/myFreecodecampLearning/myFreecodecampLearning/_site/pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100201-Lecture-Welcome-Message-from-Quincy-Larson.html
+2025-12-09T11:13:42.3639120Z            Writing: /home/runner/work/myFreecodecampLearning/myFreecodecampLearning/_site/pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100401-Lecture-Understanding-HTML-Attributes.html
+2025-12-09T11:13:42.3641972Z            Writing: /home/runner/work/myFreecodecampLearning/myFreecodecampLearning/_site/pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100601-Lecture-Understanding-the-HTML-Boilerplate.html
+2025-12-09T11:13:42.3644668Z            Writing: /home/runner/work/myFreecodecampLearning/myFreecodecampLearning/_site/pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100901-Lecture-HTML-Fundamentals.html
+2025-12-09T11:13:42.3647256Z            Writing: /home/runner/work/myFreecodecampLearning/myFreecodecampLearning/_site/pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Home-Basic-HTML.html
+2025-12-09T11:13:42.3649696Z            Writing: /home/runner/work/myFreecodecampLearning/myFreecodecampLearning/_site/pages/s100101-Certified-Full-Stack-Developer-Curriculum/Home-Certified-Full-Stack-Developer-Curriculum.html
+2025-12-09T11:13:42.3651383Z            Writing: /home/runner/work/myFreecodecampLearning/myFreecodecampLearning/_site/index.html
+2025-12-09T11:13:42.3652565Z            Writing: /home/runner/work/myFreecodecampLearning/myFreecodecampLearning/_site/pages/interactive-features.html
+2025-12-09T11:13:42.3653739Z            Writing: /home/runner/work/myFreecodecampLearning/myFreecodecampLearning/_site/feed.xml
+2025-12-09T11:13:42.3654750Z            Writing: /home/runner/work/myFreecodecampLearning/myFreecodecampLearning/_site/sitemap.xml
+2025-12-09T11:13:42.3655913Z            Writing: /home/runner/work/myFreecodecampLearning/myFreecodecampLearning/_site/robots.txt
+2025-12-09T11:13:42.3787444Z                     done in 0.15 seconds.
+2025-12-09T11:13:42.3788043Z  Auto-regeneration: disabled. Use --watch to enable.
+2025-12-09T11:13:42.3942754Z ##[group]Run touch _site/.nojekyll
+2025-12-09T11:13:42.3943066Z [36;1mtouch _site/.nojekyll[0m
+2025-12-09T11:13:42.3943480Z [36;1mecho "✅ Added .nojekyll file to prevent GitHub Pages Jekyll processing" >> $GITHUB_STEP_SUMMARY[0m
+2025-12-09T11:13:42.3976304Z shell: /usr/bin/bash -e {0}
+2025-12-09T11:13:42.3976541Z ##[endgroup]
+2025-12-09T11:13:42.4111295Z ##[group]Run peaceiris/actions-gh-pages@v4
+2025-12-09T11:13:42.4111588Z with:
+2025-12-09T11:13:42.4112152Z   github_token: ***
+2025-12-09T11:13:42.4112352Z   publish_dir: ./_site
+2025-12-09T11:13:42.4112556Z   destination_dir: staging
+2025-12-09T11:13:42.4112758Z   enable_jekyll: false
+2025-12-09T11:13:42.4112949Z   force_orphan: false
+2025-12-09T11:13:42.4113136Z   disable_nojekyll: false
+2025-12-09T11:13:42.4113357Z   publish_branch: gh-pages
+2025-12-09T11:13:42.4113591Z   allow_empty_commit: false
+2025-12-09T11:13:42.4113797Z   keep_files: false
+2025-12-09T11:13:42.4113988Z   exclude_assets: .github
+2025-12-09T11:13:42.4114181Z ##[endgroup]
+2025-12-09T11:13:42.4733240Z [INFO] Usage https://github.com/peaceiris/actions-gh-pages#readme
+2025-12-09T11:13:42.4738337Z ##[group]Dump inputs
+2025-12-09T11:13:42.4738703Z [INFO] GithubToken: true
+2025-12-09T11:13:42.4739070Z [INFO] PublishBranch: gh-pages
+2025-12-09T11:13:42.4739419Z [INFO] PublishDir: ./_site
+2025-12-09T11:13:42.4739711Z [INFO] DestinationDir: staging
+2025-12-09T11:13:42.4739956Z [INFO] ExternalRepository: 
+2025-12-09T11:13:42.4740339Z [INFO] AllowEmptyCommit: false
+2025-12-09T11:13:42.4740673Z [INFO] KeepFiles: false
+2025-12-09T11:13:42.4740984Z [INFO] ForceOrphan: false
+2025-12-09T11:13:42.4741332Z [INFO] UserName: 
+2025-12-09T11:13:42.4741648Z [INFO] UserEmail: 
+2025-12-09T11:13:42.4741967Z [INFO] CommitMessage: 
+2025-12-09T11:13:42.4742315Z [INFO] FullCommitMessage: 
+2025-12-09T11:13:42.4742689Z [INFO] TagName: 
+2025-12-09T11:13:42.4742992Z [INFO] TagMessage: 
+2025-12-09T11:13:42.4743349Z [INFO] EnableJekyll (DisableNoJekyll): false
+2025-12-09T11:13:42.4743751Z [INFO] CNAME: 
+2025-12-09T11:13:42.4744051Z [INFO] ExcludeAssets .github
+2025-12-09T11:13:42.4744284Z 
+2025-12-09T11:13:42.4744693Z ##[endgroup]
+2025-12-09T11:13:42.4745423Z ##[group]Setup auth token
+2025-12-09T11:13:42.4745796Z [INFO] setup GITHUB_TOKEN
+2025-12-09T11:13:42.4747129Z ##[endgroup]
+2025-12-09T11:13:42.4747643Z ##[group]Prepare publishing assets
+2025-12-09T11:13:42.4749439Z [INFO] ForceOrphan: false
+2025-12-09T11:13:42.4801282Z [command]/usr/bin/git clone --depth=1 --single-branch --branch gh-pages ***github.com/T193R-W00D5/myFreecodecampLearning.git /home/runner/actions_github_pages_1765278822474
+2025-12-09T11:13:42.4838139Z Cloning into '/home/runner/actions_github_pages_1765278822474'...
+2025-12-09T11:13:42.8884097Z [INFO] clean up /home/runner/actions_github_pages_1765278822474/staging
+2025-12-09T11:13:42.8885192Z [INFO] chdir /home/runner/actions_github_pages_1765278822474/staging
+2025-12-09T11:13:42.8901606Z [command]/usr/bin/git rm -r --ignore-unmatch *
+2025-12-09T11:13:42.8939784Z [INFO] chdir /home/runner/actions_github_pages_1765278822474
+2025-12-09T11:13:42.8941328Z [INFO] prepare publishing assets
+2025-12-09T11:13:42.8942616Z [INFO] copy /home/runner/work/myFreecodecampLearning/myFreecodecampLearning/_site to /home/runner/actions_github_pages_1765278822474/staging
+2025-12-09T11:13:42.9257999Z [INFO] delete excluded assets
+2025-12-09T11:13:42.9292771Z rm: no paths given
+2025-12-09T11:13:42.9296673Z ##[endgroup]
+2025-12-09T11:13:42.9297176Z ##[group]Setup Git config
+2025-12-09T11:13:42.9311062Z [command]/usr/bin/git remote rm origin
+2025-12-09T11:13:42.9366888Z [command]/usr/bin/git remote add origin ***github.com/T193R-W00D5/myFreecodecampLearning.git
+2025-12-09T11:13:42.9408366Z [command]/usr/bin/git add --all
+2025-12-09T11:13:42.9925111Z [command]/usr/bin/git config user.name T193R-W00D5
+2025-12-09T11:13:42.9967212Z [command]/usr/bin/git config user.email T193R-W00D5@users.noreply.github.com
+2025-12-09T11:13:42.9996156Z ##[endgroup]
+2025-12-09T11:13:42.9996812Z ##[group]Create a commit
+2025-12-09T11:13:43.0007818Z [command]/usr/bin/git commit -m deploy: d1c48a37612e974c398263097bde7994acc3f9b6
+2025-12-09T11:13:43.0496365Z [gh-pages b1ce286] deploy: d1c48a37612e974c398263097bde7994acc3f9b6
+2025-12-09T11:13:43.0497083Z  93 files changed, 39812 insertions(+)
+2025-12-09T11:13:43.0497538Z  create mode 100644 staging/.nojekyll
+2025-12-09T11:13:43.0498396Z  create mode 100644 staging/LICENSE
+2025-12-09T11:13:43.0498905Z  create mode 100644 staging/ReadMe.md
+2025-12-09T11:13:43.0499472Z  create mode 100644 staging/assets/audio/Duck.mp3
+2025-12-09T11:13:43.0500035Z  create mode 100644 staging/assets/favicon/Wizard.ico
+2025-12-09T11:13:43.0500651Z  create mode 100644 staging/assets/favicon/orange_inc_logo 00.jpg
+2025-12-09T11:13:43.0501318Z  create mode 100644 staging/assets/favicon/orange_inc_logo 00.xcf
+2025-12-09T11:13:43.0502035Z  create mode 100644 staging/assets/favicon/orange_inc_logo.ico
+2025-12-09T11:13:43.0502641Z  create mode 100644 staging/assets/images/bg-techy-003.svg
+2025-12-09T11:13:43.0503298Z  create mode 100644 staging/assets/images/eggs-whisk-flour-milk.jpg
+2025-12-09T11:13:43.0504074Z  create mode 100644 staging/assets/images/kids-making-a-mud-pie - Copy.jpg
+2025-12-09T11:13:43.0504860Z  create mode 100644 staging/assets/images/kids-making-a-mud-pie-400x267.avif
+2025-12-09T11:13:43.0506132Z  create mode 100644 staging/assets/images/kids-making-a-mud-pie-400x267.jpg
+2025-12-09T11:13:43.0507066Z  create mode 100644 staging/assets/images/kids-making-a-mud-pie-400x267.webp
+2025-12-09T11:13:43.0507873Z  create mode 100644 staging/assets/images/kids-making-a-mud-pie.jpg
+2025-12-09T11:13:43.0508592Z  create mode 100644 staging/assets/images/kids-making-a-mud-pie.xcf
+2025-12-09T11:13:43.0509279Z  create mode 100644 staging/assets/images/triangle-icon.svg
+2025-12-09T11:13:43.0509954Z  create mode 100644 staging/auto-staging-modern_yml_DELETE_ME.txt
+2025-12-09T11:13:43.0510562Z  create mode 100644 staging/bin/jekyll
+2025-12-09T11:13:43.0511022Z  create mode 100644 staging/bin/jekyll.cmd
+2025-12-09T11:13:43.0511493Z  create mode 100644 staging/css/prism.css
+2025-12-09T11:13:43.0511995Z  create mode 100644 staging/css/styles-center.css
+2025-12-09T11:13:43.0512543Z  create mode 100644 staging/css/styles-freecodecamp.css
+2025-12-09T11:13:43.0513178Z  create mode 100644 staging/css/styles-iframe-html-examples.css
+2025-12-09T11:13:43.0513787Z  create mode 100644 staging/css/styles-left.css
+2025-12-09T11:13:43.0514292Z  create mode 100644 staging/css/styles.css
+2025-12-09T11:13:43.0515103Z  create mode 100644 staging/docs/Ai_chats/20251023a Volta setup and add project to new Github repo CoPilot .md
+2025-12-09T11:13:43.0516260Z  create mode 100644 staging/docs/Ai_chats/20251025a Add Playwright tests and Git help.md
+2025-12-09T11:13:43.0517186Z  create mode 100644 staging/docs/Ai_chats/20251026 Playwright Installation Success Summary.md
+2025-12-09T11:13:43.0518378Z  create mode 100644 staging/docs/Ai_chats/20251105a Refactor project to use TypeScript.md
+2025-12-09T11:13:43.0519185Z  create mode 100644 staging/docs/Ai_chats/20251108a CD and scheduled E2E tests.md
+2025-12-09T11:13:43.0520120Z  create mode 100644 staging/docs/Ai_chats/20251113a playwright shared constants and test utilities functions .md
+2025-12-09T11:13:43.0521290Z  create mode 100644 staging/docs/Ai_chats/20251115a express server, fixes Lighthouse performance, discuss React.md
+2025-12-09T11:13:43.0522455Z  create mode 100644 staging/docs/Ai_chats/20251119a GitHub CoPilot - fix parallel worker tests using same port.md
+2025-12-09T11:13:43.0523523Z  create mode 100644 staging/docs/Ai_chats/20251119a workflow defensive free port 3010 Github copilot.md
+2025-12-09T11:13:43.0524263Z  create mode 100644 staging/docs/Ai_chats/VS Code help.md
+2025-12-09T11:13:43.0524707Z  create mode 100644 staging/docs/Ai_chats/daemon.md
+2025-12-09T11:13:43.0525187Z  create mode 100644 staging/docs/Ai_chats/toolchain Gai 20251024a .md
+2025-12-09T11:13:43.0525908Z  create mode 100644 staging/docs/DEBUG_CONSOLE_GUIDE.md
+2025-12-09T11:13:43.0526357Z  create mode 100644 staging/docs/DEPLOYMENT_GUIDE.md
+2025-12-09T11:13:43.0526829Z  create mode 100644 staging/docs/PLAYWRIGHT_GUIDE.md
+2025-12-09T11:13:43.0527380Z  create mode 100644 staging/docs/PROFESSIONAL_DEPLOYMENT_GUIDE.md
+2025-12-09T11:13:43.0527909Z  create mode 100644 staging/docs/PR_changes.md
+2025-12-09T11:13:43.0528598Z  create mode 100644 staging/docs/TESTING_BEST_PRACTICES.md
+2025-12-09T11:13:43.0529143Z  create mode 100644 staging/docs/TWO_TRACK_STAGING_GUIDE.md
+2025-12-09T11:13:43.0529664Z  create mode 100644 staging/docs/TYPESCRIPT_GUIDE.md
+2025-12-09T11:13:43.0530227Z  create mode 100644 staging/docs/TYPESCRIPT_MIGRATION_COMMIT.md
+2025-12-09T11:13:43.0530551Z  create mode 100644 staging/docs/ci.md
+2025-12-09T11:13:43.0530920Z  create mode 100644 staging/docs/debug_dox/Deploy to Production 1 20251207_0349UTC.txt
+2025-12-09T11:13:43.0531433Z  create mode 100644 staging/docs/debug_dox/Deploy to Production 2 20251207_2052UTC.txt
+2025-12-09T11:13:43.0531903Z  create mode 100644 staging/docs/debug_dox/Deploy to Production 2 20251207_2411UTC.txt
+2025-12-09T11:13:43.0532419Z  create mode 100644 staging/docs/debug_dox/Deploy to Production 4 20251207_2204UTC.txt
+2025-12-09T11:13:43.0532963Z  create mode 100644 staging/docs/debug_dox/GitHub deploy.yml deploy no. 15 to production 20251207_1040.txt
+2025-12-09T11:13:43.0533673Z  create mode 100644 staging/docs/debug_dox/production Basic-HTML-p100101-Workshop-Build-a-Curriculum-Outline 20251208_0618.har
+2025-12-09T11:13:43.0534284Z  create mode 100644 staging/docs/git-workflow-branching-strategy.md
+2025-12-09T11:13:43.0534612Z  create mode 100644 staging/feed.xml
+2025-12-09T11:13:43.0534905Z  create mode 100644 staging/freecodecampOrg.code-workspace
+2025-12-09T11:13:43.0535400Z  create mode 100644 staging/index.html
+2025-12-09T11:13:43.0535752Z  create mode 100644 staging/pages/about.html
+2025-12-09T11:13:43.0536027Z  create mode 100644 staging/pages/audio.html
+2025-12-09T11:13:43.0536407Z  create mode 100644 staging/pages/cafe-menu.html
+2025-12-09T11:13:43.0536950Z  create mode 100644 staging/pages/interactive-features.html
+2025-12-09T11:13:43.0537494Z  create mode 100644 staging/pages/recipes.html
+2025-12-09T11:13:43.0538512Z  create mode 100644 staging/pages/s100101-Certified-Full-Stack-Developer-Curriculum/Home-Certified-Full-Stack-Developer-Curriculum.html
+2025-12-09T11:13:43.0540239Z  create mode 100644 staging/pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100101-10101-example-page-h1-h2-p.html
+2025-12-09T11:13:43.0541800Z  create mode 100644 staging/pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100101-10201-example-page-final-page.html
+2025-12-09T11:13:43.0542877Z  create mode 100644 staging/pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100101-Workshop-Build-a-Curriculum-Outline.html
+2025-12-09T11:13:43.0544299Z  create mode 100644 staging/pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100201-Lecture-Welcome-Message-from-Quincy-Larson.html
+2025-12-09T11:13:43.0545663Z  create mode 100644 staging/pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100401-Lecture-Understanding-HTML-Attributes.html
+2025-12-09T11:13:43.0546816Z  create mode 100644 staging/pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100601-Lecture-Understanding-the-HTML-Boilerplate.html
+2025-12-09T11:13:43.0547883Z  create mode 100644 staging/pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p100901-Lecture-HTML-Fundamentals.html
+2025-12-09T11:13:43.0548875Z  create mode 100644 staging/pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Basic-HTML-p700101-Review-Basic-HTML-Review.html
+2025-12-09T11:13:43.0549763Z  create mode 100644 staging/pages/s100101-Certified-Full-Stack-Developer-Curriculum/c100101-Basic-HTML/Home-Basic-HTML.html
+2025-12-09T11:13:43.0550314Z  create mode 100644 staging/pages/svg-heart-icon.html
+2025-12-09T11:13:43.0550610Z  create mode 100644 staging/pages/videos.html
+2025-12-09T11:13:43.0550864Z  create mode 100644 staging/robots.txt
+2025-12-09T11:13:43.0551109Z  create mode 100644 staging/sitemap.xml
+2025-12-09T11:13:43.0551381Z  create mode 100644 staging/src/components/Snackbar.js
+2025-12-09T11:13:43.0551670Z  create mode 100644 staging/src/script.js
+2025-12-09T11:13:43.0552100Z  create mode 100644 staging/src/scripts/consoleLogHandler.js
+2025-12-09T11:13:43.0552429Z  create mode 100644 staging/src/scripts/css-loader.js
+2025-12-09T11:13:43.0552742Z  create mode 100644 staging/src/scripts/debug-console.js
+2025-12-09T11:13:43.0553042Z  create mode 100644 staging/src/scripts/prism.js
+2025-12-09T11:13:43.0553463Z  create mode 100644 staging/src/scripts/sharedConstants-CFSD-basic-html-helper.js
+2025-12-09T11:13:43.0553904Z  create mode 100644 staging/src/scripts/sharedConstants-__main.js
+2025-12-09T11:13:43.0554239Z  create mode 100644 staging/test-staging.html
+2025-12-09T11:13:43.0554527Z  create mode 100644 staging/tests/e2e/homepage.spec.ts
+2025-12-09T11:13:43.0554868Z  create mode 100644 staging/tests/e2e/interactive-features.spec.ts
+2025-12-09T11:13:43.0555483Z  create mode 100644 staging/tests/e2e/navigation/home-navigation.spec.ts
+2025-12-09T11:13:43.0555970Z  create mode 100644 staging/tests/e2e/navigation/nav-CFSD-pages.spec.ts
+2025-12-09T11:13:43.0556356Z  create mode 100644 staging/tests/fixtures/test-fixtures.ts
+2025-12-09T11:13:43.0556715Z  create mode 100644 staging/tests/utils/helpers-page-navigation.ts
+2025-12-09T11:13:43.0557034Z  create mode 100644 staging/tsconfig.json
+2025-12-09T11:13:43.0557621Z ##[endgroup]
+2025-12-09T11:13:43.0557954Z ##[group]Push the commit or tag
+2025-12-09T11:13:43.0558193Z [command]/usr/bin/git push origin gh-pages
+2025-12-09T11:13:43.7171264Z To https://github.com/T193R-W00D5/myFreecodecampLearning.git
+2025-12-09T11:13:43.7171935Z    e8ba0c8..b1ce286  gh-pages -> gh-pages
+2025-12-09T11:13:43.7219872Z ##[endgroup]
+2025-12-09T11:13:43.7220172Z [INFO] Action successfully completed
+2025-12-09T11:13:43.7354634Z Post job cleanup.
+2025-12-09T11:13:43.8325029Z [command]/usr/bin/git version
+2025-12-09T11:13:43.8363429Z git version 2.52.0
+2025-12-09T11:13:43.8408102Z Temporarily overriding HOME='/home/runner/work/_temp/6de27e4c-447d-4893-bdc8-b5128f457eeb' before making global git config changes
+2025-12-09T11:13:43.8409231Z Adding repository directory to the temporary git global config as a safe directory
+2025-12-09T11:13:43.8414235Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/myFreecodecampLearning/myFreecodecampLearning
+2025-12-09T11:13:43.8452636Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+2025-12-09T11:13:43.8486623Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+2025-12-09T11:13:43.8715505Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+2025-12-09T11:13:43.8739504Z http.https://github.com/.extraheader
+2025-12-09T11:13:43.8751902Z [command]/usr/bin/git config --local --unset-all http.https://github.com/.extraheader
+2025-12-09T11:13:43.8783865Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+2025-12-09T11:13:43.9007804Z [command]/usr/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+2025-12-09T11:13:43.9039706Z [command]/usr/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+2025-12-09T11:13:43.9376358Z Evaluate and set environment url
+2025-12-09T11:13:43.9379239Z Evaluated environment url: https://t193r-w00d5.github.io/myFreecodecampLearning/staging
+2025-12-09T11:13:43.9380292Z Cleaning up orphan processes
+
+logs for deployment-success job
+2025-12-09T11:13:49.9094429Z Current runner version: '2.329.0'
+2025-12-09T11:13:49.9117442Z ##[group]Runner Image Provisioner
+2025-12-09T11:13:49.9118776Z Hosted Compute Agent
+2025-12-09T11:13:49.9119320Z Version: 20251124.448
+2025-12-09T11:13:49.9119913Z Commit: fda5086b43ec66ade217e5fcd18146c879571177
+2025-12-09T11:13:49.9120642Z Build Date: 2025-11-24T21:16:26Z
+2025-12-09T11:13:49.9121209Z ##[endgroup]
+2025-12-09T11:13:49.9121767Z ##[group]Operating System
+2025-12-09T11:13:49.9122274Z Ubuntu
+2025-12-09T11:13:49.9122833Z 24.04.3
+2025-12-09T11:13:49.9123266Z LTS
+2025-12-09T11:13:49.9123706Z ##[endgroup]
+2025-12-09T11:13:49.9124242Z ##[group]Runner Image
+2025-12-09T11:13:49.9124850Z Image: ubuntu-24.04
+2025-12-09T11:13:49.9125369Z Version: 20251126.144.1
+2025-12-09T11:13:49.9126466Z Included Software: https://github.com/actions/runner-images/blob/ubuntu24/20251126.144/images/ubuntu/Ubuntu2404-Readme.md
+2025-12-09T11:13:49.9128283Z Image Release: https://github.com/actions/runner-images/releases/tag/ubuntu24%2F20251126.144
+2025-12-09T11:13:49.9129390Z ##[endgroup]
+2025-12-09T11:13:49.9132062Z ##[group]GITHUB_TOKEN Permissions
+2025-12-09T11:13:49.9134312Z Actions: write
+2025-12-09T11:13:49.9134839Z ArtifactMetadata: write
+2025-12-09T11:13:49.9135397Z Attestations: write
+2025-12-09T11:13:49.9136051Z Checks: write
+2025-12-09T11:13:49.9136541Z Contents: write
+2025-12-09T11:13:49.9137115Z Deployments: write
+2025-12-09T11:13:49.9137844Z Discussions: write
+2025-12-09T11:13:49.9138428Z Issues: write
+2025-12-09T11:13:49.9138917Z Metadata: read
+2025-12-09T11:13:49.9139476Z Models: read
+2025-12-09T11:13:49.9139947Z Packages: write
+2025-12-09T11:13:49.9140455Z Pages: write
+2025-12-09T11:13:49.9140946Z PullRequests: write
+2025-12-09T11:13:49.9141594Z RepositoryProjects: write
+2025-12-09T11:13:49.9142282Z SecurityEvents: write
+2025-12-09T11:13:49.9142800Z Statuses: write
+2025-12-09T11:13:49.9143420Z ##[endgroup]
+2025-12-09T11:13:49.9146028Z Secret source: Actions
+2025-12-09T11:13:49.9147043Z Prepare workflow directory
+2025-12-09T11:13:49.9468628Z Prepare all required actions
+2025-12-09T11:13:49.9562696Z Complete job name: deployment-success
+2025-12-09T11:13:50.0284408Z ##[group]Run echo "## 🧪 Staging Deployment Successful!" >> $GITHUB_STEP_SUMMARY
+2025-12-09T11:13:50.0285548Z [36;1mecho "## 🧪 Staging Deployment Successful!" >> $GITHUB_STEP_SUMMARY[0m
+2025-12-09T11:13:50.0287083Z [36;1mecho "" >> $GITHUB_STEP_SUMMARY[0m
+2025-12-09T11:13:50.0288527Z [36;1mecho "**Environment:** Staging" >> $GITHUB_STEP_SUMMARY[0m
+2025-12-09T11:13:50.0289914Z [36;1mecho "**Commit:** d1c48a37612e974c398263097bde7994acc3f9b6" >> $GITHUB_STEP_SUMMARY[0m
+2025-12-09T11:13:50.0290912Z [36;1mecho "**Deployed by:** T193R-W00D5" >> $GITHUB_STEP_SUMMARY[0m
+2025-12-09T11:13:50.0291807Z [36;1mecho "" >> $GITHUB_STEP_SUMMARY[0m
+2025-12-09T11:13:50.0292840Z [36;1mecho "**Staging URL:** https://t193r-w00d5.github.io/myFreecodecampLearning/staging" >> $GITHUB_STEP_SUMMARY[0m
+2025-12-09T11:13:50.0293839Z [36;1mecho "" >> $GITHUB_STEP_SUMMARY[0m
+2025-12-09T11:13:50.0294874Z [36;1mecho "Please allow 5-10 minutes for GitHub Pages to update." >> $GITHUB_STEP_SUMMARY[0m
+2025-12-09T11:13:50.0848772Z shell: /usr/bin/bash -e {0}
+2025-12-09T11:13:50.0849999Z ##[endgroup]
+2025-12-09T11:13:50.1184267Z Cleaning up orphan processes


### PR DESCRIPTION
Made changes to deploy-staging.yml because it's deployed site 404s.

The issue is that peaceiris deploys to the `gh-pages` branch, but my GitHub Pages source is set to 'GitHub Actions". The staging workflow was modified to use GitHub's native deployment actions instead.

## Key Changes Made:

1. **Replaced peaceiris with GitHub native deployment actions**: 
   - `actions/upload-pages-artifact@v3`
   - `actions/deploy-pages@v4`

2. **Added proper permissions**: `pages: write` and `id-token: write`

3. **Created staging directory structure**: The workflow now creates a `/myFreecodecampLearning/staging/` directory structure to maintain the staging subdirectory path

4. **Dynamic URL output**: Uses `${{ steps.deployment.outputs.page_url }}` instead of hardcoded URL

5. **Maintained Jekyll baseurl**: Still builds with `--baseurl "/myFreecodecampLearning/staging"`

## Why This Fixes the Issue:

- **Compatibility with GitHub Actions Pages source**: Both production and staging now use the same GitHub Actions deployment system
- **No branch conflicts**: Both workflows deploy via GitHub Actions instead of conflicting branch configurations
- **Consistent deployment method**: Matches your working production workflow pattern

The staging site should now be accessible because it will be deployed through the same GitHub Actions Pages source that the production site uses.
